### PR TITLE
Unify localized message timestamps

### DIFF
--- a/frontend/components/dashboard/agent-message.tsx
+++ b/frontend/components/dashboard/agent-message.tsx
@@ -13,6 +13,7 @@ import type { AgentDetailTarget, Message } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import { PixelAvatar } from '@/components/ui/pixel-avatar';
 import { t } from '@/lib/i18n';
+import { formatMessageTimestamp } from '@/lib/utils/time';
 import { MessageMarkdown } from './message-markdown';
 
 interface AgentMessageProps {
@@ -26,10 +27,7 @@ interface AgentMessageProps {
 }
 
 export function AgentMessage({ message, onReply, validNames = [], isHighlighted, onOpenArtifactReference, onAgentClick }: AgentMessageProps) {
-  const time = new Date(message.created_at).toLocaleString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const time = formatMessageTimestamp(message.created_at);
 
   const hasUnreadThread = message.has_unread_thread === true && (message.reply_count ?? 0) > 0;
   return (
@@ -67,9 +65,9 @@ export function AgentMessage({ message, onReply, validNames = [], isHighlighted,
               {t('agent')}
             </span>
           )}
-          <span className="font-mono text-[11px] text-muted-foreground">
+          <time dateTime={message.created_at} className="font-mono text-[11px] text-muted-foreground">
             {time}
-          </span>
+          </time>
         </div>
         <MessageMarkdown
           content={message.content}

--- a/frontend/components/dashboard/message-list.tsx
+++ b/frontend/components/dashboard/message-list.tsx
@@ -49,6 +49,7 @@ import { MessageAttachments } from './message-attachments';
 import type { AgentDetailTarget, ChannelMember, Message } from '@/lib/types';
 import { sanitizeHtml } from '@/lib/sanitize';
 import { t } from '@/lib/i18n';
+import { formatMessageTimestamp } from '@/lib/utils/time';
 // Agent activity now lives in team/observability surfaces, not inline typing badges.
 interface MessageListProps {
   messages: Message[];
@@ -200,10 +201,7 @@ const MessageItem = memo(function MessageItem({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isHovered, onEdit, onDelete, message.content, message.id, isEditing, isFailed, isSending]);
 
-  const time = new Date(message.created_at).toLocaleString('zh-CN', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const time = formatMessageTimestamp(message.created_at);
 
   const handleSaveEdit = useCallback(async () => {
     if (isSaving) return;
@@ -312,9 +310,9 @@ const MessageItem = memo(function MessageItem({
               {t('deleted')}
             </span>
           )}
-          <span className="font-mono text-[11px] text-muted-foreground">
+          <time dateTime={message.created_at} className="font-mono text-[11px] text-muted-foreground">
             {time}
-          </span>
+          </time>
           {isEditing && (
             <span className="font-mono text-[11px] text-brutal-primary animate-pulse ml-auto">
               {t('editingMessage')}

--- a/frontend/components/dashboard/streaming-message.tsx
+++ b/frontend/components/dashboard/streaming-message.tsx
@@ -13,6 +13,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { cn } from '@/lib/utils';
 import { t } from '@/lib/i18n';
+import { formatMessageTimestamp } from '@/lib/utils/time';
 import type { AgentDetailTarget, Message } from '@/lib/types';
 import { PixelAvatar } from '@/components/ui/pixel-avatar';
 
@@ -90,10 +91,7 @@ function TypingDots() {
 }
 
 export function StreamingMessage({ message, onAgentClick }: StreamingMessageProps) {
-  const time = new Date(message.created_at).toLocaleString('zh-CN', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const time = formatMessageTimestamp(message.created_at);
 
   const unclosedCodeBlock = hasUnclosedCodeBlock(message.content);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -142,9 +140,9 @@ export function StreamingMessage({ message, onAgentClick }: StreamingMessageProp
               {t('deleted')}
             </span>
           )}
-          <span className="font-mono text-[11px] text-muted-foreground">
+          <time dateTime={message.created_at} className="font-mono text-[11px] text-muted-foreground">
             {time}
-          </span>
+          </time>
           <span className="badge-brutal bg-brutal-primary/20 text-brutal-primary">
             {t('streaming')}
           </span>

--- a/frontend/components/dashboard/thread-panel.tsx
+++ b/frontend/components/dashboard/thread-panel.tsx
@@ -39,6 +39,7 @@ import { useWebSocket } from '@/lib/ws-context';
 import { useToast } from '@/components/ui/toast';
 import { MentionDropdown, type DropdownAnchor } from './mention-dropdown';
 import { t } from '@/lib/i18n';
+import { formatMessageTimestamp } from '@/lib/utils/time';
 import type { AgentDetailTarget, Message, ChannelMember, Task, TaskStatus } from '@/lib/types';
 
 interface ThreadPanelProps {
@@ -73,10 +74,7 @@ function ParentMessageBlock({
 }) {
   const isAgent = message.sender_type === 'agent';
   const displayName = task?.creator_name || message.display_name;
-  const time = new Date(message.created_at).toLocaleString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const time = formatMessageTimestamp(message.created_at);
 
   return (
     <div className={`flex gap-3 px-6 py-4 border-b-2 border-black ${isAgent ? 'border-l-2 border-l-brutal-primary' : ''}`}>
@@ -102,9 +100,9 @@ function ParentMessageBlock({
           <span className="font-heading text-sm font-bold text-foreground">
             {displayName}
           </span>
-          <span className="font-mono text-[11px] text-muted-foreground">
+          <time dateTime={message.created_at} className="font-mono text-[11px] text-muted-foreground">
             {time}
-          </span>
+          </time>
         </div>
         <div className="font-body text-sm leading-relaxed space-y-1">
           <ReactMarkdown
@@ -283,10 +281,7 @@ function ReplyItem({
   const isStreaming = message.status === 'streaming';
   const isAgent = message.sender_type === 'agent';
 
-  const time = new Date(message.created_at).toLocaleString('en-US', {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  const time = formatMessageTimestamp(message.created_at);
 
   return (
     <div
@@ -319,9 +314,9 @@ function ReplyItem({
           <span className="font-heading text-sm font-bold text-foreground">
             {message.display_name}
           </span>
-          <span className="font-mono text-[11px] text-muted-foreground">
+          <time dateTime={message.created_at} className="font-mono text-[11px] text-muted-foreground">
             {time}
-          </span>
+          </time>
           {isAgent && (
             <span className="badge-brutal bg-brutal-primary text-black">
               {t('agent')}

--- a/frontend/e2e/message-timestamp.spec.ts
+++ b/frontend/e2e/message-timestamp.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const credentials = { email: 'message-time-e2e@solo.local', password: 'SoloE2E-2026!' };
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+interface MessageResponse {
+  id: string;
+  content: string;
+  created_at: string;
+}
+
+async function authenticate(request: APIRequestContext): Promise<AuthResponse> {
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, { data: credentials });
+  if (login.ok()) return login.json();
+  const register = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: { ...credentials, display_name: 'Message Time E2E' },
+  });
+  if (!register.ok()) throw new Error(`E2E authentication failed: ${register.status()} ${await register.text()}`);
+  return register.json();
+}
+
+function shiftedDay(value: string, days: number) {
+  const date = new Date(value);
+  date.setDate(date.getDate() + days);
+  date.setHours(12, 0, 0, 0);
+  return date;
+}
+
+function expectedTime(value: string, locale: 'en' | 'zh-CN') {
+  return new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(new Date(value));
+}
+
+test('channel message timestamps use localized calendar labels and a 24-hour clock', async ({ page, request }) => {
+  const auth = await authenticate(request);
+  const createdChannel = await request.post(`${apiBase}/api/v1/channels`, {
+    headers: { authorization: `Bearer ${auth.access_token}` },
+    data: { name: `message-time-e2e-${Date.now()}`, description: 'Message timestamp E2E' },
+  });
+  expect(createdChannel.ok()).toBe(true);
+  const channel = await createdChannel.json() as { id: string };
+
+  try {
+    const createdMessage = await request.post(`${apiBase}/api/v1/channels/${channel.id}/messages`, {
+      headers: { authorization: `Bearer ${auth.access_token}` },
+      data: { content: `TIMESTAMP_E2E_${Date.now()}` },
+    });
+    expect(createdMessage.ok()).toBe(true);
+    const message = await createdMessage.json() as MessageResponse;
+
+    const listed = await request.get(`${apiBase}/api/v1/channels/${channel.id}/messages?limit=100`, {
+      headers: { authorization: `Bearer ${auth.access_token}` },
+    });
+    expect(listed.ok()).toBe(true);
+    const persisted = (await listed.json() as { messages: MessageResponse[] }).messages.find((item) => item.id === message.id);
+    expect(persisted?.content).toBe(message.content);
+    expect(new Date(persisted!.created_at).getTime()).toBe(new Date(message.created_at).getTime());
+
+    await page.addInitScript(({ accessToken, refreshToken }) => {
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('refresh_token', refreshToken);
+      if (!localStorage.getItem('solo.locale')) localStorage.setItem('solo.locale', 'zh-CN');
+    }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+    await page.clock.setFixedTime(shiftedDay(message.created_at, 0));
+    await page.goto(`/dashboard?channel=${channel.id}`);
+
+    const timestamp = page.locator(`[data-message-id="${message.id}"] time`);
+    await expect(timestamp).toHaveText(expectedTime(message.created_at, 'zh-CN'));
+
+    await page.clock.setFixedTime(shiftedDay(message.created_at, 1));
+    await page.reload();
+    await expect(timestamp).toHaveText(`昨天 ${expectedTime(message.created_at, 'zh-CN')}`);
+
+    await page.clock.setFixedTime(shiftedDay(message.created_at, 3));
+    await page.reload();
+    const zhDate = new Intl.DateTimeFormat('zh-CN', { month: 'short', day: 'numeric' }).format(new Date(message.created_at));
+    await expect(timestamp).toHaveText(`${zhDate} ${expectedTime(message.created_at, 'zh-CN')}`);
+
+    await page.evaluate(() => localStorage.setItem('solo.locale', 'en'));
+    await page.reload();
+    const enDate = new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' }).format(new Date(message.created_at));
+    await expect(timestamp).toHaveText(`${enDate} ${expectedTime(message.created_at, 'en')}`);
+  } finally {
+    await request.delete(`${apiBase}/api/v1/channels/${channel.id}`, {
+      headers: { authorization: `Bearer ${auth.access_token}` },
+    });
+  }
+});

--- a/frontend/lib/utils/time.ts
+++ b/frontend/lib/utils/time.ts
@@ -1,4 +1,4 @@
-import { t } from '@/lib/i18n';
+import { getLocale, t } from '@/lib/i18n';
 
 /**
  * Returns a human-readable relative time string.
@@ -30,6 +30,29 @@ export function relativeTime(
   const d = new Date(iso);
   const pad = (n: number) => n.toString().padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** Formats chat timestamps using local calendar days and a 24-hour clock. */
+export function formatMessageTimestamp(iso: string | null | undefined, now = new Date()): string {
+  if (!iso) return t('unknown');
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return t('unknown');
+
+  const locale = getLocale();
+  const time = new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  }).format(date);
+  if (date.toDateString() === now.toDateString()) return time;
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const day = date.toDateString() === yesterday.toDateString()
+    ? t('yesterday')
+    : new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric' }).format(date);
+  return `${day} ${time}`;
 }
 
 /**


### PR DESCRIPTION
## What changed

- show today's chat timestamps as `HH:mm`
- show yesterday as localized `Yesterday/昨天 HH:mm`
- show older messages with a localized month/day plus time
- use the same 24-hour formatter for human, agent, streaming, DM, and thread messages

## Root cause

Human, agent, streaming, and thread message components each formatted timestamps independently. Some hard-coded `zh-CN`, others hard-coded `en-US`, which dropped the date and caused 12/24-hour inconsistencies.

## Validation

- `npm run build`
- `npm run lint` (0 errors)
- `CI=1 npx playwright test e2e/message-timestamp.spec.ts --reporter=line`
- real Channel, API, and PostgreSQL persistence verified by the E2E test across today/yesterday/older and Chinese/English output
