### PR TITLE
feat: attribute agent actions to originating runs

### DIFF
--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/solo-ai/solo/internal/auth"
+	"github.com/solo-ai/solo/internal/causal"
 	"github.com/solo-ai/solo/pkg/agent"
 	"github.com/solo-ai/solo/pkg/llm"
 	"github.com/solo-ai/solo/pkg/skillloader"
@@ -399,6 +400,22 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	var originRunID string
+	if isRuntimeMutation(req.Action) {
+		scope, ok := h.taskManager.GetActionScope(req.AgentID)
+		if !ok || scope.ChannelID != req.ChannelID || scope.NodeID != req.NodeID {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "no matching active provider turn for mutation"})
+			return
+		}
+		originRunID = scope.RunID
+	}
+	proxyToken := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	claims, authErr := auth.ValidateToken(proxyToken)
+	if authErr != nil || claims.Subject != req.AgentID {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "proxy caller does not match agent_id"})
+		return
+	}
+
 	// Generate or reuse auth token for this agent (SOLO-254-B: token store).
 	token, err := h.getOrGenerateToken(r.Context(), req.AgentID)
 	if err != nil {
@@ -431,6 +448,12 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		serverBody, _ = json.Marshal(map[string]string{"status": req.Status})
 	case "task_unclaim":
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/tasks/%d/claim", req.ChannelID, req.TaskNumber)
+	case "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
+		action := strings.TrimPrefix(req.Action, "task_")
+		serverPath = fmt.Sprintf("/api/v1/channels/%s/tasks/%d/%s", req.ChannelID, req.TaskNumber, action)
+		if req.Action == "task_reject" {
+			serverBody, _ = json.Marshal(map[string]string{"reason": req.Content})
+		}
 	case "channel_members":
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/members", req.ChannelID)
 	case "server_info":
@@ -465,8 +488,11 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		method := "GET"
 		var fwdBody io.Reader
 		switch req.Action {
-		case "task_claim":
+		case "task_claim", "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
 			method = "POST"
+			if serverBody != nil {
+				fwdBody = bytes.NewReader(serverBody)
+			}
 		case "task_update":
 			method = "PATCH"
 			fwdBody = bytes.NewReader(serverBody)
@@ -486,6 +512,10 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			httpReq.Header.Set("Content-Type", "application/json")
 		}
 		httpReq.Header.Set("Authorization", "Bearer "+tok)
+		if originRunID != "" {
+			httpReq.Header.Set(causal.RunHeader, originRunID)
+			httpReq.Header.Set(causal.SignatureHeader, causal.Sign(h.internalToken, originRunID, req.AgentID, req.ChannelID))
+		}
 
 		client := h.httpClient
 		if req.Action == "team_form" {
@@ -526,6 +556,15 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
 	w.Write(body)
+}
+
+func isRuntimeMutation(action string) bool {
+	switch action {
+	case "message_send", "task_claim", "task_unclaim", "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
+		return true
+	default:
+		return false
+	}
 }
 
 func cloneHTTPClientWithTimeout(client *http.Client, timeout time.Duration) *http.Client {
@@ -573,6 +612,7 @@ func (h *daemonHandler) getProvider(providerType string) llm.Provider {
 // runTaskRequest is the payload sent by the server to the daemon.
 type runTaskRequest struct {
 	TaskID                string             `json:"task_id"`
+	RunID                 string             `json:"run_id,omitempty"`
 	AgentID               string             `json:"agent_id"`
 	ChannelID             string             `json:"channel_id"`
 	ThreadID              string             `json:"thread_id,omitempty"`
@@ -584,7 +624,8 @@ type runTaskRequest struct {
 	SystemPrompt          string             `json:"system_prompt"`
 	ThinkingRuntimePrompt string             `json:"thinking_runtime_prompt,omitempty"`
 	ModelConfig           modelConfigPayload `json:"model_config"`
-	TaskContext           string             `json:"task_context,omitempty"`    // SOLO-221-B: summary of pending tasks in channel
+	TaskContext           string             `json:"task_context,omitempty"` // SOLO-221-B: summary of pending tasks in channel
+	OriginTaskID          string             `json:"origin_task_id,omitempty"`
 	MentionedNames        []string           `json:"mentioned_names,omitempty"` // v1.3: names of @mentioned agents
 }
 
@@ -714,6 +755,12 @@ func (h *daemonHandler) processTaskWithProvider(ctx context.Context, req runTask
 
 	// Select the provider matching the agent type and stream
 	provider := h.getProvider(req.ModelConfig.Provider)
+	clearActionScope, ok := h.activateActionScope(req)
+	if !ok {
+		h.failActionScopeConflict(req)
+		return
+	}
+	defer clearActionScope()
 	streamCh, err := provider.CompleteStream(ctx, llmReq)
 	if err != nil {
 		slog.Error("task: streaming LLM call failed to start",
@@ -732,7 +779,6 @@ func (h *daemonHandler) processTaskWithProvider(ctx context.Context, req runTask
 		h.taskManager.CloseAllSubscribers(req.TaskID)
 		return
 	}
-
 	// Collect full content from stream
 	var fullContent string
 	var usage llm.Usage
@@ -1035,6 +1081,13 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		// ExtraArgs: daemonConfig.ExtraArgs[backend.Name()], // P1 reserved
 	}
 
+	clearActionScope, ok := h.activateActionScope(req)
+	if !ok {
+		h.failActionScopeConflict(req)
+		return
+	}
+	defer clearActionScope()
+
 	// v1.3: Session-aware dispatch. Thinking nodes use a node-scoped pool key
 	// while retaining the real Agent identity, workspace, and configuration.
 	var session *agent.Session
@@ -1272,6 +1325,33 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 	// Push done sentinel and close. The done event is consumed by SSE
 	// subscribers in order, eliminating the need for a delay.
 	h.pushEventJSON(req.TaskID, "done", map[string]interface{}{})
+	h.taskManager.CloseAllSubscribers(req.TaskID)
+}
+
+func (h *daemonHandler) activateActionScope(req runTaskRequest) (func(), bool) {
+	// Keep rolling upgrades compatible: an older server may omit run_id.
+	// The turn can execute, but every runtime mutation will fail closed because
+	// no causal scope is registered.
+	if req.RunID == "" {
+		return func() {}, true
+	}
+	scope := actionScope{
+		RunID: req.RunID, AgentID: req.AgentID, ChannelID: req.ChannelID,
+		ThreadID: req.ThreadID, NodeID: req.NodeID, TaskID: req.OriginTaskID,
+	}
+	if !h.taskManager.SetActionScope(scope) {
+		return func() {}, false
+	}
+	return func() { h.taskManager.ClearActionScope(req.AgentID, req.RunID) }, true
+}
+
+func (h *daemonHandler) failActionScopeConflict(req runTaskRequest) {
+	errText := "another provider turn is already active for this agent"
+	h.taskManager.UpdateStatus(req.TaskID, taskStatusFailed)
+	h.notifyServerError(req, errText)
+	h.pushEventJSON(req.TaskID, "error", map[string]interface{}{
+		"agent_id": req.AgentID, "error": errText, "retryable": true,
+	})
 	h.taskManager.CloseAllSubscribers(req.TaskID)
 }
 

--- a/cmd/daemon/handler_test.go
+++ b/cmd/daemon/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/solo-ai/solo/internal/auth"
+	"github.com/solo-ai/solo/internal/causal"
 	"github.com/solo-ai/solo/pkg/agent"
 	"github.com/solo-ai/solo/pkg/llm"
 )
@@ -213,6 +215,118 @@ func TestCloneHTTPClientWithTimeoutPreservesTransport(t *testing.T) {
 	}
 	if original.Timeout != 10*time.Second {
 		t.Fatalf("original timeout changed to %s", original.Timeout)
+	}
+}
+
+func TestProxyMutationRequiresMatchingActiveTurn(t *testing.T) {
+	tm := newTaskManager()
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, "http://example.invalid", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusConflict, resp.Body.String())
+	}
+
+	tm.SetActionScope(actionScope{RunID: "run-1", AgentID: "agent-1", ChannelID: "other-channel"})
+	req = httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"task_claim","channel_id":"channel-1","task_number":1
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	resp = httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("wrong-channel status = %d, want %d; body=%s", resp.Code, http.StatusConflict, resp.Body.String())
+	}
+}
+
+func TestProxyMutationInjectsDaemonOwnedOriginRun(t *testing.T) {
+	var gotRunID string
+	var gotSignature string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRunID = r.Header.Get(causal.RunHeader)
+		gotSignature = r.Header.Get(causal.SignatureHeader)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"message-1"}`))
+	}))
+	defer upstream.Close()
+
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-actual", AgentID: "agent-1", ChannelID: "channel-1"})
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, upstream.URL, "test-internal-secret")
+	agentToken, err := auth.GenerateAgentToken("agent-1", "Agent One")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.agentTokens["agent-1"] = &agentTokenState{accessToken: agentToken, expiresAt: time.Now().Add(time.Hour)}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("Authorization", "Bearer "+agentToken)
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusCreated, resp.Body.String())
+	}
+	if gotRunID != "run-actual" {
+		t.Fatalf("origin header = %q, want %q", gotRunID, "run-actual")
+	}
+	if !causal.Verify("test-internal-secret", gotRunID, "agent-1", "channel-1", gotSignature) {
+		t.Fatalf("invalid daemon origin signature %q", gotSignature)
+	}
+}
+
+func TestProxyRejectsCallerTokenForDifferentAgent(t *testing.T) {
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-1", AgentID: "agent-1", ChannelID: "channel-1"})
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, "http://example.invalid", "test-internal-secret")
+	otherToken, err := auth.GenerateAgentToken("agent-2", "Agent Two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("Authorization", "Bearer "+otherToken)
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusUnauthorized, resp.Body.String())
+	}
+}
+
+func TestClearActionScopeDoesNotDeleteNewerTurn(t *testing.T) {
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-old", AgentID: "agent-1"})
+	tm.ClearActionScope("agent-1", "run-old")
+	tm.SetActionScope(actionScope{RunID: "run-new", AgentID: "agent-1"})
+	tm.ClearActionScope("agent-1", "run-old")
+
+	scope, ok := tm.GetActionScope("agent-1")
+	if !ok || scope.RunID != "run-new" {
+		t.Fatalf("scope = %+v, ok=%v; want run-new", scope, ok)
+	}
+}
+
+func TestSetActionScopeRejectsConcurrentTurn(t *testing.T) {
+	tm := newTaskManager()
+	if !tm.SetActionScope(actionScope{RunID: "run-old", AgentID: "agent-1"}) {
+		t.Fatal("first scope was rejected")
+	}
+	if tm.SetActionScope(actionScope{RunID: "run-new", AgentID: "agent-1"}) {
+		t.Fatal("concurrent scope was accepted")
+	}
+	scope, ok := tm.GetActionScope("agent-1")
+	if !ok || scope.RunID != "run-old" {
+		t.Fatalf("scope = %+v, ok=%v; want run-old", scope, ok)
 	}
 }
 

--- a/cmd/daemon/task.go
+++ b/cmd/daemon/task.go
@@ -45,6 +45,15 @@ type sseSubscriber struct {
 	done   chan struct{}
 }
 
+type actionScope struct {
+	RunID     string
+	AgentID   string
+	ChannelID string
+	ThreadID  string
+	NodeID    string
+	TaskID    string
+}
+
 // taskManager manages task states and SSE subscribers in the daemon.
 type taskManager struct {
 	mu           sync.RWMutex
@@ -52,6 +61,7 @@ type taskManager struct {
 	subscribers  map[string][]*sseSubscriber   // taskID -> subscribers
 	eventHistory map[string][]sseEvent         // taskID -> replayable SSE control events
 	cancelFuncs  map[string]context.CancelFunc // taskID -> cancel func
+	actionScopes map[string]actionScope        // agentID -> current provider turn
 }
 
 // newTaskManager creates a new task manager.
@@ -61,7 +71,36 @@ func newTaskManager() *taskManager {
 		subscribers:  make(map[string][]*sseSubscriber),
 		eventHistory: make(map[string][]sseEvent),
 		cancelFuncs:  make(map[string]context.CancelFunc),
+		actionScopes: make(map[string]actionScope),
 	}
+}
+
+func (tm *taskManager) SetActionScope(scope actionScope) bool {
+	if scope.AgentID == "" || scope.RunID == "" {
+		return false
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if _, exists := tm.actionScopes[scope.AgentID]; exists {
+		return false
+	}
+	tm.actionScopes[scope.AgentID] = scope
+	return true
+}
+
+func (tm *taskManager) GetActionScope(agentID string) (actionScope, bool) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	scope, ok := tm.actionScopes[agentID]
+	return scope, ok
+}
+
+func (tm *taskManager) ClearActionScope(agentID, runID string) {
+	tm.mu.Lock()
+	if scope, ok := tm.actionScopes[agentID]; ok && scope.RunID == runID {
+		delete(tm.actionScopes, agentID)
+	}
+	tm.mu.Unlock()
 }
 
 // AddTask registers a new task.

--- a/cmd/solo/README.md
+++ b/cmd/solo/README.md
@@ -79,6 +79,21 @@ solo task reopen -n <number> -c <channel_id>
 
 `submit` moves claimed work to review. `accept` marks reviewed work done. `reject` sends reviewed work back to progress. `close` and `reopen` are human lifecycle actions.
 
+### task trajectory -- export task evidence
+
+```bash
+solo task trajectory -n <number> -c <channel_id> \
+  [--output json]
+```
+
+Exports a versioned JSON snapshot containing the requested task and its
+descendants, linked Agent runs, metadata-only ordered run events, transcript
+source-availability metadata, and selected artifact metadata. Run-event
+messages, transcript text, and tool input/output payload fields are not
+exported. The snapshot declares unavailable or unverified correlations instead
+of inferring them from timestamps. This command always writes the snapshot JSON
+object directly to stdout so it can be archived or processed with `jq`.
+
 ### message send -- send a message to a channel
 
 ```bash

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -380,6 +380,9 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 		return 0, nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
 	client := &http.Client{Timeout: proxyRequestTimeout(action)}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -388,6 +391,10 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, respBody, nil
