### PR TITLE
feat: export task trajectory evidence

### DIFF
--- a/cmd/solo/README.md
+++ b/cmd/solo/README.md
@@ -79,6 +79,21 @@ solo task reopen -n <number> -c <channel_id>
 
 `submit` moves claimed work to review. `accept` marks reviewed work done. `reject` sends reviewed work back to progress. `close` and `reopen` are human lifecycle actions.
 
+### task trajectory -- export task evidence
+
+```bash
+solo task trajectory -n <number> -c <channel_id> \
+  [--output json]
+```
+
+Exports a versioned JSON snapshot containing the requested task and its
+descendants, linked Agent runs, metadata-only ordered run events, transcript
+source-availability metadata, and selected artifact metadata. Run-event
+messages, transcript text, and tool input/output payload fields are not
+exported. The snapshot declares unavailable or unverified correlations instead
+of inferring them from timestamps. This command always writes the snapshot JSON
+object directly to stdout so it can be archived or processed with `jq`.
+
 ### message send -- send a message to a channel
 
 ```bash

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -16,6 +16,7 @@
 //	solo task reject   -n <number> -c <channel_id> --reason <reason>
 //	solo task close    -n <number> -c <channel_id>
 //	solo task reopen   -n <number> -c <channel_id>
+//	solo task trajectory -n <number> -c <channel_id> [--output json]
 //	solo artifact publish --task <task_id> --file <artifact.html> [--mode latest|final]
 //	solo channel members -c <channel_id> [--output json]
 //	solo channel join  --target <#channel-name>
@@ -391,7 +392,7 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 
 func handleTask(args []string, baseURL, token string) {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "solo: error: task subcommand required (list, claim, update, create, unclaim, submit, accept, reject, close, reopen)")
+		fmt.Fprintln(os.Stderr, "solo: error: task subcommand required (list, claim, update, create, unclaim, submit, accept, reject, close, reopen, trajectory)")
 		printUsage()
 		doExit(exitUsage)
 	}
@@ -409,11 +410,72 @@ func handleTask(args []string, baseURL, token string) {
 		handleTaskUnclaim(args[1:], baseURL, token)
 	case "submit", "accept", "reject", "close", "reopen":
 		handleTaskLifecycle(args[1:], baseURL, token, args[0])
+	case "trajectory":
+		handleTaskTrajectory(args[1:], baseURL, token)
 	default:
 		fmt.Fprintf(os.Stderr, "solo: error: unknown task subcommand %q\n", args[0])
 		printUsage()
 		doExit(exitUsage)
 	}
+}
+
+// --- task trajectory ---
+
+func handleTaskTrajectory(args []string, baseURL, token string) {
+	var channel, output string
+	var number int
+	fs := flag.NewFlagSet("task trajectory", flag.ExitOnError)
+	fs.StringVar(&channel, "c", "", "Channel ID or #name (required)")
+	fs.StringVar(&channel, "channel", "", "Channel ID or #name (required)")
+	fs.IntVar(&number, "n", 0, "Task number (required)")
+	fs.IntVar(&number, "number", 0, "Task number (required)")
+	fs.StringVar(&output, "output", "json", "Output format: json")
+	fs.Parse(args)
+
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "solo: error: unexpected argument: %s\n", fs.Arg(0))
+		doExit(exitUsage)
+	}
+	if channel == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: -c <channel_id> is required")
+		doExit(exitUsage)
+	}
+	if number <= 0 {
+		fmt.Fprintln(os.Stderr, "solo: error: -n <number> must be a positive integer")
+		doExit(exitUsage)
+	}
+	if output != "json" {
+		fmt.Fprintf(os.Stderr, "solo: error: invalid --output value %q (only \"json\" is supported)\n", output)
+		doExit(exitUsage)
+	}
+
+	channelID, err := resolveChannelParam(baseURL, token, channel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", err)
+		doExit(exitBusiness)
+	}
+	taskID, err := resolveTaskNumberToID(baseURL, token, channelID, number)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", err)
+		doExit(exitBusiness)
+	}
+
+	requestURL := fmt.Sprintf("%s/api/v1/tasks/%s/trajectory", baseURL, url.PathEscape(taskID))
+	statusCode, body, err := doHTTP(http.MethodGet, requestURL, token, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
+		doExit(exitUsage)
+	}
+	if statusCode >= 400 {
+		printJSONError(statusCode, extractErrorMessage(body))
+		handleNonProxyHTTPError(statusCode, body)
+	}
+	if !json.Valid(body) {
+		fmt.Fprintln(os.Stderr, "solo: error: trajectory endpoint returned invalid JSON")
+		doExit(exitUsage)
+	}
+	fmt.Println(string(body))
+	doExit(exitOK)
 }
 
 // --- task list ---
@@ -1466,6 +1528,7 @@ func printUsage() {
   solo task reject   -n <number> -c <channel_id> --reason <reason>
   solo task close    -n <number> -c <channel_id>
   solo task reopen   -n <number> -c <channel_id>
+  solo task trajectory -n <number> -c <channel_id> [--output json]
   solo artifact publish --task <task_id> --file <artifact.html> [--mode latest|final]
   solo channel members -c <channel_id> [--output json]
   solo channel join  --target <#channel-name>

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -268,6 +268,50 @@ func TestHandleTaskListWithChannel(t *testing.T) {
 	}
 }
 
+func TestHandleTaskTrajectoryPrintsVersionedJSON(t *testing.T) {
+	channelID := "550e8400-e29b-41d4-a716-446655440001"
+	taskID := "550e8400-e29b-41d4-a716-446655440002"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/channels/" + channelID + "/tasks":
+			json.NewEncoder(w).Encode([]map[string]any{{"id": taskID, "task_number": 7}})
+		case "/api/v1/tasks/" + taskID + "/trajectory":
+			json.NewEncoder(w).Encode(map[string]any{
+				"schema_version": "solo.task_trajectory.v1",
+				"root_task_id":   taskID,
+				"tasks":          []any{},
+				"runs":           []any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	code, stdout, stderr := captureAndRun(t, func() {
+		handleTaskTrajectory([]string{"-c", channelID, "-n", "7", "--output", "json"}, server.URL, "test-token")
+	})
+	if code != exitOK {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &output); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if output["schema_version"] != "solo.task_trajectory.v1" || output["root_task_id"] != taskID {
+		t.Fatalf("output = %+v", output)
+	}
+}
+
 func TestHandleTaskListOutputJSON(t *testing.T) {
 	var capturedMethod, capturedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handler/agent_run.go
+++ b/internal/server/handler/agent_run.go
@@ -1,20 +1,26 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/solo-ai/solo/internal/server/service"
 )
 
 type AgentRunHandler struct {
-	svc *service.AgentRunService
+	svc           *service.AgentRunService
+	trajectorySvc *service.TaskTrajectoryService
 }
 
 func NewAgentRunHandler(pool *pgxpool.Pool) *AgentRunHandler {
-	return &AgentRunHandler{svc: service.NewAgentRunService(pool)}
+	return &AgentRunHandler{
+		svc:           service.NewAgentRunService(pool),
+		trajectorySvc: service.NewTaskTrajectoryService(pool),
+	}
 }
 
 func (h *AgentRunHandler) Active(w http.ResponseWriter, r *http.Request) {
@@ -143,6 +149,33 @@ func (h *AgentRunHandler) TaskTimeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, timeline)
+}
+
+func (h *AgentRunHandler) TaskTrajectory(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	taskID := chi.URLParam(r, "taskID")
+	if _, err := uuid.Parse(taskID); err != nil {
+		writeError(w, http.StatusBadRequest, "taskID must be a UUID")
+		return
+	}
+
+	snapshot, err := h.trajectorySvc.Export(r.Context(), taskID, userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrTaskNotFound):
+			writeError(w, http.StatusNotFound, "task not found")
+		case errors.Is(err, service.ErrTaskNotChannelMember):
+			writeError(w, http.StatusForbidden, "not authorized to read this task trajectory")
+		default:
+			writeError(w, http.StatusInternalServerError, "failed to export task trajectory")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
 }
 
 func timelineLimit(r *http.Request) int {

--- a/internal/server/handler/agent_run_test.go
+++ b/internal/server/handler/agent_run_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/solo-ai/solo/internal/server/service"
+)
+
+func TestAgentRunHandlerTaskTrajectoryAuthorizationAndValidation(t *testing.T) {
+	pool := trajectoryHandlerTestPool(t)
+	ctx := context.Background()
+	ownerID := uuid.NewString()
+	otherID := uuid.NewString()
+	channelID := uuid.NewString()
+	taskID := uuid.NewString()
+	for _, user := range []struct {
+		id   string
+		name string
+	}{{ownerID, "Trajectory Owner"}, {otherID, "Trajectory Other"}} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO users (id, email, display_name, password_hash) VALUES ($1, $2, $3, 'test')`,
+			user.id, fmt.Sprintf("%s@example.test", user.id), user.name); err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channels (id, name, created_by) VALUES ($1, $2, $3)`,
+		channelID, "trajectory-handler-"+channelID[:8], ownerID); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role) VALUES ($1, 'user', $2, 'owner')`,
+		channelID, ownerID); err != nil {
+		t.Fatalf("create channel membership: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number)
+		 VALUES ($1, $2, $3, 'trajectory handler task', 'todo', 'normal', 1)`,
+		taskID, channelID, ownerID); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE id = $1`, taskID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = ANY($1::uuid[])`, []string{ownerID, otherID})
+	})
+
+	handler := NewAgentRunHandler(pool)
+	router := chi.NewRouter()
+	router.Get("/api/v1/tasks/{taskID}/trajectory", handler.TaskTrajectory)
+
+	tests := []struct {
+		name       string
+		path       string
+		userID     string
+		wantStatus int
+	}{
+		{name: "authentication required", path: "/api/v1/tasks/" + taskID + "/trajectory", wantStatus: http.StatusUnauthorized},
+		{name: "invalid task UUID", path: "/api/v1/tasks/not-a-uuid/trajectory", userID: ownerID, wantStatus: http.StatusBadRequest},
+		{name: "task not found", path: "/api/v1/tasks/" + uuid.NewString() + "/trajectory", userID: ownerID, wantStatus: http.StatusNotFound},
+		{name: "channel membership required", path: "/api/v1/tasks/" + taskID + "/trajectory", userID: otherID, wantStatus: http.StatusForbidden},
+		{name: "authorized snapshot", path: "/api/v1/tasks/" + taskID + "/trajectory", userID: ownerID, wantStatus: http.StatusOK},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, test.path, nil)
+			if test.userID != "" {
+				req.Header.Set("X-User-ID", test.userID)
+			}
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if response.Code == http.StatusOK {
+				var snapshot service.TaskTrajectorySnapshot
+				if err := json.NewDecoder(response.Body).Decode(&snapshot); err != nil {
+					t.Fatalf("decode snapshot: %v", err)
+				}
+				if snapshot.SchemaVersion != service.TaskTrajectorySchemaVersion || snapshot.RootTaskID != taskID {
+					t.Fatalf("snapshot = %+v", snapshot)
+				}
+			}
+		})
+	}
+}
+
+func trajectoryHandlerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://solo:solo-dev@localhost:5432/solo?sslmode=disable"
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Skipf("skipping DB test: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("skipping DB test: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -308,6 +308,7 @@ func NewRouter(pool *pgxpool.Pool, hub *ws.Hub, dm *service.DaemonManager, agent
 		r.Get("/api/v1/tasks/{taskID}", taskHandler.GetGlobal)
 		r.Get("/api/v1/tasks/{taskID}/runs", agentRunHandler.TaskRuns)
 		r.Get("/api/v1/tasks/{taskID}/agent-timeline", agentRunHandler.TaskTimeline)
+		r.Get("/api/v1/tasks/{taskID}/trajectory", agentRunHandler.TaskTrajectory)
 		r.Patch("/api/v1/tasks/{taskID}", taskHandler.UpdateGlobal)
 		r.Delete("/api/v1/tasks/{taskID}", taskHandler.DeleteGlobal)
 		r.Post("/api/v1/tasks/{taskID}/accept", taskHandler.AcceptGlobal)

--- a/internal/server/service/task_trajectory.go
+++ b/internal/server/service/task_trajectory.go
@@ -1,0 +1,719 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	TaskTrajectorySchemaVersion = "solo.task_trajectory.v1"
+	maxTrajectoryTasks          = 500
+	maxTrajectoryRunLinkRows    = 2000
+	maxTrajectoryEvents         = 20000
+	maxTrajectoryArtifacts      = 1000
+	maxTrajectoryShortTextRunes = 500
+	maxTrajectoryBodyTextRunes  = 4000
+)
+
+type TaskTrajectoryCoverage struct {
+	Completeness           string `json:"completeness"`
+	TaskTree               string `json:"task_tree"`
+	RunMetadata            string `json:"run_metadata"`
+	RunTaskLinks           string `json:"run_task_links"`
+	RunEvents              string `json:"run_events"`
+	TranscriptAvailability string `json:"transcript_availability"`
+	TaskArtifacts          string `json:"task_artifacts"`
+	DispatchDecisions      string `json:"dispatch_decisions"`
+	ParentRunLinks         string `json:"parent_run_links"`
+	OutboundMessageRuns    string `json:"outbound_message_runs"`
+	TaskLifecycleEvents    string `json:"task_lifecycle_events"`
+	RelationshipSnapshots  string `json:"relationship_snapshots"`
+}
+
+type TaskTrajectoryWarning struct {
+	Code    string `json:"code"`
+	RunID   string `json:"run_id,omitempty"`
+	Message string `json:"message"`
+}
+
+type TaskTrajectoryTask struct {
+	ID               string     `json:"id"`
+	TaskNumber       int        `json:"task_number"`
+	ChannelID        string     `json:"channel_id"`
+	CreatorID        string     `json:"creator_id"`
+	CreatorName      string     `json:"creator_name,omitempty"`
+	Title            string     `json:"title"`
+	Description      string     `json:"description,omitempty"`
+	Status           string     `json:"status"`
+	ClaimerID        string     `json:"claimer_id,omitempty"`
+	ClaimerName      string     `json:"claimer_name,omitempty"`
+	Priority         string     `json:"priority"`
+	DueDate          *time.Time `json:"due_date,omitempty"`
+	MessageID        string     `json:"message_id,omitempty"`
+	ParentTaskID     string     `json:"parent_task_id,omitempty"`
+	Depth            int        `json:"depth"`
+	ContentTruncated bool       `json:"content_truncated,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+type TaskTrajectoryLink struct {
+	TaskID            string    `json:"task_id"`
+	Role              string    `json:"role"`
+	Confidence        float64   `json:"confidence"`
+	MetadataTruncated bool      `json:"metadata_truncated,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+type TaskTrajectoryTranscript struct {
+	Status       string    `json:"status"`
+	Association  string    `json:"association"`
+	WindowStart  time.Time `json:"window_start"`
+	WindowEnd    time.Time `json:"window_end"`
+	TextExported bool      `json:"text_exported"`
+}
+
+type TaskTrajectoryEvent struct {
+	ID             string         `json:"id"`
+	RunID          string         `json:"run_id"`
+	Seq            int            `json:"seq"`
+	Type           string         `json:"type"`
+	ToolName       string         `json:"tool_name,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+	ContentOmitted bool           `json:"content_omitted,omitempty"`
+	CreatedAt      time.Time      `json:"created_at"`
+}
+
+type TaskTrajectoryArtifact struct {
+	ID               string    `json:"id"`
+	TaskID           string    `json:"task_id"`
+	Kind             string    `json:"kind"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary,omitempty"`
+	ContentTruncated bool      `json:"content_truncated,omitempty"`
+	URL              string    `json:"url"`
+	CreatedBy        string    `json:"created_by"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type TaskTrajectoryRun struct {
+	ID                string                   `json:"id"`
+	AgentID           string                   `json:"agent_id"`
+	AgentName         string                   `json:"agent_name,omitempty"`
+	SessionID         string                   `json:"session_id,omitempty"`
+	TriggerType       string                   `json:"trigger_type"`
+	TriggerMessageID  string                   `json:"trigger_message_id,omitempty"`
+	ChannelID         string                   `json:"channel_id,omitempty"`
+	ThreadID          string                   `json:"thread_id,omitempty"`
+	ThinkingNodeID    string                   `json:"thinking_node_id,omitempty"`
+	Status            AgentRunStatus           `json:"status"`
+	ToolName          string                   `json:"tool_name,omitempty"`
+	Source            string                   `json:"source,omitempty"`
+	Usage             map[string]any           `json:"usage,omitempty"`
+	MetadataTruncated bool                     `json:"metadata_truncated,omitempty"`
+	StartedAt         time.Time                `json:"started_at"`
+	UpdatedAt         time.Time                `json:"updated_at"`
+	FinishedAt        *time.Time               `json:"finished_at,omitempty"`
+	TaskLinks         []TaskTrajectoryLink     `json:"task_links"`
+	Events            []TaskTrajectoryEvent    `json:"events"`
+	Transcript        TaskTrajectoryTranscript `json:"transcript"`
+}
+
+type TaskTrajectorySnapshot struct {
+	SchemaVersion      string                   `json:"schema_version"`
+	DatabaseCapturedAt time.Time                `json:"database_captured_at"`
+	RootTaskID         string                   `json:"root_task_id"`
+	Coverage           TaskTrajectoryCoverage   `json:"coverage"`
+	Tasks              []TaskTrajectoryTask     `json:"tasks"`
+	Runs               []TaskTrajectoryRun      `json:"runs"`
+	Artifacts          []TaskTrajectoryArtifact `json:"artifacts"`
+	Warnings           []TaskTrajectoryWarning  `json:"warnings"`
+}
+
+type TaskTrajectoryService struct {
+	pool *pgxpool.Pool
+}
+
+func NewTaskTrajectoryService(pool *pgxpool.Pool) *TaskTrajectoryService {
+	return &TaskTrajectoryService{pool: pool}
+}
+
+type taskTrajectoryRunSource struct {
+	referenceRecorded bool
+}
+
+type taskTrajectoryTruncation struct {
+	tasks     bool
+	runLinks  bool
+	events    bool
+	artifacts bool
+}
+
+func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID string) (*TaskTrajectorySnapshot, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	var capturedAt time.Time
+	if err := tx.QueryRow(ctx, `SELECT transaction_timestamp()`).Scan(&capturedAt); err != nil {
+		return nil, err
+	}
+	rootChannelID, err := authorizeTaskTrajectory(ctx, tx, taskID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks, tasksTruncated, err := loadTaskTrajectoryTasks(ctx, tx, taskID, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	taskIDs := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		taskIDs = append(taskIDs, task.ID)
+	}
+	runs, sources, runLinksTruncated, err := loadTaskTrajectoryRuns(ctx, tx, taskIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	eventsTruncated, err := loadTaskTrajectoryEvents(ctx, tx, runs)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, artifactsTruncated, err := loadTaskTrajectoryArtifacts(ctx, tx, taskIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	warnings := []TaskTrajectoryWarning{}
+	for i := range runs {
+		runWarnings := attachTaskTrajectoryTranscriptReference(&runs[i], sources[runs[i].ID], capturedAt)
+		warnings = append(warnings, runWarnings...)
+	}
+	truncation := taskTrajectoryTruncation{
+		tasks:     tasksTruncated,
+		runLinks:  runLinksTruncated,
+		events:    eventsTruncated,
+		artifacts: artifactsTruncated,
+	}
+	warnings = append(warnings, trajectoryTruncationWarnings(truncation)...)
+	completeness := "partial_stored_records"
+	if tasksTruncated || runLinksTruncated || eventsTruncated || artifactsTruncated {
+		completeness = "partial_truncated_stored_records"
+	}
+
+	return &TaskTrajectorySnapshot{
+		SchemaVersion:      TaskTrajectorySchemaVersion,
+		DatabaseCapturedAt: capturedAt,
+		RootTaskID:         taskID,
+		Coverage: TaskTrajectoryCoverage{
+			Completeness:           completeness,
+			TaskTree:               "stored_records",
+			RunMetadata:            "stored_linked_selected_metadata",
+			RunTaskLinks:           "stored_records",
+			RunEvents:              "stored_metadata_only",
+			TranscriptAvailability: "reference_recorded_only_unverified_time_window",
+			TaskArtifacts:          "stored_selected_metadata",
+			DispatchDecisions:      "unavailable",
+			ParentRunLinks:         "unavailable",
+			OutboundMessageRuns:    "unavailable",
+			TaskLifecycleEvents:    "unavailable",
+			RelationshipSnapshots:  "unavailable",
+		},
+		Tasks:     tasks,
+		Runs:      runs,
+		Artifacts: artifacts,
+		Warnings:  warnings,
+	}, nil
+}
+
+func authorizeTaskTrajectory(ctx context.Context, tx pgx.Tx, taskID, userID string) (string, error) {
+	var channelID string
+	if err := tx.QueryRow(ctx, `SELECT channel_id::text FROM tasks WHERE id = $1`, taskID).Scan(&channelID); err != nil {
+		if err == pgx.ErrNoRows {
+			return "", ErrTaskNotFound
+		}
+		return "", err
+	}
+	var allowed bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM channels c
+			  JOIN channel_members cm ON cm.channel_id = c.id
+			 WHERE c.id = $1 AND c.is_archived = false
+			   AND cm.member_type = 'user' AND cm.member_id = $2
+		)`, channelID, userID).Scan(&allowed); err != nil {
+		return "", err
+	}
+	if !allowed {
+		return "", ErrTaskNotChannelMember
+	}
+	return channelID, nil
+}
+
+func loadTaskTrajectoryTasks(ctx context.Context, tx pgx.Tx, rootTaskID, rootChannelID string) ([]TaskTrajectoryTask, bool, error) {
+	rows, err := tx.Query(ctx, `
+		WITH RECURSIVE task_tree(id, depth) AS (
+			SELECT t.id, 0 FROM tasks t WHERE t.id = $1
+			UNION ALL
+			SELECT child.id, parent.depth + 1
+			  FROM tasks child
+			  JOIN task_tree parent ON child.parent_task_id = parent.id
+			 WHERE child.channel_id = $2
+		), bounded_tree AS MATERIALIZED (
+			SELECT id, depth FROM task_tree LIMIT $3
+		)
+		SELECT t.id::text, COALESCE(t.task_number, 0), COALESCE(t.channel_id::text, ''),
+		       t.creator_id::text, COALESCE(u_creator.display_name, a_creator.name, ''),
+		       left(t.title, $4), char_length(t.title) > $4,
+		       left(COALESCE(t.description, ''), $5), char_length(COALESCE(t.description, '')) > $5,
+		       left(t.status, $4), char_length(t.status) > $4,
+		       COALESCE(t.claimer_id::text, ''), COALESCE(u_claimer.display_name, a_claimer.name, ''),
+		       left(COALESCE(t.priority, ''), $4), char_length(COALESCE(t.priority, '')) > $4,
+		       t.due_date, COALESCE(t.message_id::text, ''),
+		       COALESCE(t.parent_task_id::text, ''), tree.depth, t.created_at, t.updated_at
+		  FROM bounded_tree tree
+		  JOIN tasks t ON t.id = tree.id
+		  LEFT JOIN users u_creator ON t.creator_id = u_creator.id
+		  LEFT JOIN agents a_creator ON t.creator_id = a_creator.id
+		  LEFT JOIN users u_claimer ON t.claimer_id = u_claimer.id
+		  LEFT JOIN agents a_claimer ON t.claimer_id = a_claimer.id
+		 ORDER BY tree.depth ASC, t.created_at ASC, t.id ASC`,
+		rootTaskID, rootChannelID, maxTrajectoryTasks+1, maxTrajectoryShortTextRunes, maxTrajectoryBodyTextRunes)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	tasks := []TaskTrajectoryTask{}
+	for rows.Next() {
+		var task TaskTrajectoryTask
+		var dueDate sql.NullTime
+		var titleTruncated bool
+		var descriptionTruncated bool
+		var statusTruncated bool
+		var priorityTruncated bool
+		if err := rows.Scan(
+			&task.ID, &task.TaskNumber, &task.ChannelID, &task.CreatorID, &task.CreatorName,
+			&task.Title, &titleTruncated, &task.Description, &descriptionTruncated,
+			&task.Status, &statusTruncated, &task.ClaimerID, &task.ClaimerName,
+			&task.Priority, &priorityTruncated, &dueDate, &task.MessageID, &task.ParentTaskID, &task.Depth,
+			&task.CreatedAt, &task.UpdatedAt,
+		); err != nil {
+			return nil, false, err
+		}
+		if dueDate.Valid {
+			task.DueDate = &dueDate.Time
+		}
+		task.ContentTruncated = titleTruncated || descriptionTruncated || statusTruncated || priorityTruncated
+		if !safeTaskTrajectoryIdentifier(task.Status, 128) {
+			task.Status = "unknown"
+			task.ContentTruncated = true
+		}
+		if task.Priority != "" && !safeTaskTrajectoryIdentifier(task.Priority, 128) {
+			task.Priority = "unknown"
+			task.ContentTruncated = true
+		}
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(tasks) > maxTrajectoryTasks
+	if truncated {
+		tasks = tasks[:maxTrajectoryTasks]
+	}
+	return tasks, truncated, nil
+}
+
+func loadTaskTrajectoryRuns(ctx context.Context, tx pgx.Tx, taskIDs []string, rootChannelID string) ([]TaskTrajectoryRun, map[string]taskTrajectoryRunSource, bool, error) {
+	if len(taskIDs) == 0 {
+		return []TaskTrajectoryRun{}, map[string]taskTrajectoryRunSource{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_links AS MATERIALIZED (
+			SELECT l.run_id, l.task_id, l.role, l.confidence, l.created_at
+			  FROM agent_run_task_links l
+			  JOIN tasks linked_task ON linked_task.id = l.task_id
+			  JOIN agent_runs linked_run ON linked_run.id = l.run_id
+			 WHERE l.task_id = ANY($1::uuid[]) AND linked_task.channel_id = $2
+			   AND (linked_run.channel_id = $2 OR linked_run.channel_id IS NULL)
+			 LIMIT $3
+		)
+		SELECT r.id::text, r.agent_id::text,
+		       left(COALESCE(a.name, ''), $4), char_length(COALESCE(a.name, '')) > $4,
+		       COALESCE(r.session_id::text, ''),
+		       left(r.trigger_type, $4), char_length(r.trigger_type) > $4,
+		       COALESCE(r.trigger_message_id::text, ''), COALESCE(r.channel_id::text, ''),
+		       COALESCE(r.thread_id::text, ''), COALESCE(r.thinking_node_id::text, ''),
+		       left(r.status, $4), char_length(r.status) > $4,
+		       left(COALESCE(r.tool_name, ''), $4), char_length(COALESCE(r.tool_name, '')) > $4,
+		       left(COALESCE(r.source, ''), $4), char_length(COALESCE(r.source, '')) > $4,
+		       CASE WHEN COALESCE(r.usage_json->>'input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'input_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'output_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'output_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'cache_creation_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'cache_creation_input_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'cache_read_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'cache_read_input_tokens')::bigint END,
+		       r.started_at, r.updated_at, r.finished_at,
+		       l.task_id::text, left(l.role, $4), char_length(l.role) > $4, l.confidence, l.created_at,
+		       (COALESCE(r.transcript_path, sess.transcript_path, '') <> '' OR COALESCE(sess.external_session_id, '') <> '')
+		  FROM bounded_links l
+		  JOIN agent_runs r ON r.id = l.run_id
+		  LEFT JOIN agents a ON a.id = r.agent_id
+		  LEFT JOIN agent_sessions sess ON sess.id = r.session_id
+		 ORDER BY r.started_at ASC, r.id ASC, l.created_at ASC, l.task_id ASC
+		`, taskIDs, rootChannelID, maxTrajectoryRunLinkRows+1, maxTrajectoryShortTextRunes)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer rows.Close()
+
+	runs := []TaskTrajectoryRun{}
+	indexByID := map[string]int{}
+	sources := map[string]taskTrajectoryRunSource{}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryRunLinkRows {
+			break
+		}
+		var run TaskTrajectoryRun
+		var link TaskTrajectoryLink
+		var status string
+		var agentNameTruncated bool
+		var triggerTypeTruncated bool
+		var statusTruncated bool
+		var toolNameTruncated bool
+		var sourceTruncated bool
+		var roleTruncated bool
+		var finished sql.NullTime
+		var inputTokens sql.NullInt64
+		var outputTokens sql.NullInt64
+		var cacheCreationTokens sql.NullInt64
+		var cacheReadTokens sql.NullInt64
+		var source taskTrajectoryRunSource
+		if err := rows.Scan(
+			&run.ID, &run.AgentID, &run.AgentName, &agentNameTruncated, &run.SessionID,
+			&run.TriggerType, &triggerTypeTruncated,
+			&run.TriggerMessageID, &run.ChannelID, &run.ThreadID, &run.ThinkingNodeID,
+			&status, &statusTruncated, &run.ToolName, &toolNameTruncated, &run.Source, &sourceTruncated,
+			&inputTokens, &outputTokens, &cacheCreationTokens, &cacheReadTokens,
+			&run.StartedAt, &run.UpdatedAt, &finished,
+			&link.TaskID, &link.Role, &roleTruncated, &link.Confidence, &link.CreatedAt,
+			&source.referenceRecorded,
+		); err != nil {
+			return nil, nil, false, err
+		}
+		run.Status = AgentRunStatus(status)
+		run.MetadataTruncated = agentNameTruncated || triggerTypeTruncated || statusTruncated || toolNameTruncated || sourceTruncated
+		link.MetadataTruncated = roleTruncated
+		if !safeTaskTrajectoryIdentifier(run.TriggerType, 128) {
+			run.TriggerType = "unknown"
+			run.MetadataTruncated = true
+		}
+		if !safeTaskTrajectoryIdentifier(string(run.Status), 128) {
+			run.Status = AgentRunStatus("unknown")
+			run.MetadataTruncated = true
+		}
+		if run.ToolName != "" && !safeTaskTrajectoryIdentifier(run.ToolName, 128) {
+			run.ToolName = ""
+			run.MetadataTruncated = true
+		}
+		if run.Source != "" && !safeTaskTrajectoryIdentifier(run.Source, 128) {
+			run.Source = ""
+			run.MetadataTruncated = true
+		}
+		if !safeTaskTrajectoryIdentifier(link.Role, 128) {
+			link.Role = "unknown"
+			link.MetadataTruncated = true
+		}
+		run.Usage = taskTrajectoryUsageFromColumns(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens)
+		if finished.Valid {
+			run.FinishedAt = &finished.Time
+		}
+		if idx, ok := indexByID[run.ID]; ok {
+			runs[idx].TaskLinks = append(runs[idx].TaskLinks, link)
+			continue
+		}
+		run.TaskLinks = []TaskTrajectoryLink{link}
+		run.Events = []TaskTrajectoryEvent{}
+		indexByID[run.ID] = len(runs)
+		runs = append(runs, run)
+		sources[run.ID] = source
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, false, err
+	}
+	return runs, sources, rowCount > maxTrajectoryRunLinkRows, nil
+}
+
+func loadTaskTrajectoryEvents(ctx context.Context, tx pgx.Tx, runs []TaskTrajectoryRun) (bool, error) {
+	if len(runs) == 0 {
+		return false, nil
+	}
+	runIDs := make([]string, 0, len(runs))
+	indexByID := make(map[string]int, len(runs))
+	for i := range runs {
+		runIDs = append(runIDs, runs[i].ID)
+		indexByID[runs[i].ID] = i
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_events AS MATERIALIZED (
+			SELECT id FROM agent_run_events WHERE run_id = ANY($1::uuid[]) LIMIT $2
+		)
+		SELECT e.id::text, e.run_id::text, e.seq,
+		       left(e.type, $3), char_length(e.type) > $3,
+		       left(COALESCE(e.tool_name, ''), $3), char_length(COALESCE(e.tool_name, '')) > $3,
+		       jsonb_strip_nulls(jsonb_build_object(
+		         'agent_id', left(e.payload->>'agent_id', 128),
+		         'task_id', left(e.payload->>'task_id', 128),
+		         'call_id', left(e.payload->>'call_id', 128),
+		         'role', left(e.payload->>'role', 128),
+		         'status', left(e.payload->>'status', 128),
+		         'is_error', CASE WHEN jsonb_typeof(e.payload->'is_error') = 'boolean' THEN (e.payload->>'is_error')::boolean END,
+		         'exit_code', CASE WHEN COALESCE(e.payload->>'exit_code', '') ~ '^-?[0-9]{1,18}$' THEN (e.payload->>'exit_code')::bigint END,
+		         'duration_ms', CASE WHEN COALESCE(e.payload->>'duration_ms', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'duration_ms')::bigint END,
+		         'input_tokens', CASE WHEN COALESCE(e.payload->>'input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'input_tokens')::bigint END,
+		         'output_tokens', CASE WHEN COALESCE(e.payload->>'output_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'output_tokens')::bigint END,
+		         'cache_creation_input_tokens', CASE WHEN COALESCE(e.payload->>'cache_creation_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'cache_creation_input_tokens')::bigint END,
+		         'cache_read_input_tokens', CASE WHEN COALESCE(e.payload->>'cache_read_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'cache_read_input_tokens')::bigint END
+		       )),
+		       (e.message <> '' OR e.payload <> '{}'::jsonb), e.created_at
+		  FROM bounded_events bounded
+		  JOIN agent_run_events e ON e.id = bounded.id
+		  JOIN agent_runs r ON r.id = e.run_id
+		 ORDER BY r.started_at ASC, e.run_id ASC, e.seq ASC
+		`, runIDs, maxTrajectoryEvents+1, maxTrajectoryShortTextRunes)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryEvents {
+			break
+		}
+		var event TaskTrajectoryEvent
+		var eventTypeTruncated bool
+		var toolNameTruncated bool
+		var metadataJSON json.RawMessage
+		var sourceContentPresent bool
+		if err := rows.Scan(
+			&event.ID, &event.RunID, &event.Seq, &event.Type, &eventTypeTruncated,
+			&event.ToolName, &toolNameTruncated, &metadataJSON, &sourceContentPresent, &event.CreatedAt,
+		); err != nil {
+			return false, err
+		}
+		if idx, ok := indexByID[event.RunID]; ok {
+			metadata, payloadOmitted := taskTrajectoryEventMetadata(metadataJSON)
+			event.Metadata = metadata
+			event.ContentOmitted = sourceContentPresent || payloadOmitted || eventTypeTruncated || toolNameTruncated
+			if !safeTaskTrajectoryIdentifier(event.Type, 128) {
+				event.Type = "unknown"
+				event.ContentOmitted = true
+			}
+			if event.ToolName != "" && !safeTaskTrajectoryIdentifier(event.ToolName, 128) {
+				event.ToolName = ""
+				event.ContentOmitted = true
+			}
+			runs[idx].Events = append(runs[idx].Events, event)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return rowCount > maxTrajectoryEvents, nil
+}
+
+func taskTrajectoryEventMetadata(payload json.RawMessage) (map[string]any, bool) {
+	var values map[string]any
+	if len(payload) == 0 || json.Unmarshal(payload, &values) != nil || len(values) == 0 {
+		return nil, len(payload) > 0 && string(payload) != "{}"
+	}
+	allowed := map[string]bool{
+		"agent_id": true, "task_id": true, "call_id": true, "role": true,
+		"status": true, "is_error": true, "exit_code": true, "duration_ms": true,
+		"input_tokens": true, "output_tokens": true, "cache_creation_input_tokens": true,
+		"cache_read_input_tokens": true,
+	}
+	metadata := map[string]any{}
+	omitted := false
+	for key, value := range values {
+		if !allowed[key] || !safeTaskTrajectoryEventMetadataValue(key, value) {
+			omitted = true
+			continue
+		}
+		metadata[key] = value
+	}
+	if len(metadata) == 0 {
+		metadata = nil
+	}
+	return metadata, omitted
+}
+
+func safeTaskTrajectoryEventMetadataValue(key string, value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return key == "is_error"
+	case float64:
+		return true
+	case string:
+		switch key {
+		case "agent_id", "task_id":
+			_, err := uuid.Parse(typed)
+			return err == nil
+		case "call_id", "role", "status":
+			return safeTaskTrajectoryIdentifier(typed, 128)
+		}
+	}
+	return false
+}
+
+func safeTaskTrajectoryIdentifier(value string, maxRunes int) bool {
+	runes := []rune(value)
+	if len(runes) == 0 || len(runes) > maxRunes {
+		return false
+	}
+	for _, r := range runes {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == ':' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func taskTrajectoryUsageFromColumns(input, output, cacheCreation, cacheRead sql.NullInt64) map[string]any {
+	metadata := map[string]any{}
+	for key, value := range map[string]sql.NullInt64{
+		"input_tokens": input, "output_tokens": output,
+		"cache_creation_input_tokens": cacheCreation, "cache_read_input_tokens": cacheRead,
+	} {
+		if value.Valid {
+			metadata[key] = value.Int64
+		}
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func loadTaskTrajectoryArtifacts(ctx context.Context, tx pgx.Tx, taskIDs []string, rootChannelID string) ([]TaskTrajectoryArtifact, bool, error) {
+	if len(taskIDs) == 0 {
+		return []TaskTrajectoryArtifact{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_artifacts AS MATERIALIZED (
+			SELECT id FROM artifacts
+			 WHERE task_id = ANY($1::uuid[]) AND channel_id = $2
+			 LIMIT $3
+		)
+		SELECT artifact.id::text, artifact.task_id::text,
+		       left(artifact.kind, $4), char_length(artifact.kind) > $4,
+		       left(artifact.title, $4), char_length(artifact.title) > $4,
+		       left(COALESCE(artifact.summary, ''), $5), char_length(COALESCE(artifact.summary, '')) > $5,
+		       artifact.created_by::text, artifact.created_at, artifact.updated_at
+		  FROM bounded_artifacts bounded
+		  JOIN artifacts artifact ON artifact.id = bounded.id
+		 ORDER BY artifact.created_at ASC, artifact.id ASC`,
+		taskIDs, rootChannelID, maxTrajectoryArtifacts+1, maxTrajectoryShortTextRunes, maxTrajectoryBodyTextRunes)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	artifacts := []TaskTrajectoryArtifact{}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryArtifacts {
+			break
+		}
+		var artifact TaskTrajectoryArtifact
+		var kindTruncated bool
+		var titleTruncated bool
+		var summaryTruncated bool
+		if err := rows.Scan(
+			&artifact.ID, &artifact.TaskID, &artifact.Kind, &kindTruncated,
+			&artifact.Title, &titleTruncated, &artifact.Summary, &summaryTruncated,
+			&artifact.CreatedBy, &artifact.CreatedAt, &artifact.UpdatedAt,
+		); err != nil {
+			return nil, false, err
+		}
+		artifact.URL = "/api/v1/artifacts/" + artifact.ID
+		artifact.ContentTruncated = kindTruncated || titleTruncated || summaryTruncated
+		if !safeTaskTrajectoryIdentifier(artifact.Kind, 128) {
+			artifact.Kind = "unknown"
+			artifact.ContentTruncated = true
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	return artifacts, rowCount > maxTrajectoryArtifacts, nil
+}
+
+func trajectoryTruncationWarnings(truncation taskTrajectoryTruncation) []TaskTrajectoryWarning {
+	warnings := []TaskTrajectoryWarning{}
+	if truncation.tasks {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "task_limit_reached", Message: fmt.Sprintf("task tree exceeded the %d-task export limit", maxTrajectoryTasks)})
+	}
+	if truncation.runLinks {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "run_link_limit_reached", Message: fmt.Sprintf("run-to-task links exceeded the %d-row export limit; a boundary run may have partial links and some runs may be omitted", maxTrajectoryRunLinkRows)})
+	}
+	if truncation.events {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "event_limit_reached", Message: fmt.Sprintf("run events exceeded the %d-event export limit; a boundary run may have partial events and some events may be omitted", maxTrajectoryEvents)})
+	}
+	if truncation.artifacts {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "artifact_limit_reached", Message: fmt.Sprintf("artifact metadata exceeded the %d-record export limit", maxTrajectoryArtifacts)})
+	}
+	return warnings
+}
+
+func attachTaskTrajectoryTranscriptReference(run *TaskTrajectoryRun, source taskTrajectoryRunSource, capturedAt time.Time) []TaskTrajectoryWarning {
+	warnings := []TaskTrajectoryWarning{}
+	windowEnd := capturedAt
+	if run.FinishedAt != nil {
+		windowEnd = *run.FinishedAt
+	}
+	run.Transcript = TaskTrajectoryTranscript{
+		Status:       "reference_recorded",
+		Association:  "unverified_time_window",
+		WindowStart:  run.StartedAt.Add(-2 * time.Second),
+		WindowEnd:    windowEnd.Add(2 * time.Second),
+		TextExported: false,
+	}
+	if run.FinishedAt == nil {
+		warnings = append(warnings, TaskTrajectoryWarning{
+			Code:    "run_in_progress",
+			RunID:   run.ID,
+			Message: "run was not finished at the database snapshot time",
+		})
+	}
+	if !source.referenceRecorded {
+		run.Transcript.Status = "missing"
+		warnings = append(warnings, TaskTrajectoryWarning{
+			Code:    "transcript_reference_missing",
+			RunID:   run.ID,
+			Message: "no transcript source reference is stored for this run",
+		})
+	}
+	return warnings
+}

--- a/internal/server/service/task_trajectory_test.go
+++ b/internal/server/service/task_trajectory_test.go
@@ -1,0 +1,277 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestTaskTrajectoryExportUsesStoredMetadataWithoutInternalContent(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	otherUserID := agentRunUser(t, pool)
+	agentAID := agentRunAgent(t, pool, ownerID)
+	agentBID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	otherChannelID := agentRunChannel(t, pool, otherUserID)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		 VALUES ($1, 'user', $2, 'owner')`, channelID, ownerID); err != nil {
+		t.Fatalf("add channel owner: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_sessions WHERE agent_id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, otherChannelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, otherChannelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = ANY($1::uuid[])`, []string{ownerID, otherUserID})
+	})
+
+	taskSvc := NewTaskService(pool)
+	root, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{
+		Title:       "Prepare release notes",
+		Description: "Summarize the ordinary release work",
+	})
+	if err != nil {
+		t.Fatalf("create root task: %v", err)
+	}
+	child, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{
+		Title:        "Check changelog",
+		ParentTaskID: root.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child task: %v", err)
+	}
+	crossChannelTaskID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number, parent_task_id)
+		VALUES ($1, $2, $3, 'cross-channel-secret-task', 'todo', 'normal', 1, $4)`,
+		crossChannelTaskID, otherChannelID, otherUserID, root.ID); err != nil {
+		t.Fatalf("create defensive cross-channel child: %v", err)
+	}
+	artifactID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO artifacts (id, task_id, channel_id, kind, title, html_path, summary, created_by)
+		VALUES ($1, $2, $3, 'task_snapshot', 'Release notes', '/private/artifact.html', 'published result', $4)`,
+		artifactID, root.ID, channelID, ownerID); err != nil {
+		t.Fatalf("create artifact: %v", err)
+	}
+
+	runSvc := NewAgentRunService(pool)
+	session, err := runSvc.UpsertSession(ctx, UpsertSessionInput{
+		AgentID:           agentAID,
+		Provider:          "codex",
+		ExternalSessionID: "trajectory-session",
+		TranscriptPath:    agentRunTranscriptFileWithText(t, "reviewed the changelog"),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	completedRun, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentAID,
+		SessionID:    session.ID,
+		TriggerType:  AgentRunTriggerTask,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusRunning,
+		ActivityText: "reviewing changelog",
+		Source:       "codex",
+		Usage:        map[string]any{"input_tokens": 12, "private_context": "secret-usage"},
+	})
+	if err != nil {
+		t.Fatalf("start completed run: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: completedRun.ID, TaskID: root.ID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
+		t.Fatalf("link root task: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: completedRun.ID, TaskID: child.ID, Role: AgentRunTaskRoleRelated, Confidence: 0.75}); err != nil {
+		t.Fatalf("link child task: %v", err)
+	}
+	firstEvent, err := runSvc.AppendEvent(ctx, AppendRunEventInput{RunID: completedRun.ID, Type: AgentRunEventRunStarted, Message: "started"})
+	if err != nil {
+		t.Fatalf("append first event: %v", err)
+	}
+	secondEvent, err := runSvc.AppendEvent(ctx, AppendRunEventInput{
+		RunID:   completedRun.ID,
+		Type:    AgentRunEventToolFinished,
+		Message: "secret event output",
+		Payload: map[string]any{"call_id": "call-1", "is_error": false, "output": "secret-token"},
+	})
+	if err != nil {
+		t.Fatalf("append second event: %v", err)
+	}
+	if _, err := runSvc.FinishRun(ctx, FinishRunInput{RunID: completedRun.ID, Status: AgentRunStatusCompleted, ActivityText: "done"}); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+
+	runningRun, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentBID,
+		TriggerType:  AgentRunTriggerTask,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusRunning,
+		ActivityText: "drafting notes",
+		Source:       "codex",
+	})
+	if err != nil {
+		t.Fatalf("start running run: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: runningRun.ID, TaskID: child.ID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
+		t.Fatalf("link running run: %v", err)
+	}
+
+	snapshot, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, ownerID)
+	if err != nil {
+		t.Fatalf("export trajectory: %v", err)
+	}
+	if snapshot.SchemaVersion != TaskTrajectorySchemaVersion || snapshot.RootTaskID != root.ID {
+		t.Fatalf("snapshot identity = %+v", snapshot)
+	}
+	if len(snapshot.Tasks) != 2 || snapshot.Tasks[0].ID != root.ID || snapshot.Tasks[1].ParentTaskID != root.ID {
+		t.Fatalf("task tree = %+v", snapshot.Tasks)
+	}
+	if len(snapshot.Runs) != 2 {
+		t.Fatalf("runs = %+v, want 2", snapshot.Runs)
+	}
+
+	completed := trajectoryRunByID(t, snapshot.Runs, completedRun.ID)
+	if len(completed.TaskLinks) != 2 {
+		t.Fatalf("completed task links = %+v, want 2", completed.TaskLinks)
+	}
+	if len(completed.Events) != 2 || completed.Events[0].ID != firstEvent.ID || completed.Events[1].ID != secondEvent.ID {
+		t.Fatalf("ordered events = %+v", completed.Events)
+	}
+	if !completed.Events[1].ContentOmitted || completed.Events[1].Metadata["call_id"] != "call-1" || completed.Events[1].Metadata["is_error"] != false {
+		t.Fatalf("metadata-only event = %+v", completed.Events[1])
+	}
+	if completed.Transcript.Status != "reference_recorded" || completed.Transcript.TextExported || completed.Transcript.Association != "unverified_time_window" {
+		t.Fatalf("completed transcript = %+v", completed.Transcript)
+	}
+	if completed.Usage["input_tokens"] != int64(12) {
+		t.Fatalf("sanitized usage = %+v", completed.Usage)
+	}
+	running := trajectoryRunByID(t, snapshot.Runs, runningRun.ID)
+	if running.Transcript.Status != "missing" {
+		t.Fatalf("running transcript = %+v, want missing", running.Transcript)
+	}
+	if !trajectoryHasWarning(snapshot.Warnings, "run_in_progress", runningRun.ID) || !trajectoryHasWarning(snapshot.Warnings, "transcript_reference_missing", runningRun.ID) {
+		t.Fatalf("warnings = %+v", snapshot.Warnings)
+	}
+	if snapshot.Coverage.ParentRunLinks != "unavailable" || snapshot.Coverage.TranscriptAvailability != "reference_recorded_only_unverified_time_window" || snapshot.Coverage.Completeness != "partial_stored_records" {
+		t.Fatalf("coverage = %+v", snapshot.Coverage)
+	}
+	if len(snapshot.Artifacts) != 1 || snapshot.Artifacts[0].ID != artifactID || snapshot.Artifacts[0].URL != "/api/v1/artifacts/"+artifactID {
+		t.Fatalf("artifacts = %+v", snapshot.Artifacts)
+	}
+
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	jsonText := string(raw)
+	for _, secret := range []string{"transcript_path", `"raw"`, `"input"`, "reviewed the changelog", "secret event output", "secret-token", "secret-usage", "/private/artifact.html", "cross-channel-secret-task"} {
+		if strings.Contains(jsonText, secret) {
+			t.Fatalf("snapshot leaked internal content %q: %s", secret, jsonText)
+		}
+	}
+
+	if _, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, otherUserID); !errors.Is(err, ErrTaskNotChannelMember) {
+		t.Fatalf("unauthorized export error = %v, want %v", err, ErrTaskNotChannelMember)
+	}
+}
+
+func TestTaskTrajectoryExportCapsLargeTaskTrees(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		 VALUES ($1, 'user', $2, 'owner')`, channelID, ownerID); err != nil {
+		t.Fatalf("add channel owner: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	root, err := NewTaskService(pool).CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "large trajectory root"})
+	if err != nil {
+		t.Fatalf("create root task: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number, parent_task_id)
+		SELECT gen_random_uuid(), $1, $2, 'child-' || n, 'todo', 'normal', n + 1, $3
+		  FROM generate_series(1, $4) AS n`, channelID, ownerID, root.ID, maxTrajectoryTasks+5); err != nil {
+		t.Fatalf("create child tasks: %v", err)
+	}
+
+	snapshot, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, ownerID)
+	if err != nil {
+		t.Fatalf("export capped trajectory: %v", err)
+	}
+	if len(snapshot.Tasks) != maxTrajectoryTasks {
+		t.Fatalf("task count = %d, want cap %d", len(snapshot.Tasks), maxTrajectoryTasks)
+	}
+	if snapshot.Coverage.Completeness != "partial_truncated_stored_records" || !trajectoryHasWarning(snapshot.Warnings, "task_limit_reached", "") {
+		t.Fatalf("coverage = %+v, warnings = %+v", snapshot.Coverage, snapshot.Warnings)
+	}
+}
+
+func TestTaskTrajectoryEventMetadataRejectsUntrustedValues(t *testing.T) {
+	metadata, omitted := taskTrajectoryEventMetadata(json.RawMessage(`{
+		"call_id":"contains a space",
+		"task_id":"not-a-uuid",
+		"is_error":true,
+		"output":{"secret":"value"},
+		"unknown":"secret"
+	}`))
+	if !omitted {
+		t.Fatal("untrusted event fields were not marked omitted")
+	}
+	if len(metadata) != 1 || metadata["is_error"] != true {
+		t.Fatalf("metadata = %+v, want only is_error", metadata)
+	}
+}
+
+func TestTaskTrajectoryTranscriptOnlyClaimsStoredReference(t *testing.T) {
+	finishedAt := time.Now().UTC()
+	run := TaskTrajectoryRun{ID: "run-reference", StartedAt: finishedAt.Add(-time.Minute), FinishedAt: &finishedAt}
+	warnings := attachTaskTrajectoryTranscriptReference(&run, taskTrajectoryRunSource{referenceRecorded: true}, finishedAt)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v", warnings)
+	}
+	if run.Transcript.Status != "reference_recorded" || run.Transcript.TextExported {
+		t.Fatalf("transcript = %+v", run.Transcript)
+	}
+}
+
+func trajectoryRunByID(t *testing.T, runs []TaskTrajectoryRun, id string) TaskTrajectoryRun {
+	t.Helper()
+	for _, run := range runs {
+		if run.ID == id {
+			return run
+		}
+	}
+	t.Fatalf("run %s not found in %+v", id, runs)
+	return TaskTrajectoryRun{}
+}
+
+func trajectoryHasWarning(warnings []TaskTrajectoryWarning, code, runID string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code && warning.RunID == runID {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- add a versioned, read-only `GET /api/v1/tasks/{taskID}/trajectory` snapshot and `solo task trajectory` CLI command
- export bounded task-tree, linked Run, metadata-only Run Event, selected Artifact, and transcript-reference availability evidence
- declare missing correlations and truncation explicitly without changing prompts, routing, task lifecycle, Agent runtime, or the database schema

The export deliberately omits Run Event messages, transcript text and paths, tool input/output payloads, arbitrary Usage JSON, and Artifact filesystem paths. Authorization and database reads share one read-only repeatable-read transaction, and every task/run/artifact query is constrained to the root channel.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests

## Related

Closes #50

## Architecture and scope

- domain: an ephemeral `solo.task_trajectory.v1` evidence snapshot; it is not a new source of truth
- persistence: reuses existing tasks, Agent Runs, links, Events, Sessions, and Artifacts; no migration
- consistency: resource authorization and stored evidence are read in one PostgreSQL repeatable-read snapshot
- safety: SQL-side selected fields, bounded materialized ID sets, metadata validation, and explicit partial/truncated coverage
- recovery: database failures fail the request; missing transcript references and running Runs become structured warnings
- non-goals: no parent-Run inference, dispatch-decision inference, outbound-message attribution, failure taxonomy, dashboard, or collaboration behavior changes

## Validation

- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] real PostgreSQL integration tests for task hierarchy, multiple Agents/Runs, ordered metadata-only Events, Artifact references, internal-content omission, record caps, cross-channel isolation, 401/400/403/404 handling, and CLI JSON transport
- [ ] make-managed frontend/API/PostgreSQL E2E

The E2E checkbox remains open because this machine currently has unrelated services bound to Solo hard-coded ports 3000/8080/8081, and npm is not installed. The repository rules only allow starting Solo through `make rebuild`; I did not stop unrelated services or manually bypass that lifecycle. This is why the PR is opened as draft.

## Screenshots

Not applicable; this PR adds no UI.