### PR TITLE
fix(make): only kill listening sockets in `make stop`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ stop: ## Shut down all services
 	@echo "=== Stopping all services ==="
 	@-for f in .pids/*.pid; do [ -f "$$f" ] || continue; kill "$$(cat "$$f")" 2>/dev/null || true; done
 	@-lsof -t "$$(pwd)/.pids/server" "$$(pwd)/.pids/daemon" 2>/dev/null | xargs kill 2>/dev/null && echo "Stale .pids processes stopped" || true
-	@-lsof -ti :8080 | xargs kill 2>/dev/null && echo "Server stopped" || echo "Server not running"
-	@-lsof -ti :8081 | xargs kill 2>/dev/null && echo "Daemon stopped" || echo "Daemon not running"
-	@-lsof -ti :3000 | xargs kill 2>/dev/null && echo "Frontend stopped" || echo "Frontend not running"
+	@-lsof -ti tcp:8080 -sTCP:LISTEN | xargs kill 2>/dev/null && echo "Server stopped" || echo "Server not running"
+	@-lsof -ti tcp:8081 -sTCP:LISTEN | xargs kill 2>/dev/null && echo "Daemon stopped" || echo "Daemon not running"
+	@-lsof -ti tcp:3000 -sTCP:LISTEN | xargs kill 2>/dev/null && echo "Frontend stopped" || echo "Frontend not running"
 	@rm -f .pids/*.pid
 	@sleep 1
 	@echo "=== All services stopped ==="


### PR DESCRIPTION
## Summary

`make stop` could kill the user's browser. `lsof -ti :PORT` matches every socket bound to that port — including the *client* side of ESTABLISHED connections — so with a browser tab open on the Solo UI (`:3000`) or hitting the API (`:8080`), the browser process got SIGTERM along with the actual services. This scopes the lookup to listening sockets via `-sTCP:LISTEN`.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests

## Related

Closes #

## Screenshots (if applicable)

N/A — no UI change.

---

### Reproduction

With the dev stack running and a browser open on the Solo UI:

```
$ lsof -ti :3000
560     <- Zen Browser (ESTABLISHED client socket)
10494   <- next dev server
```

`make stop` piped both into `xargs kill`.

### Verification

After the fix, on the same machine and same open browser:

```
$ lsof -ti tcp:3000 -sTCP:LISTEN
10494   <- server only
```

`make stop` output:

```
=== Stopping all services ===
Server stopped
Daemon stopped
Frontend stopped
=== All services stopped ===
```

- All three ports released, no leftover processes (including `next dev` children)
- Browser process survived — it was killed before this change
- `solo-postgres` container untouched, `pgdata` volume intact

### Notes for reviewers

- The `lsof -t "$(pwd)/.pids/server" ...` line above is unaffected — it matches processes by open binary, not by port, so it never had this problem.
- `-sTCP:LISTEN` requires the `tcp:` prefix on the port selector; `lsof -ti :3000 -sTCP:LISTEN` alone does not filter. Both were changed together.