+}
+
+func agentRuntimeConfigured() bool {
+	return strings.TrimSpace(os.Getenv("SOLO_AGENT_ID")) != ""
 }
 
 func handleTask(args []string, baseURL, token string) {
@@ -579,7 +586,7 @@ func handleTaskClaim(args []string, baseURL, token string) {
 	// Try daemon proxy first (uses fresh JWT).
 	// Pass messageID via taskID parameter so the proxy uses it in the URL path.
 	statusCode, body, err := proxyRequest("task_claim", channelID, taskID, "", token, number, "")
-	if err != nil {
+	if err != nil && !agentRuntimeConfigured() {
 		// Fallback to direct API
 		apiURL := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%s/claim", baseURL, channelID, taskID)
 		statusCode, body, err = doHTTP(http.MethodPost, apiURL, token, nil)
@@ -743,7 +750,7 @@ func handleTaskUnclaim(args []string, baseURL, token string) {
 
 	// Try daemon proxy first (uses fresh JWT)
 	statusCode, body, err := proxyRequest("task_unclaim", channelID, "", "", token, number, "")
-	if err != nil {
+	if err != nil && !agentRuntimeConfigured() {
 		// Fallback to direct API
 		url := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%d/claim", baseURL, channelID, number)
 		statusCode, body, err = doHTTP(http.MethodDelete, url, token, nil)
@@ -792,12 +799,15 @@ func handleTaskLifecycle(args []string, baseURL, token, action string) {
 		doExit(exitBusiness)
 	}
 
-	url := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%d/%s", baseURL, channelID, number, action)
 	var reqBody []byte
 	if action == "reject" {
 		reqBody, _ = json.Marshal(map[string]string{"reason": strings.TrimSpace(reason)})
 	}
-	statusCode, body, err := doHTTP(http.MethodPost, url, token, reqBody)
+	statusCode, body, err := proxyRequest("task_"+action, channelID, strings.TrimSpace(reason), "", token, number, "")
+	if err != nil && !agentRuntimeConfigured() {
+		url := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%d/%s", baseURL, channelID, number, action)
+		statusCode, body, err = doHTTP(http.MethodPost, url, token, reqBody)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
 		doExit(exitUsage)
@@ -875,7 +885,7 @@ func handleMessageSend(args []string, baseURL, token string) {
 	body, _ := json.Marshal(reqBody)
 	// Try daemon proxy first
 	statusCode, respBody, err := proxyRequest("message_send", channelID, content, threadID, token, 0, "")
-	if err != nil {
+	if err != nil && !agentRuntimeConfigured() {
 		// Fallback to direct API
 		url := fmt.Sprintf("%s/api/v1/channels/%s/messages", baseURL, channelID)
 		statusCode, respBody, err = doHTTP(http.MethodPost, url, token, body)

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -16,6 +16,7 @@
 //	solo task reject   -n <number> -c <channel_id> --reason <reason>
 //	solo task close    -n <number> -c <channel_id>
 //	solo task reopen   -n <number> -c <channel_id>
+//	solo task trajectory -n <number> -c <channel_id> [--output json]
 //	solo artifact publish --task <task_id> --file <artifact.html> [--mode latest|final]
 //	solo channel members -c <channel_id> [--output json]
 //	solo channel join  --target <#channel-name>
@@ -391,7 +392,7 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 
 func handleTask(args []string, baseURL, token string) {
 	if len(args) < 1 {
-		fmt.Fprintln(os.Stderr, "solo: error: task subcommand required (list, claim, update, create, unclaim, submit, accept, reject, close, reopen)")
+		fmt.Fprintln(os.Stderr, "solo: error: task subcommand required (list, claim, update, create, unclaim, submit, accept, reject, close, reopen, trajectory)")
 		printUsage()
 		doExit(exitUsage)
 	}
@@ -409,11 +410,72 @@ func handleTask(args []string, baseURL, token string) {
 		handleTaskUnclaim(args[1:], baseURL, token)
 	case "submit", "accept", "reject", "close", "reopen":
 		handleTaskLifecycle(args[1:], baseURL, token, args[0])
+	case "trajectory":
+		handleTaskTrajectory(args[1:], baseURL, token)
 	default:
 		fmt.Fprintf(os.Stderr, "solo: error: unknown task subcommand %q\n", args[0])
 		printUsage()
 		doExit(exitUsage)
 	}
+}
+
+// --- task trajectory ---
+
+func handleTaskTrajectory(args []string, baseURL, token string) {
+	var channel, output string
+	var number int
+	fs := flag.NewFlagSet("task trajectory", flag.ExitOnError)
+	fs.StringVar(&channel, "c", "", "Channel ID or #name (required)")
+	fs.StringVar(&channel, "channel", "", "Channel ID or #name (required)")
+	fs.IntVar(&number, "n", 0, "Task number (required)")
+	fs.IntVar(&number, "number", 0, "Task number (required)")
+	fs.StringVar(&output, "output", "json", "Output format: json")
+	fs.Parse(args)
+
+	if fs.NArg() > 0 {
+		fmt.Fprintf(os.Stderr, "solo: error: unexpected argument: %s\n", fs.Arg(0))
+		doExit(exitUsage)
+	}
+	if channel == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: -c <channel_id> is required")
+		doExit(exitUsage)
+	}
+	if number <= 0 {
+		fmt.Fprintln(os.Stderr, "solo: error: -n <number> must be a positive integer")
+		doExit(exitUsage)
+	}
+	if output != "json" {
+		fmt.Fprintf(os.Stderr, "solo: error: invalid --output value %q (only \"json\" is supported)\n", output)
+		doExit(exitUsage)
+	}
+
+	channelID, err := resolveChannelParam(baseURL, token, channel)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", err)
+		doExit(exitBusiness)
+	}
+	taskID, err := resolveTaskNumberToID(baseURL, token, channelID, number)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", err)
+		doExit(exitBusiness)
+	}
+
+	requestURL := fmt.Sprintf("%s/api/v1/tasks/%s/trajectory", baseURL, url.PathEscape(taskID))
+	statusCode, body, err := doHTTP(http.MethodGet, requestURL, token, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
+		doExit(exitUsage)
+	}
+	if statusCode >= 400 {
+		printJSONError(statusCode, extractErrorMessage(body))
+		handleNonProxyHTTPError(statusCode, body)
+	}
+	if !json.Valid(body) {
+		fmt.Fprintln(os.Stderr, "solo: error: trajectory endpoint returned invalid JSON")
+		doExit(exitUsage)
+	}
+	fmt.Println(string(body))
+	doExit(exitOK)
 }
 
 // --- task list ---
@@ -1466,6 +1528,7 @@ func printUsage() {
   solo task reject   -n <number> -c <channel_id> --reason <reason>
   solo task close    -n <number> -c <channel_id>
   solo task reopen   -n <number> -c <channel_id>
+  solo task trajectory -n <number> -c <channel_id> [--output json]
   solo artifact publish --task <task_id> --file <artifact.html> [--mode latest|final]
   solo channel members -c <channel_id> [--output json]
   solo channel join  --target <#channel-name>

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -604,6 +604,48 @@ func TestHandleTaskLifecycleCloseReopen(t *testing.T) {
 	}
 }
 
+func TestAgentTaskLifecycleUsesDaemonProxy(t *testing.T) {
+	var action string
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		action, _ = body["action"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"1","status":"in_review"}`))
+	}))
+	defer daemon.Close()
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+	t.Setenv("SOLO_DAEMON_URL", daemon.URL)
+
+	code, _, _ := captureAndRun(t, func() {
+		handleTaskLifecycle([]string{"-n", "1", "-c", "550e8400-e29b-41d4-a716-446655440001"}, "http://127.0.0.1:1", "stale-token", "submit")
+	})
+	if code != exitOK || action != "task_submit" {
+		t.Fatalf("code=%d action=%q, want %d/task_submit", code, action, exitOK)
+	}
+}
+
+func TestAgentTaskLifecycleFailsClosedWhenDaemonUnavailable(t *testing.T) {
+	var directRequests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		directRequests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+	t.Setenv("SOLO_DAEMON_URL", "http://127.0.0.1:1")
+
+	code, _, stderr := captureAndRun(t, func() {
+		handleTaskLifecycle([]string{"-n", "1", "-c", "550e8400-e29b-41d4-a716-446655440001"}, server.URL, "stale-token", "submit")
+	})
+	if code != exitUsage {
+		t.Fatalf("code=%d, want %d; stderr=%s", code, exitUsage, stderr)
+	}
+	if directRequests != 0 {
+		t.Fatalf("agent mutation fell back to direct API: requests=%d", directRequests)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // task create tests
 // ---------------------------------------------------------------------------

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -268,6 +268,50 @@ func TestHandleTaskListWithChannel(t *testing.T) {
 	}
 }
 
+func TestHandleTaskTrajectoryPrintsVersionedJSON(t *testing.T) {
+	channelID := "550e8400-e29b-41d4-a716-446655440001"
+	taskID := "550e8400-e29b-41d4-a716-446655440002"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization = %q", r.Header.Get("Authorization"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/channels/" + channelID + "/tasks":
+			json.NewEncoder(w).Encode([]map[string]any{{"id": taskID, "task_number": 7}})
+		case "/api/v1/tasks/" + taskID + "/trajectory":
+			json.NewEncoder(w).Encode(map[string]any{
+				"schema_version": "solo.task_trajectory.v1",
+				"root_task_id":   taskID,
+				"tasks":          []any{},
+				"runs":           []any{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	code, stdout, stderr := captureAndRun(t, func() {
+		handleTaskTrajectory([]string{"-c", channelID, "-n", "7", "--output", "json"}, server.URL, "test-token")
+	})
+	if code != exitOK {
+		t.Fatalf("exit code = %d, stderr = %s", code, stderr)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &output); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout)
+	}
+	if output["schema_version"] != "solo.task_trajectory.v1" || output["root_task_id"] != taskID {
+		t.Fatalf("output = %+v", output)
+	}
+}
+
 func TestHandleTaskListOutputJSON(t *testing.T) {
 	var capturedMethod, capturedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/causal/origin.go
+++ b/internal/causal/origin.go
@@ -1,0 +1,37 @@
+package causal
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+const (
+	RunHeader       = "X-Solo-Origin-Run-ID"
+	SignatureHeader = "X-Solo-Origin-Signature"
+)
+
+func SharedSecret() string {
+	if secret := os.Getenv("INTERNAL_TOKEN_SECRET"); secret != "" {
+		return secret
+	}
+	return os.Getenv("JWT_SECRET")
+}
+
+func Sign(secret, runID, actorID, channelID string) string {
+	if secret == "" || runID == "" || actorID == "" || channelID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(runID + "\n" + actorID + "\n" + channelID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func Verify(secret, runID, actorID, channelID, signature string) bool {
+	expected := Sign(secret, runID, actorID, channelID)
+	if expected == "" || signature == "" {
+		return false
+	}
+	return hmac.Equal([]byte(expected), []byte(signature))
+}

--- a/internal/causal/origin_test.go
+++ b/internal/causal/origin_test.go
@@ -1,0 +1,28 @@
+package causal
+
+import "testing"
+
+func TestOriginSignatureBindsRunActorAndChannel(t *testing.T) {
+	signature := Sign("secret", "run-1", "agent-1", "channel-1")
+	if !Verify("secret", "run-1", "agent-1", "channel-1", signature) {
+		t.Fatal("valid origin signature was rejected")
+	}
+	for _, altered := range []struct{ run, actor, channel string }{
+		{"run-2", "agent-1", "channel-1"},
+		{"run-1", "agent-2", "channel-1"},
+		{"run-1", "agent-1", "channel-2"},
+	} {
+		if Verify("secret", altered.run, altered.actor, altered.channel, signature) {
+			t.Fatalf("altered origin was accepted: %+v", altered)
+		}
+	}
+}
+
+func TestOriginSignatureRejectsMissingSecretOrSignature(t *testing.T) {
+	if Sign("", "run-1", "agent-1", "channel-1") != "" {
+		t.Fatal("empty secret produced a signature")
+	}
+	if Verify("secret", "run-1", "agent-1", "channel-1", "") {
+		t.Fatal("empty signature was accepted")
+	}
+}

--- a/internal/server/handler/agent_run.go
+++ b/internal/server/handler/agent_run.go
@@ -1,20 +1,26 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/solo-ai/solo/internal/server/service"
 )
 
 type AgentRunHandler struct {
-	svc *service.AgentRunService
+	svc           *service.AgentRunService
+	trajectorySvc *service.TaskTrajectoryService
 }
 
 func NewAgentRunHandler(pool *pgxpool.Pool) *AgentRunHandler {
-	return &AgentRunHandler{svc: service.NewAgentRunService(pool)}
+	return &AgentRunHandler{
+		svc:           service.NewAgentRunService(pool),
+		trajectorySvc: service.NewTaskTrajectoryService(pool),
+	}
 }
 
 func (h *AgentRunHandler) Active(w http.ResponseWriter, r *http.Request) {
@@ -143,6 +149,33 @@ func (h *AgentRunHandler) TaskTimeline(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, timeline)
+}
+
+func (h *AgentRunHandler) TaskTrajectory(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	taskID := chi.URLParam(r, "taskID")
+	if _, err := uuid.Parse(taskID); err != nil {
+		writeError(w, http.StatusBadRequest, "taskID must be a UUID")
+		return
+	}
+
+	snapshot, err := h.trajectorySvc.Export(r.Context(), taskID, userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrTaskNotFound):
+			writeError(w, http.StatusNotFound, "task not found")
+		case errors.Is(err, service.ErrTaskNotChannelMember):
+			writeError(w, http.StatusForbidden, "not authorized to read this task trajectory")
+		default:
+			writeError(w, http.StatusInternalServerError, "failed to export task trajectory")
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, snapshot)
 }
 
 func timelineLimit(r *http.Request) int {

--- a/internal/server/handler/agent_run_test.go
+++ b/internal/server/handler/agent_run_test.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/solo-ai/solo/internal/server/service"
+)
+
+func TestAgentRunHandlerTaskTrajectoryAuthorizationAndValidation(t *testing.T) {
+	pool := trajectoryHandlerTestPool(t)
+	ctx := context.Background()
+	ownerID := uuid.NewString()
+	otherID := uuid.NewString()
+	channelID := uuid.NewString()
+	taskID := uuid.NewString()
+	for _, user := range []struct {
+		id   string
+		name string
+	}{{ownerID, "Trajectory Owner"}, {otherID, "Trajectory Other"}} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO users (id, email, display_name, password_hash) VALUES ($1, $2, $3, 'test')`,
+			user.id, fmt.Sprintf("%s@example.test", user.id), user.name); err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channels (id, name, created_by) VALUES ($1, $2, $3)`,
+		channelID, "trajectory-handler-"+channelID[:8], ownerID); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role) VALUES ($1, 'user', $2, 'owner')`,
+		channelID, ownerID); err != nil {
+		t.Fatalf("create channel membership: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number)
+		 VALUES ($1, $2, $3, 'trajectory handler task', 'todo', 'normal', 1)`,
+		taskID, channelID, ownerID); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE id = $1`, taskID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = ANY($1::uuid[])`, []string{ownerID, otherID})
+	})
+
+	handler := NewAgentRunHandler(pool)
+	router := chi.NewRouter()
+	router.Get("/api/v1/tasks/{taskID}/trajectory", handler.TaskTrajectory)
+
+	tests := []struct {
+		name       string
+		path       string
+		userID     string
+		wantStatus int
+	}{
+		{name: "authentication required", path: "/api/v1/tasks/" + taskID + "/trajectory", wantStatus: http.StatusUnauthorized},
+		{name: "invalid task UUID", path: "/api/v1/tasks/not-a-uuid/trajectory", userID: ownerID, wantStatus: http.StatusBadRequest},
+		{name: "task not found", path: "/api/v1/tasks/" + uuid.NewString() + "/trajectory", userID: ownerID, wantStatus: http.StatusNotFound},
+		{name: "channel membership required", path: "/api/v1/tasks/" + taskID + "/trajectory", userID: otherID, wantStatus: http.StatusForbidden},
+		{name: "authorized snapshot", path: "/api/v1/tasks/" + taskID + "/trajectory", userID: ownerID, wantStatus: http.StatusOK},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, test.path, nil)
+			if test.userID != "" {
+				req.Header.Set("X-User-ID", test.userID)
+			}
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", response.Code, test.wantStatus, response.Body.String())
+			}
+			if response.Code == http.StatusOK {
+				var snapshot service.TaskTrajectorySnapshot
+				if err := json.NewDecoder(response.Body).Decode(&snapshot); err != nil {
+					t.Fatalf("decode snapshot: %v", err)
+				}
+				if snapshot.SchemaVersion != service.TaskTrajectorySchemaVersion || snapshot.RootTaskID != taskID {
+					t.Fatalf("snapshot = %+v", snapshot)
+				}
+			}
+		})
+	}
+}
+
+func trajectoryHandlerTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		dsn = "postgres://solo:solo-dev@localhost:5432/solo?sslmode=disable"
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Skipf("skipping DB test: %v", err)
+	}
+	if err := pool.Ping(context.Background()); err != nil {
+		pool.Close()
+		t.Skipf("skipping DB test: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -125,6 +125,7 @@ type MessageResponse struct {
 	TaskClaimerDeleted bool             `json:"task_claimer_deleted"`
 	HasUnreadThread    bool             `json:"has_unread_thread,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
+	OriginRunID        string           `json:"origin_run_id,omitempty"`
 }
 
 type MessageListResponse struct {
@@ -214,6 +215,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		`SELECT EXISTS(SELECT 1 FROM agents WHERE id = $1)`, userID,
 	).Scan(&isAgent)
 	senderType := "user"
+	originRunID := strings.TrimSpace(r.Header.Get(service.OriginRunHeader))
 	if isAgent {
 		senderType = "agent"
 		thinkingNodeID, err = reconcileThinkingNodeScope(r.Context(), h.pool, userID, channelID, thinkingNodeID)
@@ -221,6 +223,13 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeThinkingScopeError(w, err)
 			return
 		}
+		if err := service.NewAgentRunService(h.pool).ValidateActionOrigin(r.Context(), originRunID, r.Header.Get(service.OriginSignatureHeader), userID, channelID); err != nil {
+			writeError(w, http.StatusConflict, "origin run does not match active Agent runtime")
+			return
+		}
+	} else {
+		// Human callers cannot attribute their messages to Agent runtime rows.
+		originRunID = ""
 	}
 	if thinkingNodeID != "" && (req.ThreadID != "" || req.AsTask) {
 		writeError(w, http.StatusBadRequest, "thinking node messages cannot also be threads or tasks")
@@ -404,9 +413,9 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		nullableThreadID = threadID
 	}
 	_, err = h.pool.Exec(r.Context(),
-		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::uuid[], $9::uuid[], $10, $10)`,
-		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), now,
+		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, origin_run_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid[], $10::uuid[], $11, $11)`,
+		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), nullableUUIDString(originRunID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), now,
 	)
 	if err != nil {
 		slog.Error("failed to persist message", "error", err)
@@ -485,6 +494,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 				SenderName:    displayName,
 				Content:       content,
 				ContentType:   "text",
+				OriginRunID:   originRunID,
 				AttachmentIDs: attachmentIDs,
 				Attachments:   toWSAttachmentMeta(attachments),
 				CreatedAt:     now.UTC().Format(time.RFC3339),
@@ -558,6 +568,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ContentType:       "text",
 			ThreadID:          threadID,
 			ThinkingNodeID:    thinkingNodeID,
+			OriginRunID:       originRunID,
 			MentionedAgentIDs: mentionedAgentIDs,
 			AttachmentIDs:     attachmentIDs,
 			Attachments:       toWSAttachmentMeta(attachments),
@@ -610,7 +621,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	resp := MessageResponse{
 		ID:                messageID,
 		ChannelID:         channelID,
-		SenderType:        "user",
+		SenderType:        senderType,
 		SenderID:          userID,
 		SenderName:        displayName,
 		Content:           content,
@@ -619,6 +630,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs:     attachmentIDs,
 		Attachments:       attachments,
 		ThinkingNodeID:    thinkingNodeID,
+		OriginRunID:       originRunID,
 		CreatedAt:         now.Format(time.RFC3339),
 	}
 
@@ -735,8 +747,9 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		                   WHEN m.sender_type = 'system' THEN 'Solo'
 		                   ELSE COALESCE(u.display_name, a.name, m.sender_id::text)
 		                 END as sender_name,
-		                 COALESCE(a.is_active, false) AS sender_active,
-		                 COALESCE(m.thinking_node_id::text, '') AS thinking_node_id,
+	                 COALESCE(a.is_active, false) AS sender_active,
+	                 COALESCE(m.thinking_node_id::text, '') AS thinking_node_id,
+	                 COALESCE(m.origin_run_id::text, '') AS origin_run_id,
 	                 m.content, m.content_type, COALESCE(m.attachment_ids, '{}') as attachment_ids, m.created_at,
 		                 COALESCE(t.reply_count, 0) AS reply_count,
 		                 COALESCE(tasks.task_number, 0) AS task_number,
@@ -783,7 +796,7 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		var msg MessageResponse
 		var createdAt time.Time
 		err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.SenderType, &msg.SenderID,
-			&msg.SenderName, &msg.SenderActive, &msg.ThinkingNodeID, &msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt,
+			&msg.SenderName, &msg.SenderActive, &msg.ThinkingNodeID, &msg.OriginRunID, &msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt,
 			&msg.ReplyCount, &msg.TaskNumber, &msg.TaskStatus, &msg.TaskClaimerName, &msg.TaskClaimerDeleted, &msg.HasUnreadThread)
 		if err != nil {
 			slog.Error("failed to scan message row", "error", err)
@@ -1093,6 +1106,7 @@ func (h *MessageHandler) broadcastDMIfNeeded(channelID string, msg ws.MessageNew
 		AttachmentIDs: msg.AttachmentIDs,
 		Attachments:   msg.Attachments,
 		ThreadID:      msg.ThreadID,
+		OriginRunID:   msg.OriginRunID,
 		CreatedAt:     msg.CreatedAt,
 	}
 	h.hub.BroadcastToChannel(channelID, ws.Envelope(ws.EventDMMessageNew, dmPayload))

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -548,7 +548,11 @@ func (h *TaskHandler) Claim(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	task, err := h.svc.ClaimTask(r.Context(), channelID, t.ID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "claim")
+	if !ok {
+		return
+	}
+	task, err := h.svc.ClaimTask(actionCtx, channelID, t.ID, userID)
 	if err != nil {
 		switch {
 		case err == service.ErrTaskNotFound:
@@ -631,7 +635,11 @@ func (h *TaskHandler) Unclaim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.svc.UnclaimTask(r.Context(), channelID, t.ID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "unclaim")
+	if !ok {
+		return
+	}
+	task, err := h.svc.UnclaimTask(actionCtx, channelID, t.ID, userID)
 	if err != nil {
 		switch {
 		case err == service.ErrTaskNotFound:
@@ -688,11 +696,11 @@ func (h *TaskHandler) Unclaim(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *TaskHandler) Submit(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.SubmitTask)
+	h.lifecycleAction(w, r, "submit", h.svc.SubmitTask)
 }
 
 func (h *TaskHandler) Accept(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.AcceptTask)
+	h.lifecycleAction(w, r, "accept", h.svc.AcceptTask)
 }
 
 func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
@@ -714,7 +722,11 @@ func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	task, err := h.svc.RejectTask(r.Context(), channelID, taskID, userID, strings.TrimSpace(req.Reason))
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "reject")
+	if !ok {
+		return
+	}
+	task, err := h.svc.RejectTask(actionCtx, channelID, taskID, userID, strings.TrimSpace(req.Reason))
 	if err != nil {
 		h.writeTaskLifecycleError(w, err)
 		return
@@ -723,11 +735,11 @@ func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *TaskHandler) Close(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.CloseTask)
+	h.lifecycleAction(w, r, "close", h.svc.CloseTask)
 }
 
 func (h *TaskHandler) Reopen(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.ReopenTask)
+	h.lifecycleAction(w, r, "reopen", h.svc.ReopenTask)
 }
 
 func (h *TaskHandler) AcceptGlobal(w http.ResponseWriter, r *http.Request) {
@@ -765,6 +777,7 @@ func (h *TaskHandler) ReopenGlobal(w http.ResponseWriter, r *http.Request) {
 func (h *TaskHandler) lifecycleAction(
 	w http.ResponseWriter,
 	r *http.Request,
+	actionName string,
 	action func(context.Context, string, string, string) (*service.Task, error),
 ) {
 	userID, ok := requireUserID(r)
@@ -779,13 +792,31 @@ func (h *TaskHandler) lifecycleAction(
 		return
 	}
 
-	task, err := action(r.Context(), channelID, taskID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, actionName)
+	if !ok {
+		return
+	}
+	task, err := action(actionCtx, channelID, taskID, userID)
 	if err != nil {
 		h.writeTaskLifecycleError(w, err)
 		return
 	}
 
 	h.writeTaskUpdate(w, task)
+}
+
+func (h *TaskHandler) taskActionContext(w http.ResponseWriter, r *http.Request, actorID, channelID, action string) (context.Context, bool) {
+	runID := strings.TrimSpace(r.Header.Get(service.OriginRunHeader))
+	if runID == "" {
+		return r.Context(), true
+	}
+	if err := service.NewAgentRunService(h.pool).ValidateActionOrigin(r.Context(), runID, r.Header.Get(service.OriginSignatureHeader), actorID, channelID); err != nil {
+		writeError(w, http.StatusConflict, "origin run is not the active agent turn")
+		return nil, false
+	}
+	return service.WithTaskActionOrigin(r.Context(), service.TaskActionOrigin{
+		RunID: runID, ActorID: actorID, Action: action,
+	}), true
 }
 
 func (h *TaskHandler) lifecycleActionGlobal(
@@ -838,6 +869,8 @@ func (h *TaskHandler) writeTaskLifecycleError(w http.ResponseWriter, err error) 
 		writeError(w, http.StatusConflict, err.Error())
 	case err == service.ErrTaskReasonRequired:
 		writeError(w, http.StatusBadRequest, err.Error())
+	case err == service.ErrInvalidAgentRunOrigin:
+		writeError(w, http.StatusConflict, err.Error())
 	default:
 		slog.Error("failed task lifecycle action", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update task")

--- a/internal/server/handler/thread.go
+++ b/internal/server/handler/thread.go
@@ -64,6 +64,7 @@ type ThreadReplyResponse struct {
 	SenderActive  bool             `json:"sender_active"`
 	Content       string           `json:"content"`
 	ContentType   string           `json:"content_type"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
@@ -472,7 +473,8 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 	query := `SELECT m.id, m.channel_id, m.thread_id, m.sender_type, m.sender_id,
 	                 COALESCE(u.display_name, a.name, '') as sender_name,
 	                 COALESCE(a.is_active, false) AS sender_active,
-	                 m.content, m.content_type, COALESCE(m.attachment_ids, '{}') as attachment_ids,
+	                 m.content, m.content_type, COALESCE(m.origin_run_id::text, '') AS origin_run_id,
+	                 COALESCE(m.attachment_ids, '{}') as attachment_ids,
                  m.created_at
 	          FROM messages m
 	          LEFT JOIN users u ON m.sender_type = 'user' AND m.sender_id = u.id
@@ -506,7 +508,7 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 		err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.ThreadID,
 			&msg.SenderType, &msg.SenderID, &msg.SenderName,
 			&msg.SenderActive,
-			&msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt)
+			&msg.Content, &msg.ContentType, &msg.OriginRunID, &msg.AttachmentIDs, &createdAt)
 		if err != nil {
 			slog.Error("failed to scan thread message row", "error", err)
 			continue

--- a/internal/server/handler/thread_test.go
+++ b/internal/server/handler/thread_test.go
@@ -196,6 +196,7 @@ func TestThreadHandler_ResponseFormat(t *testing.T) {
 		SenderName:  "Test User",
 		Content:     "This is a thread reply!",
 		ContentType: "text",
+		OriginRunID: "run-1",
 		CreatedAt:   "2025-01-01T00:00:00Z",
 	}
 
@@ -217,6 +218,9 @@ func TestThreadHandler_ResponseFormat(t *testing.T) {
 	}
 	if decoded.Content != "This is a thread reply!" {
 		t.Errorf("expected content 'This is a thread reply!', got %s", decoded.Content)
+	}
+	if decoded.OriginRunID != "run-1" {
+		t.Errorf("expected origin_run_id run-1, got %s", decoded.OriginRunID)
 	}
 }
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -308,6 +308,7 @@ func NewRouter(pool *pgxpool.Pool, hub *ws.Hub, dm *service.DaemonManager, agent
 		r.Get("/api/v1/tasks/{taskID}", taskHandler.GetGlobal)
 		r.Get("/api/v1/tasks/{taskID}/runs", agentRunHandler.TaskRuns)
 		r.Get("/api/v1/tasks/{taskID}/agent-timeline", agentRunHandler.TaskTimeline)
+		r.Get("/api/v1/tasks/{taskID}/trajectory", agentRunHandler.TaskTrajectory)
 		r.Patch("/api/v1/tasks/{taskID}", taskHandler.UpdateGlobal)
 		r.Delete("/api/v1/tasks/{taskID}", taskHandler.DeleteGlobal)
 		r.Post("/api/v1/tasks/{taskID}/accept", taskHandler.AcceptGlobal)

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -649,6 +649,7 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 	}
 	if run != nil {
 		s.dm.AttachTaskRun(taskReq.TaskID, run.ID)
+		taskReq.RunID = run.ID
 	}
 	if run != nil && taskReq.OriginTaskID != "" {
 		if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: run.ID, TaskID: taskReq.OriginTaskID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
@@ -2350,6 +2351,7 @@ func (s *AgentService) getChannelOpenTasksSummary(ctx context.Context, channelID
 // daemonTaskRequest is the format for tasks sent from server to daemon.
 type daemonTaskRequest struct {
 	TaskID                string            `json:"task_id"`
+	RunID                 string            `json:"run_id,omitempty"`
 	AgentID               string            `json:"agent_id"`
 	ChannelID             string            `json:"channel_id"`
 	ThreadID              string            `json:"thread_id,omitempty"`

--- a/internal/server/service/agent_run.go
+++ b/internal/server/service/agent_run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/solo-ai/solo/internal/causal"
 	agentruntime "github.com/solo-ai/solo/pkg/agent"
 )
 
@@ -69,6 +70,12 @@ var nonPrimaryTaskRunStatuses = []string{
 }
 
 var ErrAmbiguousAgentRunScope = errors.New("multiple executing runs for one Agent and channel")
+var ErrInvalidAgentRunOrigin = errors.New("origin run does not match active Agent runtime")
+
+const (
+	OriginRunHeader       = causal.RunHeader
+	OriginSignatureHeader = causal.SignatureHeader
+)
 
 type AgentSession struct {
 	ID                string    `json:"id"`
@@ -448,6 +455,58 @@ func (s *AgentRunService) LinkTask(ctx context.Context, input LinkRunTaskInput) 
 		input.RunID, input.TaskID, input.Role, input.Confidence,
 	)
 	return err
+}
+
+// ValidateActionRun verifies daemon-owned turn context forwarded to a mutation.
+// Callers must never derive this value from "latest run" timestamps.
+func (s *AgentRunService) ValidateActionRun(ctx context.Context, runID, agentID, channelID string) error {
+	if runID == "" {
+		return nil
+	}
+	var valid bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM agent_runs
+			 WHERE id = $1 AND agent_id = $2 AND channel_id = $3
+			   AND finished_at IS NULL
+			   AND status = ANY($4)
+		)`,
+		runID,
+		agentID,
+		channelID,
+		[]string{
+			string(AgentRunStatusQueued),
+			string(AgentRunStatusThinking), string(AgentRunStatusRunning),
+			string(AgentRunStatusStreaming), string(AgentRunStatusWaitingInput),
+			string(AgentRunStatusWaitingApproval),
+		},
+	).Scan(&valid)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return ErrInvalidAgentRunOrigin
+	}
+	return nil
+}
+
+func (s *AgentRunService) ValidateActionOrigin(ctx context.Context, runID, signature, agentID, channelID string) error {
+	if runID == "" {
+		return nil
+	}
+	if !causal.Verify(causal.SharedSecret(), runID, agentID, channelID, signature) {
+		return ErrInvalidAgentRunOrigin
+	}
+	return s.ValidateActionRun(ctx, runID, agentID, channelID)
+}
+
+func safeRunTaskAction(action string) bool {
+	switch action {
+	case "claim", "unclaim", "submit", "accept", "reject", "close", "reopen":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *AgentRunService) FinishRun(ctx context.Context, input FinishRunInput) (*AgentRun, error) {

--- a/internal/server/service/task.go
+++ b/internal/server/service/task.go
@@ -82,6 +82,41 @@ var (
 	ErrTaskLifecyclePatch    = errors.New("task lifecycle status changes must use lifecycle endpoints")
 )
 
+type taskActionOriginKey struct{}
+
+type TaskActionOrigin struct {
+	RunID   string
+	ActorID string
+	Action  string
+}
+
+func WithTaskActionOrigin(ctx context.Context, origin TaskActionOrigin) context.Context {
+	if origin.RunID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, taskActionOriginKey{}, origin)
+}
+
+func recordTaskActionInTx(ctx context.Context, tx pgx.Tx, taskID string) error {
+	origin, ok := ctx.Value(taskActionOriginKey{}).(TaskActionOrigin)
+	if !ok || origin.RunID == "" {
+		return nil
+	}
+	if !safeRunTaskAction(origin.Action) || origin.ActorID == "" {
+		return ErrInvalidAgentRunOrigin
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_run_task_links (run_id, task_id, role, confidence)
+		VALUES ($1, $2, 'executor', 1)
+		ON CONFLICT (run_id, task_id) DO NOTHING`, origin.RunID, taskID); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO agent_run_task_actions (run_id, task_id, actor_id, action)
+		VALUES ($1, $2, $3, $4)`, origin.RunID, taskID, origin.ActorID, origin.Action)
+	return err
+}
+
 // Task represents a task in a channel.
 type Task struct {
 	ID               string     `json:"id"`
@@ -428,6 +463,9 @@ func (s *TaskService) ClaimTask(ctx context.Context, channelID, taskID, userID s
 	if err != nil {
 		return nil, fmt.Errorf("update claim: %w", err)
 	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record claim origin: %w", err)
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit: %w", err)
@@ -456,30 +494,40 @@ func (s *TaskService) UnclaimTask(ctx context.Context, channelID, taskID, userID
 	if err := s.requireChannelMember(ctx, channelID, userID); err != nil {
 		return nil, err
 	}
-
-	current, err := s.GetTask(ctx, channelID, taskID, userID)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	if current.ClaimerID == "" {
+	defer tx.Rollback(ctx)
+	var currentStatus, currentClaimerID string
+	if err := tx.QueryRow(ctx, `
+		SELECT status, COALESCE(claimer_id::text, '')
+		  FROM tasks WHERE id = $1 AND channel_id = $2 FOR UPDATE`, taskID, channelID,
+	).Scan(&currentStatus, &currentClaimerID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, err
+	}
+	if currentClaimerID != userID {
 		return nil, ErrTaskNotClaimer
 	}
-	if current.ClaimerID != userID {
-		return nil, ErrTaskNotClaimer
-	}
-
-	if TerminalStatuses[current.Status] {
+	if TerminalStatuses[currentStatus] {
 		return nil, ErrTaskInTerminalState
 	}
-
 	now := time.Now()
-	_, err = s.pool.Exec(ctx,
+	_, err = tx.Exec(ctx,
 		`UPDATE tasks SET claimer_id = NULL, status = $1, updated_at = $2
 		 WHERE id = $3 AND channel_id = $4`,
 		TaskStatusTodo, now, taskID, channelID,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record unclaim origin: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -541,6 +589,9 @@ func (s *TaskService) SubmitTask(ctx context.Context, channelID, taskID, userID 
 	if _, err := tx.Exec(ctx, `UPDATE tasks SET status = $1, updated_at = now() WHERE id = $2`, TaskStatusInReview, task.ID); err != nil {
 		return nil, err
 	}
+	if err := recordTaskActionInTx(ctx, tx, task.ID); err != nil {
+		return nil, fmt.Errorf("record submit origin: %w", err)
+	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
@@ -571,7 +622,7 @@ func (s *TaskService) AcceptTask(ctx context.Context, channelID, taskID, userID 
 	if task.Status != TaskStatusInReview {
 		return nil, ErrTaskNotReviewable
 	}
-	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusDone)
+	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusDone, TaskStatusInReview)
 	if err == nil && s.agentNotifier != nil {
 		if notifyErr := s.agentNotifier.NotifyAccepted(ctx, updated.ID, userID); notifyErr != nil {
 			slog.Warn("notify accepted failed", "task_id", updated.ID, "err", notifyErr)
@@ -595,7 +646,7 @@ func (s *TaskService) RejectTask(ctx context.Context, channelID, taskID, userID,
 	if task.Status != TaskStatusInReview {
 		return nil, ErrTaskNotReviewable
 	}
-	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusInProgress)
+	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusInProgress, TaskStatusInReview)
 	if err == nil && s.agentNotifier != nil {
 		if notifyErr := s.agentNotifier.NotifyRejected(ctx, updated.ID, userID, reason); notifyErr != nil {
 			slog.Warn("notify rejected failed", "task_id", updated.ID, "err", notifyErr)
@@ -619,7 +670,7 @@ func (s *TaskService) CloseTask(ctx context.Context, channelID, taskID, userID s
 	if task.Status == TaskStatusClosed {
 		return nil, ErrTaskInTerminalState
 	}
-	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusClosed)
+	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusClosed, TaskStatusTodo, TaskStatusInProgress, TaskStatusInReview, TaskStatusDone)
 	if err == nil && s.agentNotifier != nil {
 		if notifyErr := s.agentNotifier.NotifyClosed(ctx, updated.ID, userID); notifyErr != nil {
 			slog.Warn("notify closed failed", "task_id", updated.ID, "err", notifyErr)
@@ -646,7 +697,7 @@ func (s *TaskService) ReopenTask(ctx context.Context, channelID, taskID, userID 
 	if task.Status != TaskStatusClosed && task.Status != TaskStatusDone {
 		return nil, ErrTaskInvalidTransition
 	}
-	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusTodo)
+	updated, err := s.setTaskStatus(ctx, channelID, task.ID, userID, TaskStatusTodo, TaskStatusClosed, TaskStatusDone)
 	if err == nil && s.agentNotifier != nil {
 		if notifyErr := s.agentNotifier.NotifyReopened(ctx, updated.ID, userID); notifyErr != nil {
 			slog.Warn("notify reopened failed", "task_id", updated.ID, "err", notifyErr)
@@ -655,11 +706,33 @@ func (s *TaskService) ReopenTask(ctx context.Context, channelID, taskID, userID 
 	return updated, err
 }
 
-func (s *TaskService) setTaskStatus(ctx context.Context, channelID, taskID, userID, status string) (*Task, error) {
+func (s *TaskService) setTaskStatus(ctx context.Context, channelID, taskID, userID, status string, allowedFrom ...string) (*Task, error) {
 	if err := s.requireChannelMember(ctx, channelID, userID); err != nil {
 		return nil, err
 	}
-	tag, err := s.pool.Exec(ctx,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	var currentStatus string
+	if err := tx.QueryRow(ctx, `SELECT status FROM tasks WHERE id = $1 AND channel_id = $2 FOR UPDATE`, taskID, channelID).Scan(&currentStatus); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, err
+	}
+	allowed := false
+	for _, candidate := range allowedFrom {
+		if currentStatus == candidate {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return nil, ErrTaskInvalidTransition
+	}
+	tag, err := tx.Exec(ctx,
 		`UPDATE tasks SET status = $1, updated_at = now() WHERE id = $2 AND channel_id = $3`,
 		status, taskID, channelID,
 	)
@@ -668,6 +741,12 @@ func (s *TaskService) setTaskStatus(ctx context.Context, channelID, taskID, user
 	}
 	if tag.RowsAffected() == 0 {
 		return nil, ErrTaskNotFound
+	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record task action origin: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
 	}
 	return s.GetTask(ctx, channelID, taskID, userID)
 }

--- a/internal/server/service/task_causal_evidence_test.go
+++ b/internal/server/service/task_causal_evidence_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestTaskMutationRecordsCausalEvidenceAtomically(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		VALUES ($1, 'user', $2, 'owner'), ($1, 'agent', $3, 'member')`, channelID, ownerID, agentID); err != nil {
+		t.Fatalf("add members: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	taskSvc := NewTaskService(pool)
+	task, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "causal task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	run, err := NewAgentRunService(pool).StartRun(ctx, StartRunInput{
+		AgentID: agentID, TriggerType: AgentRunTriggerTask, ChannelID: channelID,
+		Status: AgentRunStatusRunning, ActivityText: "working",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	claimCtx := WithTaskActionOrigin(ctx, TaskActionOrigin{RunID: run.ID, ActorID: agentID, Action: "claim"})
+	claimed, err := taskSvc.ClaimTask(claimCtx, channelID, task.ID, agentID)
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if claimed.Status != TaskStatusInProgress || claimed.ClaimerID != agentID {
+		t.Fatalf("claimed task = %+v", claimed)
+	}
+	var actionCount, linkCount int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_actions WHERE run_id = $1 AND task_id = $2 AND action = 'claim'`, run.ID, task.ID).Scan(&actionCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_links WHERE run_id = $1 AND task_id = $2 AND role = 'executor'`, run.ID, task.ID).Scan(&linkCount); err != nil {
+		t.Fatal(err)
+	}
+	if actionCount != 1 || linkCount != 1 {
+		t.Fatalf("action_count=%d link_count=%d, want 1/1", actionCount, linkCount)
+	}
+}
+
+func TestTaskMutationRollsBackWhenCausalEvidenceCannotBeStored(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		VALUES ($1, 'user', $2, 'owner'), ($1, 'agent', $3, 'member')`, channelID, ownerID, agentID); err != nil {
+		t.Fatalf("add members: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	taskSvc := NewTaskService(pool)
+	task, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "rollback task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	badRunID := uuid.NewString()
+	claimCtx := WithTaskActionOrigin(ctx, TaskActionOrigin{RunID: badRunID, ActorID: agentID, Action: "claim"})
+	if _, err := taskSvc.ClaimTask(claimCtx, channelID, task.ID, agentID); err == nil {
+		t.Fatal("claim unexpectedly succeeded with missing origin run")
+	}
+
+	unchanged, err := taskSvc.GetTask(ctx, channelID, task.ID, ownerID)
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if unchanged.Status != TaskStatusTodo || unchanged.ClaimerID != "" {
+		t.Fatalf("task mutation was not rolled back: %+v", unchanged)
+	}
+	var actionCount, linkCount int
+	_ = pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_actions WHERE task_id = $1`, task.ID).Scan(&actionCount)
+	_ = pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_links WHERE task_id = $1`, task.ID).Scan(&linkCount)
+	if actionCount != 0 || linkCount != 0 {
+		t.Fatalf("partial evidence remained: action_count=%d link_count=%d", actionCount, linkCount)
+	}
+}

--- a/internal/server/service/task_trajectory.go
+++ b/internal/server/service/task_trajectory.go
@@ -1,0 +1,719 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	TaskTrajectorySchemaVersion = "solo.task_trajectory.v1"
+	maxTrajectoryTasks          = 500
+	maxTrajectoryRunLinkRows    = 2000
+	maxTrajectoryEvents         = 20000
+	maxTrajectoryArtifacts      = 1000
+	maxTrajectoryShortTextRunes = 500
+	maxTrajectoryBodyTextRunes  = 4000
+)
+
+type TaskTrajectoryCoverage struct {
+	Completeness           string `json:"completeness"`
+	TaskTree               string `json:"task_tree"`
+	RunMetadata            string `json:"run_metadata"`
+	RunTaskLinks           string `json:"run_task_links"`
+	RunEvents              string `json:"run_events"`
+	TranscriptAvailability string `json:"transcript_availability"`
+	TaskArtifacts          string `json:"task_artifacts"`
+	DispatchDecisions      string `json:"dispatch_decisions"`
+	ParentRunLinks         string `json:"parent_run_links"`
+	OutboundMessageRuns    string `json:"outbound_message_runs"`
+	TaskLifecycleEvents    string `json:"task_lifecycle_events"`
+	RelationshipSnapshots  string `json:"relationship_snapshots"`
+}
+
+type TaskTrajectoryWarning struct {
+	Code    string `json:"code"`
+	RunID   string `json:"run_id,omitempty"`
+	Message string `json:"message"`
+}
+
+type TaskTrajectoryTask struct {
+	ID               string     `json:"id"`
+	TaskNumber       int        `json:"task_number"`
+	ChannelID        string     `json:"channel_id"`
+	CreatorID        string     `json:"creator_id"`
+	CreatorName      string     `json:"creator_name,omitempty"`
+	Title            string     `json:"title"`
+	Description      string     `json:"description,omitempty"`
+	Status           string     `json:"status"`
+	ClaimerID        string     `json:"claimer_id,omitempty"`
+	ClaimerName      string     `json:"claimer_name,omitempty"`
+	Priority         string     `json:"priority"`
+	DueDate          *time.Time `json:"due_date,omitempty"`
+	MessageID        string     `json:"message_id,omitempty"`
+	ParentTaskID     string     `json:"parent_task_id,omitempty"`
+	Depth            int        `json:"depth"`
+	ContentTruncated bool       `json:"content_truncated,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+type TaskTrajectoryLink struct {
+	TaskID            string    `json:"task_id"`
+	Role              string    `json:"role"`
+	Confidence        float64   `json:"confidence"`
+	MetadataTruncated bool      `json:"metadata_truncated,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
+}
+
+type TaskTrajectoryTranscript struct {
+	Status       string    `json:"status"`
+	Association  string    `json:"association"`
+	WindowStart  time.Time `json:"window_start"`
+	WindowEnd    time.Time `json:"window_end"`
+	TextExported bool      `json:"text_exported"`
+}
+
+type TaskTrajectoryEvent struct {
+	ID             string         `json:"id"`
+	RunID          string         `json:"run_id"`
+	Seq            int            `json:"seq"`
+	Type           string         `json:"type"`
+	ToolName       string         `json:"tool_name,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+	ContentOmitted bool           `json:"content_omitted,omitempty"`
+	CreatedAt      time.Time      `json:"created_at"`
+}
+
+type TaskTrajectoryArtifact struct {
+	ID               string    `json:"id"`
+	TaskID           string    `json:"task_id"`
+	Kind             string    `json:"kind"`
+	Title            string    `json:"title"`
+	Summary          string    `json:"summary,omitempty"`
+	ContentTruncated bool      `json:"content_truncated,omitempty"`
+	URL              string    `json:"url"`
+	CreatedBy        string    `json:"created_by"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type TaskTrajectoryRun struct {
+	ID                string                   `json:"id"`
+	AgentID           string                   `json:"agent_id"`
+	AgentName         string                   `json:"agent_name,omitempty"`
+	SessionID         string                   `json:"session_id,omitempty"`
+	TriggerType       string                   `json:"trigger_type"`
+	TriggerMessageID  string                   `json:"trigger_message_id,omitempty"`
+	ChannelID         string                   `json:"channel_id,omitempty"`
+	ThreadID          string                   `json:"thread_id,omitempty"`
+	ThinkingNodeID    string                   `json:"thinking_node_id,omitempty"`
+	Status            AgentRunStatus           `json:"status"`
+	ToolName          string                   `json:"tool_name,omitempty"`
+	Source            string                   `json:"source,omitempty"`
+	Usage             map[string]any           `json:"usage,omitempty"`
+	MetadataTruncated bool                     `json:"metadata_truncated,omitempty"`
+	StartedAt         time.Time                `json:"started_at"`
+	UpdatedAt         time.Time                `json:"updated_at"`
+	FinishedAt        *time.Time               `json:"finished_at,omitempty"`
+	TaskLinks         []TaskTrajectoryLink     `json:"task_links"`
+	Events            []TaskTrajectoryEvent    `json:"events"`
+	Transcript        TaskTrajectoryTranscript `json:"transcript"`
+}
+
+type TaskTrajectorySnapshot struct {
+	SchemaVersion      string                   `json:"schema_version"`
+	DatabaseCapturedAt time.Time                `json:"database_captured_at"`
+	RootTaskID         string                   `json:"root_task_id"`
+	Coverage           TaskTrajectoryCoverage   `json:"coverage"`
+	Tasks              []TaskTrajectoryTask     `json:"tasks"`
+	Runs               []TaskTrajectoryRun      `json:"runs"`
+	Artifacts          []TaskTrajectoryArtifact `json:"artifacts"`
+	Warnings           []TaskTrajectoryWarning  `json:"warnings"`
+}
+
+type TaskTrajectoryService struct {
+	pool *pgxpool.Pool
+}
+
+func NewTaskTrajectoryService(pool *pgxpool.Pool) *TaskTrajectoryService {
+	return &TaskTrajectoryService{pool: pool}
+}
+
+type taskTrajectoryRunSource struct {
+	referenceRecorded bool
+}
+
+type taskTrajectoryTruncation struct {
+	tasks     bool
+	runLinks  bool
+	events    bool
+	artifacts bool
+}
+
+func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID string) (*TaskTrajectorySnapshot, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel:   pgx.RepeatableRead,
+		AccessMode: pgx.ReadOnly,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	var capturedAt time.Time
+	if err := tx.QueryRow(ctx, `SELECT transaction_timestamp()`).Scan(&capturedAt); err != nil {
+		return nil, err
+	}
+	rootChannelID, err := authorizeTaskTrajectory(ctx, tx, taskID, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	tasks, tasksTruncated, err := loadTaskTrajectoryTasks(ctx, tx, taskID, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	taskIDs := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		taskIDs = append(taskIDs, task.ID)
+	}
+	runs, sources, runLinksTruncated, err := loadTaskTrajectoryRuns(ctx, tx, taskIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	eventsTruncated, err := loadTaskTrajectoryEvents(ctx, tx, runs)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, artifactsTruncated, err := loadTaskTrajectoryArtifacts(ctx, tx, taskIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	warnings := []TaskTrajectoryWarning{}
+	for i := range runs {
+		runWarnings := attachTaskTrajectoryTranscriptReference(&runs[i], sources[runs[i].ID], capturedAt)
+		warnings = append(warnings, runWarnings...)
+	}
+	truncation := taskTrajectoryTruncation{
+		tasks:     tasksTruncated,
+		runLinks:  runLinksTruncated,
+		events:    eventsTruncated,
+		artifacts: artifactsTruncated,
+	}
+	warnings = append(warnings, trajectoryTruncationWarnings(truncation)...)
+	completeness := "partial_stored_records"
+	if tasksTruncated || runLinksTruncated || eventsTruncated || artifactsTruncated {
+		completeness = "partial_truncated_stored_records"
+	}
+
+	return &TaskTrajectorySnapshot{
+		SchemaVersion:      TaskTrajectorySchemaVersion,
+		DatabaseCapturedAt: capturedAt,
+		RootTaskID:         taskID,
+		Coverage: TaskTrajectoryCoverage{
+			Completeness:           completeness,
+			TaskTree:               "stored_records",
+			RunMetadata:            "stored_linked_selected_metadata",
+			RunTaskLinks:           "stored_records",
+			RunEvents:              "stored_metadata_only",
+			TranscriptAvailability: "reference_recorded_only_unverified_time_window",
+			TaskArtifacts:          "stored_selected_metadata",
+			DispatchDecisions:      "unavailable",
+			ParentRunLinks:         "unavailable",
+			OutboundMessageRuns:    "unavailable",
+			TaskLifecycleEvents:    "unavailable",
+			RelationshipSnapshots:  "unavailable",
+		},
+		Tasks:     tasks,
+		Runs:      runs,
+		Artifacts: artifacts,
+		Warnings:  warnings,
+	}, nil
+}
+
+func authorizeTaskTrajectory(ctx context.Context, tx pgx.Tx, taskID, userID string) (string, error) {
+	var channelID string
+	if err := tx.QueryRow(ctx, `SELECT channel_id::text FROM tasks WHERE id = $1`, taskID).Scan(&channelID); err != nil {
+		if err == pgx.ErrNoRows {
+			return "", ErrTaskNotFound
+		}
+		return "", err
+	}
+	var allowed bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM channels c
+			  JOIN channel_members cm ON cm.channel_id = c.id
+			 WHERE c.id = $1 AND c.is_archived = false
+			   AND cm.member_type = 'user' AND cm.member_id = $2
+		)`, channelID, userID).Scan(&allowed); err != nil {
+		return "", err
+	}
+	if !allowed {
+		return "", ErrTaskNotChannelMember
+	}
+	return channelID, nil
+}
+
+func loadTaskTrajectoryTasks(ctx context.Context, tx pgx.Tx, rootTaskID, rootChannelID string) ([]TaskTrajectoryTask, bool, error) {
+	rows, err := tx.Query(ctx, `
+		WITH RECURSIVE task_tree(id, depth) AS (
+			SELECT t.id, 0 FROM tasks t WHERE t.id = $1
+			UNION ALL
+			SELECT child.id, parent.depth + 1
+			  FROM tasks child
+			  JOIN task_tree parent ON child.parent_task_id = parent.id
+			 WHERE child.channel_id = $2
+		), bounded_tree AS MATERIALIZED (
+			SELECT id, depth FROM task_tree LIMIT $3
+		)
+		SELECT t.id::text, COALESCE(t.task_number, 0), COALESCE(t.channel_id::text, ''),
+		       t.creator_id::text, COALESCE(u_creator.display_name, a_creator.name, ''),
+		       left(t.title, $4), char_length(t.title) > $4,
+		       left(COALESCE(t.description, ''), $5), char_length(COALESCE(t.description, '')) > $5,
+		       left(t.status, $4), char_length(t.status) > $4,
+		       COALESCE(t.claimer_id::text, ''), COALESCE(u_claimer.display_name, a_claimer.name, ''),
+		       left(COALESCE(t.priority, ''), $4), char_length(COALESCE(t.priority, '')) > $4,
+		       t.due_date, COALESCE(t.message_id::text, ''),
+		       COALESCE(t.parent_task_id::text, ''), tree.depth, t.created_at, t.updated_at
+		  FROM bounded_tree tree
+		  JOIN tasks t ON t.id = tree.id
+		  LEFT JOIN users u_creator ON t.creator_id = u_creator.id
+		  LEFT JOIN agents a_creator ON t.creator_id = a_creator.id
+		  LEFT JOIN users u_claimer ON t.claimer_id = u_claimer.id
+		  LEFT JOIN agents a_claimer ON t.claimer_id = a_claimer.id
+		 ORDER BY tree.depth ASC, t.created_at ASC, t.id ASC`,
+		rootTaskID, rootChannelID, maxTrajectoryTasks+1, maxTrajectoryShortTextRunes, maxTrajectoryBodyTextRunes)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+
+	tasks := []TaskTrajectoryTask{}
+	for rows.Next() {
+		var task TaskTrajectoryTask
+		var dueDate sql.NullTime
+		var titleTruncated bool
+		var descriptionTruncated bool
+		var statusTruncated bool
+		var priorityTruncated bool
+		if err := rows.Scan(
+			&task.ID, &task.TaskNumber, &task.ChannelID, &task.CreatorID, &task.CreatorName,
+			&task.Title, &titleTruncated, &task.Description, &descriptionTruncated,
+			&task.Status, &statusTruncated, &task.ClaimerID, &task.ClaimerName,
+			&task.Priority, &priorityTruncated, &dueDate, &task.MessageID, &task.ParentTaskID, &task.Depth,
+			&task.CreatedAt, &task.UpdatedAt,
+		); err != nil {
+			return nil, false, err
+		}
+		if dueDate.Valid {
+			task.DueDate = &dueDate.Time
+		}
+		task.ContentTruncated = titleTruncated || descriptionTruncated || statusTruncated || priorityTruncated
+		if !safeTaskTrajectoryIdentifier(task.Status, 128) {
+			task.Status = "unknown"
+			task.ContentTruncated = true
+		}
+		if task.Priority != "" && !safeTaskTrajectoryIdentifier(task.Priority, 128) {
+			task.Priority = "unknown"
+			task.ContentTruncated = true
+		}
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(tasks) > maxTrajectoryTasks
+	if truncated {
+		tasks = tasks[:maxTrajectoryTasks]
+	}
+	return tasks, truncated, nil
+}
+
+func loadTaskTrajectoryRuns(ctx context.Context, tx pgx.Tx, taskIDs []string, rootChannelID string) ([]TaskTrajectoryRun, map[string]taskTrajectoryRunSource, bool, error) {
+	if len(taskIDs) == 0 {
+		return []TaskTrajectoryRun{}, map[string]taskTrajectoryRunSource{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_links AS MATERIALIZED (
+			SELECT l.run_id, l.task_id, l.role, l.confidence, l.created_at
+			  FROM agent_run_task_links l
+			  JOIN tasks linked_task ON linked_task.id = l.task_id
+			  JOIN agent_runs linked_run ON linked_run.id = l.run_id
+			 WHERE l.task_id = ANY($1::uuid[]) AND linked_task.channel_id = $2
+			   AND (linked_run.channel_id = $2 OR linked_run.channel_id IS NULL)
+			 LIMIT $3
+		)
+		SELECT r.id::text, r.agent_id::text,
+		       left(COALESCE(a.name, ''), $4), char_length(COALESCE(a.name, '')) > $4,
+		       COALESCE(r.session_id::text, ''),
+		       left(r.trigger_type, $4), char_length(r.trigger_type) > $4,
+		       COALESCE(r.trigger_message_id::text, ''), COALESCE(r.channel_id::text, ''),
+		       COALESCE(r.thread_id::text, ''), COALESCE(r.thinking_node_id::text, ''),
+		       left(r.status, $4), char_length(r.status) > $4,
+		       left(COALESCE(r.tool_name, ''), $4), char_length(COALESCE(r.tool_name, '')) > $4,
+		       left(COALESCE(r.source, ''), $4), char_length(COALESCE(r.source, '')) > $4,
+		       CASE WHEN COALESCE(r.usage_json->>'input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'input_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'output_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'output_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'cache_creation_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'cache_creation_input_tokens')::bigint END,
+		       CASE WHEN COALESCE(r.usage_json->>'cache_read_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (r.usage_json->>'cache_read_input_tokens')::bigint END,
+		       r.started_at, r.updated_at, r.finished_at,
+		       l.task_id::text, left(l.role, $4), char_length(l.role) > $4, l.confidence, l.created_at,
+		       (COALESCE(r.transcript_path, sess.transcript_path, '') <> '' OR COALESCE(sess.external_session_id, '') <> '')
+		  FROM bounded_links l
+		  JOIN agent_runs r ON r.id = l.run_id
+		  LEFT JOIN agents a ON a.id = r.agent_id
+		  LEFT JOIN agent_sessions sess ON sess.id = r.session_id
+		 ORDER BY r.started_at ASC, r.id ASC, l.created_at ASC, l.task_id ASC
+		`, taskIDs, rootChannelID, maxTrajectoryRunLinkRows+1, maxTrajectoryShortTextRunes)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	defer rows.Close()
+
+	runs := []TaskTrajectoryRun{}
+	indexByID := map[string]int{}
+	sources := map[string]taskTrajectoryRunSource{}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryRunLinkRows {
+			break
+		}
+		var run TaskTrajectoryRun
+		var link TaskTrajectoryLink
+		var status string
+		var agentNameTruncated bool
+		var triggerTypeTruncated bool
+		var statusTruncated bool
+		var toolNameTruncated bool
+		var sourceTruncated bool
+		var roleTruncated bool
+		var finished sql.NullTime
+		var inputTokens sql.NullInt64
+		var outputTokens sql.NullInt64
+		var cacheCreationTokens sql.NullInt64
+		var cacheReadTokens sql.NullInt64
+		var source taskTrajectoryRunSource
+		if err := rows.Scan(
+			&run.ID, &run.AgentID, &run.AgentName, &agentNameTruncated, &run.SessionID,
+			&run.TriggerType, &triggerTypeTruncated,
+			&run.TriggerMessageID, &run.ChannelID, &run.ThreadID, &run.ThinkingNodeID,
+			&status, &statusTruncated, &run.ToolName, &toolNameTruncated, &run.Source, &sourceTruncated,
+			&inputTokens, &outputTokens, &cacheCreationTokens, &cacheReadTokens,
+			&run.StartedAt, &run.UpdatedAt, &finished,
+			&link.TaskID, &link.Role, &roleTruncated, &link.Confidence, &link.CreatedAt,
+			&source.referenceRecorded,
+		); err != nil {
+			return nil, nil, false, err
+		}
+		run.Status = AgentRunStatus(status)
+		run.MetadataTruncated = agentNameTruncated || triggerTypeTruncated || statusTruncated || toolNameTruncated || sourceTruncated
+		link.MetadataTruncated = roleTruncated
+		if !safeTaskTrajectoryIdentifier(run.TriggerType, 128) {
+			run.TriggerType = "unknown"
+			run.MetadataTruncated = true
+		}
+		if !safeTaskTrajectoryIdentifier(string(run.Status), 128) {
+			run.Status = AgentRunStatus("unknown")
+			run.MetadataTruncated = true
+		}
+		if run.ToolName != "" && !safeTaskTrajectoryIdentifier(run.ToolName, 128) {
+			run.ToolName = ""
+			run.MetadataTruncated = true
+		}
+		if run.Source != "" && !safeTaskTrajectoryIdentifier(run.Source, 128) {
+			run.Source = ""
+			run.MetadataTruncated = true
+		}
+		if !safeTaskTrajectoryIdentifier(link.Role, 128) {
+			link.Role = "unknown"
+			link.MetadataTruncated = true
+		}
+		run.Usage = taskTrajectoryUsageFromColumns(inputTokens, outputTokens, cacheCreationTokens, cacheReadTokens)
+		if finished.Valid {
+			run.FinishedAt = &finished.Time
+		}
+		if idx, ok := indexByID[run.ID]; ok {
+			runs[idx].TaskLinks = append(runs[idx].TaskLinks, link)
+			continue
+		}
+		run.TaskLinks = []TaskTrajectoryLink{link}
+		run.Events = []TaskTrajectoryEvent{}
+		indexByID[run.ID] = len(runs)
+		runs = append(runs, run)
+		sources[run.ID] = source
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, false, err
+	}
+	return runs, sources, rowCount > maxTrajectoryRunLinkRows, nil
+}
+
+func loadTaskTrajectoryEvents(ctx context.Context, tx pgx.Tx, runs []TaskTrajectoryRun) (bool, error) {
+	if len(runs) == 0 {
+		return false, nil
+	}
+	runIDs := make([]string, 0, len(runs))
+	indexByID := make(map[string]int, len(runs))
+	for i := range runs {
+		runIDs = append(runIDs, runs[i].ID)
+		indexByID[runs[i].ID] = i
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_events AS MATERIALIZED (
+			SELECT id FROM agent_run_events WHERE run_id = ANY($1::uuid[]) LIMIT $2
+		)
+		SELECT e.id::text, e.run_id::text, e.seq,
+		       left(e.type, $3), char_length(e.type) > $3,
+		       left(COALESCE(e.tool_name, ''), $3), char_length(COALESCE(e.tool_name, '')) > $3,
+		       jsonb_strip_nulls(jsonb_build_object(
+		         'agent_id', left(e.payload->>'agent_id', 128),
+		         'task_id', left(e.payload->>'task_id', 128),
+		         'call_id', left(e.payload->>'call_id', 128),
+		         'role', left(e.payload->>'role', 128),
+		         'status', left(e.payload->>'status', 128),
+		         'is_error', CASE WHEN jsonb_typeof(e.payload->'is_error') = 'boolean' THEN (e.payload->>'is_error')::boolean END,
+		         'exit_code', CASE WHEN COALESCE(e.payload->>'exit_code', '') ~ '^-?[0-9]{1,18}$' THEN (e.payload->>'exit_code')::bigint END,
+		         'duration_ms', CASE WHEN COALESCE(e.payload->>'duration_ms', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'duration_ms')::bigint END,
+		         'input_tokens', CASE WHEN COALESCE(e.payload->>'input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'input_tokens')::bigint END,
+		         'output_tokens', CASE WHEN COALESCE(e.payload->>'output_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'output_tokens')::bigint END,
+		         'cache_creation_input_tokens', CASE WHEN COALESCE(e.payload->>'cache_creation_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'cache_creation_input_tokens')::bigint END,
+		         'cache_read_input_tokens', CASE WHEN COALESCE(e.payload->>'cache_read_input_tokens', '') ~ '^[0-9]{1,18}$' THEN (e.payload->>'cache_read_input_tokens')::bigint END
+		       )),
+		       (e.message <> '' OR e.payload <> '{}'::jsonb), e.created_at
+		  FROM bounded_events bounded
+		  JOIN agent_run_events e ON e.id = bounded.id
+		  JOIN agent_runs r ON r.id = e.run_id
+		 ORDER BY r.started_at ASC, e.run_id ASC, e.seq ASC
+		`, runIDs, maxTrajectoryEvents+1, maxTrajectoryShortTextRunes)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryEvents {
+			break
+		}
+		var event TaskTrajectoryEvent
+		var eventTypeTruncated bool
+		var toolNameTruncated bool
+		var metadataJSON json.RawMessage
+		var sourceContentPresent bool
+		if err := rows.Scan(
+			&event.ID, &event.RunID, &event.Seq, &event.Type, &eventTypeTruncated,
+			&event.ToolName, &toolNameTruncated, &metadataJSON, &sourceContentPresent, &event.CreatedAt,
+		); err != nil {
+			return false, err
+		}
+		if idx, ok := indexByID[event.RunID]; ok {
+			metadata, payloadOmitted := taskTrajectoryEventMetadata(metadataJSON)
+			event.Metadata = metadata
+			event.ContentOmitted = sourceContentPresent || payloadOmitted || eventTypeTruncated || toolNameTruncated
+			if !safeTaskTrajectoryIdentifier(event.Type, 128) {
+				event.Type = "unknown"
+				event.ContentOmitted = true
+			}
+			if event.ToolName != "" && !safeTaskTrajectoryIdentifier(event.ToolName, 128) {
+				event.ToolName = ""
+				event.ContentOmitted = true
+			}
+			runs[idx].Events = append(runs[idx].Events, event)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return rowCount > maxTrajectoryEvents, nil
+}
+
+func taskTrajectoryEventMetadata(payload json.RawMessage) (map[string]any, bool) {
+	var values map[string]any
+	if len(payload) == 0 || json.Unmarshal(payload, &values) != nil || len(values) == 0 {
+		return nil, len(payload) > 0 && string(payload) != "{}"
+	}
+	allowed := map[string]bool{
+		"agent_id": true, "task_id": true, "call_id": true, "role": true,
+		"status": true, "is_error": true, "exit_code": true, "duration_ms": true,
+		"input_tokens": true, "output_tokens": true, "cache_creation_input_tokens": true,
+		"cache_read_input_tokens": true,
+	}
+	metadata := map[string]any{}
+	omitted := false
+	for key, value := range values {
+		if !allowed[key] || !safeTaskTrajectoryEventMetadataValue(key, value) {
+			omitted = true
+			continue
+		}
+		metadata[key] = value
+	}
+	if len(metadata) == 0 {
+		metadata = nil
+	}
+	return metadata, omitted
+}
+
+func safeTaskTrajectoryEventMetadataValue(key string, value any) bool {
+	switch typed := value.(type) {
+	case bool:
+		return key == "is_error"
+	case float64:
+		return true
+	case string:
+		switch key {
+		case "agent_id", "task_id":
+			_, err := uuid.Parse(typed)
+			return err == nil
+		case "call_id", "role", "status":
+			return safeTaskTrajectoryIdentifier(typed, 128)
+		}
+	}
+	return false
+}
+
+func safeTaskTrajectoryIdentifier(value string, maxRunes int) bool {
+	runes := []rune(value)
+	if len(runes) == 0 || len(runes) > maxRunes {
+		return false
+	}
+	for _, r := range runes {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == ':' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func taskTrajectoryUsageFromColumns(input, output, cacheCreation, cacheRead sql.NullInt64) map[string]any {
+	metadata := map[string]any{}
+	for key, value := range map[string]sql.NullInt64{
+		"input_tokens": input, "output_tokens": output,
+		"cache_creation_input_tokens": cacheCreation, "cache_read_input_tokens": cacheRead,
+	} {
+		if value.Valid {
+			metadata[key] = value.Int64
+		}
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return metadata
+}
+
+func loadTaskTrajectoryArtifacts(ctx context.Context, tx pgx.Tx, taskIDs []string, rootChannelID string) ([]TaskTrajectoryArtifact, bool, error) {
+	if len(taskIDs) == 0 {
+		return []TaskTrajectoryArtifact{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		WITH bounded_artifacts AS MATERIALIZED (
+			SELECT id FROM artifacts
+			 WHERE task_id = ANY($1::uuid[]) AND channel_id = $2
+			 LIMIT $3
+		)
+		SELECT artifact.id::text, artifact.task_id::text,
+		       left(artifact.kind, $4), char_length(artifact.kind) > $4,
+		       left(artifact.title, $4), char_length(artifact.title) > $4,
+		       left(COALESCE(artifact.summary, ''), $5), char_length(COALESCE(artifact.summary, '')) > $5,
+		       artifact.created_by::text, artifact.created_at, artifact.updated_at
+		  FROM bounded_artifacts bounded
+		  JOIN artifacts artifact ON artifact.id = bounded.id
+		 ORDER BY artifact.created_at ASC, artifact.id ASC`,
+		taskIDs, rootChannelID, maxTrajectoryArtifacts+1, maxTrajectoryShortTextRunes, maxTrajectoryBodyTextRunes)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	artifacts := []TaskTrajectoryArtifact{}
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		if rowCount > maxTrajectoryArtifacts {
+			break
+		}
+		var artifact TaskTrajectoryArtifact
+		var kindTruncated bool
+		var titleTruncated bool
+		var summaryTruncated bool
+		if err := rows.Scan(
+			&artifact.ID, &artifact.TaskID, &artifact.Kind, &kindTruncated,
+			&artifact.Title, &titleTruncated, &artifact.Summary, &summaryTruncated,
+			&artifact.CreatedBy, &artifact.CreatedAt, &artifact.UpdatedAt,
+		); err != nil {
+			return nil, false, err
+		}
+		artifact.URL = "/api/v1/artifacts/" + artifact.ID
+		artifact.ContentTruncated = kindTruncated || titleTruncated || summaryTruncated
+		if !safeTaskTrajectoryIdentifier(artifact.Kind, 128) {
+			artifact.Kind = "unknown"
+			artifact.ContentTruncated = true
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	return artifacts, rowCount > maxTrajectoryArtifacts, nil
+}
+
+func trajectoryTruncationWarnings(truncation taskTrajectoryTruncation) []TaskTrajectoryWarning {
+	warnings := []TaskTrajectoryWarning{}
+	if truncation.tasks {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "task_limit_reached", Message: fmt.Sprintf("task tree exceeded the %d-task export limit", maxTrajectoryTasks)})
+	}
+	if truncation.runLinks {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "run_link_limit_reached", Message: fmt.Sprintf("run-to-task links exceeded the %d-row export limit; a boundary run may have partial links and some runs may be omitted", maxTrajectoryRunLinkRows)})
+	}
+	if truncation.events {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "event_limit_reached", Message: fmt.Sprintf("run events exceeded the %d-event export limit; a boundary run may have partial events and some events may be omitted", maxTrajectoryEvents)})
+	}
+	if truncation.artifacts {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "artifact_limit_reached", Message: fmt.Sprintf("artifact metadata exceeded the %d-record export limit", maxTrajectoryArtifacts)})
+	}
+	return warnings
+}
+
+func attachTaskTrajectoryTranscriptReference(run *TaskTrajectoryRun, source taskTrajectoryRunSource, capturedAt time.Time) []TaskTrajectoryWarning {
+	warnings := []TaskTrajectoryWarning{}
+	windowEnd := capturedAt
+	if run.FinishedAt != nil {
+		windowEnd = *run.FinishedAt
+	}
+	run.Transcript = TaskTrajectoryTranscript{
+		Status:       "reference_recorded",
+		Association:  "unverified_time_window",
+		WindowStart:  run.StartedAt.Add(-2 * time.Second),
+		WindowEnd:    windowEnd.Add(2 * time.Second),
+		TextExported: false,
+	}
+	if run.FinishedAt == nil {
+		warnings = append(warnings, TaskTrajectoryWarning{
+			Code:    "run_in_progress",
+			RunID:   run.ID,
+			Message: "run was not finished at the database snapshot time",
+		})
+	}
+	if !source.referenceRecorded {
+		run.Transcript.Status = "missing"
+		warnings = append(warnings, TaskTrajectoryWarning{
+			Code:    "transcript_reference_missing",
+			RunID:   run.ID,
+			Message: "no transcript source reference is stored for this run",
+		})
+	}
+	return warnings
+}

--- a/internal/server/service/task_trajectory.go
+++ b/internal/server/service/task_trajectory.go
@@ -13,11 +13,13 @@ import (
 )
 
 const (
-	TaskTrajectorySchemaVersion = "solo.task_trajectory.v1"
+	TaskTrajectorySchemaVersion = "solo.task_trajectory.v2"
 	maxTrajectoryTasks          = 500
 	maxTrajectoryRunLinkRows    = 2000
 	maxTrajectoryEvents         = 20000
 	maxTrajectoryArtifacts      = 1000
+	maxTrajectoryTaskActions    = 5000
+	maxTrajectoryMessages       = 5000
 	maxTrajectoryShortTextRunes = 500
 	maxTrajectoryBodyTextRunes  = 4000
 )
@@ -104,6 +106,27 @@ type TaskTrajectoryArtifact struct {
 	UpdatedAt        time.Time `json:"updated_at"`
 }
 
+type TaskTrajectoryTaskAction struct {
+	ID        string    `json:"id"`
+	RunID     string    `json:"run_id"`
+	TaskID    string    `json:"task_id"`
+	ActorID   string    `json:"actor_id"`
+	Action    string    `json:"action"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type TaskTrajectoryOutboundMessage struct {
+	ID              string    `json:"id"`
+	OriginRunID     string    `json:"origin_run_id"`
+	ChannelID       string    `json:"channel_id"`
+	ThreadID        string    `json:"thread_id,omitempty"`
+	ThinkingNodeID  string    `json:"thinking_node_id,omitempty"`
+	ContentType     string    `json:"content_type"`
+	AttachmentCount int       `json:"attachment_count"`
+	ContentOmitted  bool      `json:"content_omitted"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
 type TaskTrajectoryRun struct {
 	ID                string                   `json:"id"`
 	AgentID           string                   `json:"agent_id"`
@@ -128,14 +151,16 @@ type TaskTrajectoryRun struct {
 }
 
 type TaskTrajectorySnapshot struct {
-	SchemaVersion      string                   `json:"schema_version"`
-	DatabaseCapturedAt time.Time                `json:"database_captured_at"`
-	RootTaskID         string                   `json:"root_task_id"`
-	Coverage           TaskTrajectoryCoverage   `json:"coverage"`
-	Tasks              []TaskTrajectoryTask     `json:"tasks"`
-	Runs               []TaskTrajectoryRun      `json:"runs"`
-	Artifacts          []TaskTrajectoryArtifact `json:"artifacts"`
-	Warnings           []TaskTrajectoryWarning  `json:"warnings"`
+	SchemaVersion      string                          `json:"schema_version"`
+	DatabaseCapturedAt time.Time                       `json:"database_captured_at"`
+	RootTaskID         string                          `json:"root_task_id"`
+	Coverage           TaskTrajectoryCoverage          `json:"coverage"`
+	Tasks              []TaskTrajectoryTask            `json:"tasks"`
+	Runs               []TaskTrajectoryRun             `json:"runs"`
+	Artifacts          []TaskTrajectoryArtifact        `json:"artifacts"`
+	TaskActions        []TaskTrajectoryTaskAction      `json:"task_actions"`
+	OutboundMessages   []TaskTrajectoryOutboundMessage `json:"outbound_messages"`
+	Warnings           []TaskTrajectoryWarning         `json:"warnings"`
 }
 
 type TaskTrajectoryService struct {
@@ -155,6 +180,8 @@ type taskTrajectoryTruncation struct {
 	runLinks  bool
 	events    bool
 	artifacts bool
+	actions   bool
+	messages  bool
 }
 
 func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID string) (*TaskTrajectorySnapshot, error) {
@@ -196,6 +223,18 @@ func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID strin
 	if err != nil {
 		return nil, err
 	}
+	actions, actionsTruncated, err := loadTaskTrajectoryTaskActions(ctx, tx, taskIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
+	runIDs := make([]string, 0, len(runs))
+	for _, run := range runs {
+		runIDs = append(runIDs, run.ID)
+	}
+	messages, messagesTruncated, err := loadTaskTrajectoryOutboundMessages(ctx, tx, runIDs, rootChannelID)
+	if err != nil {
+		return nil, err
+	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
@@ -210,10 +249,12 @@ func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID strin
 		runLinks:  runLinksTruncated,
 		events:    eventsTruncated,
 		artifacts: artifactsTruncated,
+		actions:   actionsTruncated,
+		messages:  messagesTruncated,
 	}
 	warnings = append(warnings, trajectoryTruncationWarnings(truncation)...)
 	completeness := "partial_stored_records"
-	if tasksTruncated || runLinksTruncated || eventsTruncated || artifactsTruncated {
+	if tasksTruncated || runLinksTruncated || eventsTruncated || artifactsTruncated || actionsTruncated || messagesTruncated {
 		completeness = "partial_truncated_stored_records"
 	}
 
@@ -231,15 +272,94 @@ func (s *TaskTrajectoryService) Export(ctx context.Context, taskID, userID strin
 			TaskArtifacts:          "stored_selected_metadata",
 			DispatchDecisions:      "unavailable",
 			ParentRunLinks:         "unavailable",
-			OutboundMessageRuns:    "unavailable",
-			TaskLifecycleEvents:    "unavailable",
+			OutboundMessageRuns:    "stored_metadata_only",
+			TaskLifecycleEvents:    "stored_records",
 			RelationshipSnapshots:  "unavailable",
 		},
-		Tasks:     tasks,
-		Runs:      runs,
-		Artifacts: artifacts,
-		Warnings:  warnings,
+		Tasks:            tasks,
+		Runs:             runs,
+		Artifacts:        artifacts,
+		TaskActions:      actions,
+		OutboundMessages: messages,
+		Warnings:         warnings,
 	}, nil
+}
+
+func loadTaskTrajectoryTaskActions(ctx context.Context, tx pgx.Tx, taskIDs []string, rootChannelID string) ([]TaskTrajectoryTaskAction, bool, error) {
+	if len(taskIDs) == 0 {
+		return []TaskTrajectoryTaskAction{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT a.id::text, a.run_id::text, a.task_id::text, a.actor_id::text,
+		       left(a.action, $3), a.created_at
+		  FROM agent_run_task_actions a
+		  JOIN tasks t ON t.id = a.task_id
+		  JOIN agent_runs r ON r.id = a.run_id
+		 WHERE a.task_id = ANY($1::uuid[]) AND t.channel_id = $2 AND r.channel_id = $2
+		 ORDER BY a.created_at ASC, a.id ASC
+		 LIMIT $4`, taskIDs, rootChannelID, maxTrajectoryShortTextRunes, maxTrajectoryTaskActions+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	actions := []TaskTrajectoryTaskAction{}
+	for rows.Next() {
+		var action TaskTrajectoryTaskAction
+		if err := rows.Scan(&action.ID, &action.RunID, &action.TaskID, &action.ActorID, &action.Action, &action.CreatedAt); err != nil {
+			return nil, false, err
+		}
+		if !safeRunTaskAction(action.Action) {
+			action.Action = "unknown"
+		}
+		actions = append(actions, action)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(actions) > maxTrajectoryTaskActions
+	if truncated {
+		actions = actions[:maxTrajectoryTaskActions]
+	}
+	return actions, truncated, nil
+}
+
+func loadTaskTrajectoryOutboundMessages(ctx context.Context, tx pgx.Tx, runIDs []string, rootChannelID string) ([]TaskTrajectoryOutboundMessage, bool, error) {
+	if len(runIDs) == 0 {
+		return []TaskTrajectoryOutboundMessage{}, false, nil
+	}
+	rows, err := tx.Query(ctx, `
+		SELECT m.id::text, m.origin_run_id::text, m.channel_id::text,
+		       COALESCE(m.thread_id::text, ''), COALESCE(m.thinking_node_id::text, ''),
+		       left(COALESCE(m.content_type, 'text'), $3), cardinality(COALESCE(m.attachment_ids, '{}')), m.created_at
+		  FROM messages m
+		 WHERE m.origin_run_id = ANY($1::uuid[]) AND m.channel_id = $2
+		 ORDER BY m.created_at ASC, m.id ASC
+		 LIMIT $4`, runIDs, rootChannelID, maxTrajectoryShortTextRunes, maxTrajectoryMessages+1)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	messages := []TaskTrajectoryOutboundMessage{}
+	for rows.Next() {
+		var message TaskTrajectoryOutboundMessage
+		if err := rows.Scan(&message.ID, &message.OriginRunID, &message.ChannelID, &message.ThreadID,
+			&message.ThinkingNodeID, &message.ContentType, &message.AttachmentCount, &message.CreatedAt); err != nil {
+			return nil, false, err
+		}
+		message.ContentOmitted = true
+		if !safeTaskTrajectoryIdentifier(message.ContentType, 128) {
+			message.ContentType = "unknown"
+		}
+		messages = append(messages, message)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := len(messages) > maxTrajectoryMessages
+	if truncated {
+		messages = messages[:maxTrajectoryMessages]
+	}
+	return messages, truncated, nil
 }
 
 func authorizeTaskTrajectory(ctx context.Context, tx pgx.Tx, taskID, userID string) (string, error) {
@@ -683,6 +803,12 @@ func trajectoryTruncationWarnings(truncation taskTrajectoryTruncation) []TaskTra
 	}
 	if truncation.artifacts {
 		warnings = append(warnings, TaskTrajectoryWarning{Code: "artifact_limit_reached", Message: fmt.Sprintf("artifact metadata exceeded the %d-record export limit", maxTrajectoryArtifacts)})
+	}
+	if truncation.actions {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "task_action_limit_reached", Message: fmt.Sprintf("task lifecycle evidence exceeded the %d-record export limit", maxTrajectoryTaskActions)})
+	}
+	if truncation.messages {
+		warnings = append(warnings, TaskTrajectoryWarning{Code: "outbound_message_limit_reached", Message: fmt.Sprintf("outbound message evidence exceeded the %d-record export limit", maxTrajectoryMessages)})
 	}
 	return warnings
 }

--- a/internal/server/service/task_trajectory_test.go
+++ b/internal/server/service/task_trajectory_test.go
@@ -1,0 +1,277 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestTaskTrajectoryExportUsesStoredMetadataWithoutInternalContent(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	otherUserID := agentRunUser(t, pool)
+	agentAID := agentRunAgent(t, pool, ownerID)
+	agentBID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	otherChannelID := agentRunChannel(t, pool, otherUserID)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		 VALUES ($1, 'user', $2, 'owner')`, channelID, ownerID); err != nil {
+		t.Fatalf("add channel owner: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_sessions WHERE agent_id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, otherChannelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, otherChannelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = ANY($1::uuid[])`, []string{agentAID, agentBID})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = ANY($1::uuid[])`, []string{ownerID, otherUserID})
+	})
+
+	taskSvc := NewTaskService(pool)
+	root, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{
+		Title:       "Prepare release notes",
+		Description: "Summarize the ordinary release work",
+	})
+	if err != nil {
+		t.Fatalf("create root task: %v", err)
+	}
+	child, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{
+		Title:        "Check changelog",
+		ParentTaskID: root.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child task: %v", err)
+	}
+	crossChannelTaskID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number, parent_task_id)
+		VALUES ($1, $2, $3, 'cross-channel-secret-task', 'todo', 'normal', 1, $4)`,
+		crossChannelTaskID, otherChannelID, otherUserID, root.ID); err != nil {
+		t.Fatalf("create defensive cross-channel child: %v", err)
+	}
+	artifactID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO artifacts (id, task_id, channel_id, kind, title, html_path, summary, created_by)
+		VALUES ($1, $2, $3, 'task_snapshot', 'Release notes', '/private/artifact.html', 'published result', $4)`,
+		artifactID, root.ID, channelID, ownerID); err != nil {
+		t.Fatalf("create artifact: %v", err)
+	}
+
+	runSvc := NewAgentRunService(pool)
+	session, err := runSvc.UpsertSession(ctx, UpsertSessionInput{
+		AgentID:           agentAID,
+		Provider:          "codex",
+		ExternalSessionID: "trajectory-session",
+		TranscriptPath:    agentRunTranscriptFileWithText(t, "reviewed the changelog"),
+	})
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+	completedRun, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentAID,
+		SessionID:    session.ID,
+		TriggerType:  AgentRunTriggerTask,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusRunning,
+		ActivityText: "reviewing changelog",
+		Source:       "codex",
+		Usage:        map[string]any{"input_tokens": 12, "private_context": "secret-usage"},
+	})
+	if err != nil {
+		t.Fatalf("start completed run: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: completedRun.ID, TaskID: root.ID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
+		t.Fatalf("link root task: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: completedRun.ID, TaskID: child.ID, Role: AgentRunTaskRoleRelated, Confidence: 0.75}); err != nil {
+		t.Fatalf("link child task: %v", err)
+	}
+	firstEvent, err := runSvc.AppendEvent(ctx, AppendRunEventInput{RunID: completedRun.ID, Type: AgentRunEventRunStarted, Message: "started"})
+	if err != nil {
+		t.Fatalf("append first event: %v", err)
+	}
+	secondEvent, err := runSvc.AppendEvent(ctx, AppendRunEventInput{
+		RunID:   completedRun.ID,
+		Type:    AgentRunEventToolFinished,
+		Message: "secret event output",
+		Payload: map[string]any{"call_id": "call-1", "is_error": false, "output": "secret-token"},
+	})
+	if err != nil {
+		t.Fatalf("append second event: %v", err)
+	}
+	if _, err := runSvc.FinishRun(ctx, FinishRunInput{RunID: completedRun.ID, Status: AgentRunStatusCompleted, ActivityText: "done"}); err != nil {
+		t.Fatalf("finish run: %v", err)
+	}
+
+	runningRun, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentBID,
+		TriggerType:  AgentRunTriggerTask,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusRunning,
+		ActivityText: "drafting notes",
+		Source:       "codex",
+	})
+	if err != nil {
+		t.Fatalf("start running run: %v", err)
+	}
+	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: runningRun.ID, TaskID: child.ID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
+		t.Fatalf("link running run: %v", err)
+	}
+
+	snapshot, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, ownerID)
+	if err != nil {
+		t.Fatalf("export trajectory: %v", err)
+	}
+	if snapshot.SchemaVersion != TaskTrajectorySchemaVersion || snapshot.RootTaskID != root.ID {
+		t.Fatalf("snapshot identity = %+v", snapshot)
+	}
+	if len(snapshot.Tasks) != 2 || snapshot.Tasks[0].ID != root.ID || snapshot.Tasks[1].ParentTaskID != root.ID {
+		t.Fatalf("task tree = %+v", snapshot.Tasks)
+	}
+	if len(snapshot.Runs) != 2 {
+		t.Fatalf("runs = %+v, want 2", snapshot.Runs)
+	}
+
+	completed := trajectoryRunByID(t, snapshot.Runs, completedRun.ID)
+	if len(completed.TaskLinks) != 2 {
+		t.Fatalf("completed task links = %+v, want 2", completed.TaskLinks)
+	}
+	if len(completed.Events) != 2 || completed.Events[0].ID != firstEvent.ID || completed.Events[1].ID != secondEvent.ID {
+		t.Fatalf("ordered events = %+v", completed.Events)
+	}
+	if !completed.Events[1].ContentOmitted || completed.Events[1].Metadata["call_id"] != "call-1" || completed.Events[1].Metadata["is_error"] != false {
+		t.Fatalf("metadata-only event = %+v", completed.Events[1])
+	}
+	if completed.Transcript.Status != "reference_recorded" || completed.Transcript.TextExported || completed.Transcript.Association != "unverified_time_window" {
+		t.Fatalf("completed transcript = %+v", completed.Transcript)
+	}
+	if completed.Usage["input_tokens"] != int64(12) {
+		t.Fatalf("sanitized usage = %+v", completed.Usage)
+	}
+	running := trajectoryRunByID(t, snapshot.Runs, runningRun.ID)
+	if running.Transcript.Status != "missing" {
+		t.Fatalf("running transcript = %+v, want missing", running.Transcript)
+	}
+	if !trajectoryHasWarning(snapshot.Warnings, "run_in_progress", runningRun.ID) || !trajectoryHasWarning(snapshot.Warnings, "transcript_reference_missing", runningRun.ID) {
+		t.Fatalf("warnings = %+v", snapshot.Warnings)
+	}
+	if snapshot.Coverage.ParentRunLinks != "unavailable" || snapshot.Coverage.TranscriptAvailability != "reference_recorded_only_unverified_time_window" || snapshot.Coverage.Completeness != "partial_stored_records" {
+		t.Fatalf("coverage = %+v", snapshot.Coverage)
+	}
+	if len(snapshot.Artifacts) != 1 || snapshot.Artifacts[0].ID != artifactID || snapshot.Artifacts[0].URL != "/api/v1/artifacts/"+artifactID {
+		t.Fatalf("artifacts = %+v", snapshot.Artifacts)
+	}
+
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	jsonText := string(raw)
+	for _, secret := range []string{"transcript_path", `"raw"`, `"input"`, "reviewed the changelog", "secret event output", "secret-token", "secret-usage", "/private/artifact.html", "cross-channel-secret-task"} {
+		if strings.Contains(jsonText, secret) {
+			t.Fatalf("snapshot leaked internal content %q: %s", secret, jsonText)
+		}
+	}
+
+	if _, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, otherUserID); !errors.Is(err, ErrTaskNotChannelMember) {
+		t.Fatalf("unauthorized export error = %v, want %v", err, ErrTaskNotChannelMember)
+	}
+}
+
+func TestTaskTrajectoryExportCapsLargeTaskTrees(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		 VALUES ($1, 'user', $2, 'owner')`, channelID, ownerID); err != nil {
+		t.Fatalf("add channel owner: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	root, err := NewTaskService(pool).CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "large trajectory root"})
+	if err != nil {
+		t.Fatalf("create root task: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO tasks (id, channel_id, creator_id, title, status, priority, task_number, parent_task_id)
+		SELECT gen_random_uuid(), $1, $2, 'child-' || n, 'todo', 'normal', n + 1, $3
+		  FROM generate_series(1, $4) AS n`, channelID, ownerID, root.ID, maxTrajectoryTasks+5); err != nil {
+		t.Fatalf("create child tasks: %v", err)
+	}
+
+	snapshot, err := NewTaskTrajectoryService(pool).Export(ctx, root.ID, ownerID)
+	if err != nil {
+		t.Fatalf("export capped trajectory: %v", err)
+	}
+	if len(snapshot.Tasks) != maxTrajectoryTasks {
+		t.Fatalf("task count = %d, want cap %d", len(snapshot.Tasks), maxTrajectoryTasks)
+	}
+	if snapshot.Coverage.Completeness != "partial_truncated_stored_records" || !trajectoryHasWarning(snapshot.Warnings, "task_limit_reached", "") {
+		t.Fatalf("coverage = %+v, warnings = %+v", snapshot.Coverage, snapshot.Warnings)
+	}
+}
+
+func TestTaskTrajectoryEventMetadataRejectsUntrustedValues(t *testing.T) {
+	metadata, omitted := taskTrajectoryEventMetadata(json.RawMessage(`{
+		"call_id":"contains a space",
+		"task_id":"not-a-uuid",
+		"is_error":true,
+		"output":{"secret":"value"},
+		"unknown":"secret"
+	}`))
+	if !omitted {
+		t.Fatal("untrusted event fields were not marked omitted")
+	}
+	if len(metadata) != 1 || metadata["is_error"] != true {
+		t.Fatalf("metadata = %+v, want only is_error", metadata)
+	}
+}
+
+func TestTaskTrajectoryTranscriptOnlyClaimsStoredReference(t *testing.T) {
+	finishedAt := time.Now().UTC()
+	run := TaskTrajectoryRun{ID: "run-reference", StartedAt: finishedAt.Add(-time.Minute), FinishedAt: &finishedAt}
+	warnings := attachTaskTrajectoryTranscriptReference(&run, taskTrajectoryRunSource{referenceRecorded: true}, finishedAt)
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %+v", warnings)
+	}
+	if run.Transcript.Status != "reference_recorded" || run.Transcript.TextExported {
+		t.Fatalf("transcript = %+v", run.Transcript)
+	}
+}
+
+func trajectoryRunByID(t *testing.T, runs []TaskTrajectoryRun, id string) TaskTrajectoryRun {
+	t.Helper()
+	for _, run := range runs {
+		if run.ID == id {
+			return run
+		}
+	}
+	t.Fatalf("run %s not found in %+v", id, runs)
+	return TaskTrajectoryRun{}
+}
+
+func trajectoryHasWarning(warnings []TaskTrajectoryWarning, code, runID string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code && warning.RunID == runID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/service/task_trajectory_test.go
+++ b/internal/server/service/task_trajectory_test.go
@@ -96,6 +96,19 @@ func TestTaskTrajectoryExportUsesStoredMetadataWithoutInternalContent(t *testing
 	if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: completedRun.ID, TaskID: child.ID, Role: AgentRunTaskRoleRelated, Confidence: 0.75}); err != nil {
 		t.Fatalf("link child task: %v", err)
 	}
+	actionID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO agent_run_task_actions (id, run_id, task_id, actor_id, action)
+		VALUES ($1, $2, $3, $4, 'submit')`, actionID, completedRun.ID, root.ID, agentAID); err != nil {
+		t.Fatalf("insert task action: %v", err)
+	}
+	outboundMessageID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, origin_run_id, sender_type, sender_id, content, content_type, created_at, updated_at)
+		VALUES ($1, $2, $3, 'agent', $4, 'private outbound content', 'text', now(), now())`,
+		outboundMessageID, channelID, completedRun.ID, agentAID); err != nil {
+		t.Fatalf("insert outbound message: %v", err)
+	}
 	firstEvent, err := runSvc.AppendEvent(ctx, AppendRunEventInput{RunID: completedRun.ID, Type: AgentRunEventRunStarted, Message: "started"})
 	if err != nil {
 		t.Fatalf("append first event: %v", err)
@@ -168,6 +181,15 @@ func TestTaskTrajectoryExportUsesStoredMetadataWithoutInternalContent(t *testing
 	if snapshot.Coverage.ParentRunLinks != "unavailable" || snapshot.Coverage.TranscriptAvailability != "reference_recorded_only_unverified_time_window" || snapshot.Coverage.Completeness != "partial_stored_records" {
 		t.Fatalf("coverage = %+v", snapshot.Coverage)
 	}
+	if snapshot.Coverage.OutboundMessageRuns != "stored_metadata_only" || snapshot.Coverage.TaskLifecycleEvents != "stored_records" {
+		t.Fatalf("causal coverage = %+v", snapshot.Coverage)
+	}
+	if len(snapshot.TaskActions) != 1 || snapshot.TaskActions[0].ID != actionID || snapshot.TaskActions[0].RunID != completedRun.ID {
+		t.Fatalf("task actions = %+v", snapshot.TaskActions)
+	}
+	if len(snapshot.OutboundMessages) != 1 || snapshot.OutboundMessages[0].ID != outboundMessageID || !snapshot.OutboundMessages[0].ContentOmitted {
+		t.Fatalf("outbound messages = %+v", snapshot.OutboundMessages)
+	}
 	if len(snapshot.Artifacts) != 1 || snapshot.Artifacts[0].ID != artifactID || snapshot.Artifacts[0].URL != "/api/v1/artifacts/"+artifactID {
 		t.Fatalf("artifacts = %+v", snapshot.Artifacts)
 	}
@@ -177,7 +199,7 @@ func TestTaskTrajectoryExportUsesStoredMetadataWithoutInternalContent(t *testing
 		t.Fatalf("marshal snapshot: %v", err)
 	}
 	jsonText := string(raw)
-	for _, secret := range []string{"transcript_path", `"raw"`, `"input"`, "reviewed the changelog", "secret event output", "secret-token", "secret-usage", "/private/artifact.html", "cross-channel-secret-task"} {
+	for _, secret := range []string{"transcript_path", `"raw"`, `"input"`, "reviewed the changelog", "secret event output", "secret-token", "secret-usage", "private outbound content", "/private/artifact.html", "cross-channel-secret-task"} {
 		if strings.Contains(jsonText, secret) {
 			t.Fatalf("snapshot leaked internal content %q: %s", secret, jsonText)
 		}

--- a/internal/server/ws/message.go
+++ b/internal/server/ws/message.go
@@ -157,6 +157,7 @@ type MessageNewPayload struct {
 	ContentType        string           `json:"content_type"`
 	ThreadID           string           `json:"thread_id,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
+	OriginRunID        string           `json:"origin_run_id,omitempty"`
 	MentionedAgentIDs  []string         `json:"mentioned_agent_ids,omitempty"`
 	AttachmentIDs      []string         `json:"attachment_ids,omitempty"`
 	Attachments        []AttachmentMeta `json:"attachments,omitempty"`
@@ -252,6 +253,7 @@ type ThreadMessageItem struct {
 	SenderName    string           `json:"sender_name,omitempty"`
 	Content       string           `json:"content"`
 	ContentType   string           `json:"content_type"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
@@ -333,6 +335,7 @@ type DMMessageNewPayload struct {
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	ThreadID      string           `json:"thread_id,omitempty"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	CreatedAt     string           `json:"created_at"`
 }
 

--- a/migrations/000034_add_agent_run_causal_evidence.down.sql
+++ b/migrations/000034_add_agent_run_causal_evidence.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS agent_run_task_actions;
+DROP INDEX IF EXISTS idx_messages_origin_run;
+ALTER TABLE messages DROP COLUMN IF EXISTS origin_run_id;

--- a/migrations/000034_add_agent_run_causal_evidence.up.sql
+++ b/migrations/000034_add_agent_run_causal_evidence.up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS origin_run_id UUID REFERENCES agent_runs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_messages_origin_run
+    ON messages(origin_run_id, created_at ASC)
+    WHERE origin_run_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS agent_run_task_actions (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id     UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    task_id    UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    actor_id   UUID NOT NULL,
+    action     TEXT NOT NULL CHECK (action IN ('claim', 'unclaim', 'submit', 'accept', 'reject', 'close', 'reopen')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_task_actions_task_created
+    ON agent_run_task_actions(task_id, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_task_actions_run_created
+    ON agent_run_task_actions(run_id, created_at ASC);


### PR DESCRIPTION
## Summary

- make the daemon own the active provider-turn action scope and sign `run_id + actor_id + channel_id` before forwarding mutations
- fail closed when an Agent mutation has no unambiguous active turn, while preserving direct API behavior for human CLI use
- store `messages.origin_run_id` and record task lifecycle actions plus executor links in the same transaction as the task state change
- export metadata-only outbound messages and task actions in `solo.task_trajectory.v2`

## Why

Previously a successful Agent run, its outbound messages, and its task lifecycle commands could not be joined causally. Timestamp/latest-run inference would be ambiguous for persistent sessions and queued turns. This change carries an exact runtime-owned origin instead of asking the Agent or prompt to report one.

## Safety properties

- the Agent JWT subject must match the proxy `agent_id`
- the origin envelope is HMAC signed with the Server/Daemon internal secret
- Server validation binds the origin to the same Agent and channel and rejects terminal runs
- concurrent turns for one Agent cannot overwrite each other
- task mutation, executor link, and lifecycle evidence commit or roll back together
- exported outbound messages omit content

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- targeted `go test -race` for action scope, signature, task transaction, and trajectory paths
- migration applied successfully to the isolated development database

## Stack

This PR includes the trajectory-export commit from draft PR #51. Once #51 lands, the review diff should collapse to the causal-evidence changes. It complements the truthful run lifecycle work in #54.

## Real isolated task

A Codex agent completed an ordinary repository documentation review task in the isolated stack. One exact run ID was present on both `claim` and `submit`, and on two outbound thread messages. The task ended `in_review`; trajectory v2 returned message metadata with `content_omitted: true`; and a fresh thread reload preserved `origin_run_id`. This run also exposed a separate failed follow-up run with no transcript, which remains visible as a warning rather than being guessed into the successful run.