### PR TITLE
feat: attribute agent actions to originating runs

### DIFF
--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/solo-ai/solo/internal/auth"
+	"github.com/solo-ai/solo/internal/causal"
 	"github.com/solo-ai/solo/pkg/agent"
 	"github.com/solo-ai/solo/pkg/llm"
 	"github.com/solo-ai/solo/pkg/skillloader"
@@ -398,6 +399,21 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			req.NodeID = runtimeNodeID
 		}
 	}
+	var originRunID string
+	if isRuntimeMutation(req.Action) {
+		scope, ok := h.taskManager.GetActionScope(req.AgentID)
+		if !ok || scope.ChannelID != req.ChannelID || scope.NodeID != req.NodeID {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "no matching active provider turn for mutation"})
+			return
+		}
+		originRunID = scope.RunID
+	}
+	proxyToken := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	claims, authErr := auth.ValidateToken(proxyToken)
+	if authErr != nil || claims.Subject != req.AgentID {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "proxy caller does not match agent_id"})
+		return
+	}
 
 	// Generate or reuse auth token for this agent (SOLO-254-B: token store).
 	token, err := h.getOrGenerateToken(r.Context(), req.AgentID)
@@ -431,6 +447,12 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		serverBody, _ = json.Marshal(map[string]string{"status": req.Status})
 	case "task_unclaim":
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/tasks/%d/claim", req.ChannelID, req.TaskNumber)
+	case "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
+		action := strings.TrimPrefix(req.Action, "task_")
+		serverPath = fmt.Sprintf("/api/v1/channels/%s/tasks/%d/%s", req.ChannelID, req.TaskNumber, action)
+		if req.Action == "task_reject" {
+			serverBody, _ = json.Marshal(map[string]string{"reason": req.Content})
+		}
 	case "channel_members":
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/members", req.ChannelID)
 	case "server_info":
@@ -465,8 +487,11 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		method := "GET"
 		var fwdBody io.Reader
 		switch req.Action {
-		case "task_claim":
+		case "task_claim", "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
 			method = "POST"
+			if serverBody != nil {
+				fwdBody = bytes.NewReader(serverBody)
+			}
 		case "task_update":
 			method = "PATCH"
 			fwdBody = bytes.NewReader(serverBody)
@@ -486,6 +511,10 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			httpReq.Header.Set("Content-Type", "application/json")
 		}
 		httpReq.Header.Set("Authorization", "Bearer "+tok)
+		if originRunID != "" {
+			httpReq.Header.Set(causal.RunHeader, originRunID)
+			httpReq.Header.Set(causal.SignatureHeader, causal.Sign(h.internalToken, originRunID, req.AgentID, req.ChannelID))
+		}
 
 		client := h.httpClient
 		if req.Action == "team_form" {
@@ -526,6 +555,15 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(resp.StatusCode)
 	w.Write(body)
+}
+
+func isRuntimeMutation(action string) bool {
+	switch action {
+	case "message_send", "task_claim", "task_unclaim", "task_submit", "task_accept", "task_reject", "task_close", "task_reopen":
+		return true
+	default:
+		return false
+	}
 }
 
 func cloneHTTPClientWithTimeout(client *http.Client, timeout time.Duration) *http.Client {
@@ -585,7 +623,8 @@ type runTaskRequest struct {
 	SystemPrompt          string             `json:"system_prompt"`
 	ThinkingRuntimePrompt string             `json:"thinking_runtime_prompt,omitempty"`
 	ModelConfig           modelConfigPayload `json:"model_config"`
-	TaskContext           string             `json:"task_context,omitempty"`    // SOLO-221-B: summary of pending tasks in channel
+	TaskContext           string             `json:"task_context,omitempty"` // SOLO-221-B: summary of pending tasks in channel
+	OriginTaskID          string             `json:"origin_task_id,omitempty"`
 	MentionedNames        []string           `json:"mentioned_names,omitempty"` // v1.3: names of @mentioned agents
 }
 
@@ -723,6 +762,12 @@ func (h *daemonHandler) processTaskWithProvider(ctx context.Context, req runTask
 
 	// Select the provider matching the agent type and stream
 	provider := h.getProvider(req.ModelConfig.Provider)
+	clearActionScope, ok := h.activateActionScope(req)
+	if !ok {
+		h.failActionScopeConflict(req)
+		return
+	}
+	defer clearActionScope()
 	streamCh, err := provider.CompleteStream(ctx, llmReq)
 	if err != nil {
 		slog.Error("task: streaming LLM call failed to start",
@@ -1046,6 +1091,13 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		// ExtraArgs: daemonConfig.ExtraArgs[backend.Name()], // P1 reserved
 	}
 
+	clearActionScope, ok := h.activateActionScope(req)
+	if !ok {
+		h.failActionScopeConflict(req)
+		return
+	}
+	defer clearActionScope()
+
 	// v1.3: Session-aware dispatch. Thinking nodes use a node-scoped pool key
 	// while retaining the real Agent identity, workspace, and configuration.
 	var session *agent.Session
@@ -1325,6 +1377,34 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 	// Push done sentinel and close. The done event is consumed by SSE
 	// subscribers in order, eliminating the need for a delay.
 	h.pushEventJSON(req.TaskID, "done", map[string]interface{}{})
+	h.taskManager.CloseAllSubscribers(req.TaskID)
+}
+
+func (h *daemonHandler) activateActionScope(req runTaskRequest) (func(), bool) {
+	if req.RunID == "" {
+		return func() {}, true
+	}
+	scope := actionScope{
+		RunID:     req.RunID,
+		AgentID:   req.AgentID,
+		ChannelID: req.ChannelID,
+		ThreadID:  req.ThreadID,
+		NodeID:    req.NodeID,
+		TaskID:    req.OriginTaskID,
+	}
+	if !h.taskManager.SetActionScope(scope) {
+		return func() {}, false
+	}
+	return func() { h.taskManager.ClearActionScope(req.AgentID, req.RunID) }, true
+}
+
+func (h *daemonHandler) failActionScopeConflict(req runTaskRequest) {
+	errText := "another provider turn is already active for this agent"
+	h.taskManager.UpdateStatus(req.TaskID, taskStatusFailed)
+	h.notifyServerError(req, errText)
+	h.pushEventJSON(req.TaskID, "error", map[string]interface{}{
+		"agent_id": req.AgentID, "error": errText, "retryable": true,
+	})
 	h.taskManager.CloseAllSubscribers(req.TaskID)
 }
 

--- a/cmd/daemon/handler_test.go
+++ b/cmd/daemon/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/solo-ai/solo/internal/auth"
+	"github.com/solo-ai/solo/internal/causal"
 	"github.com/solo-ai/solo/pkg/agent"
 	"github.com/solo-ai/solo/pkg/llm"
 )
@@ -213,6 +215,118 @@ func TestCloneHTTPClientWithTimeoutPreservesTransport(t *testing.T) {
 	}
 	if original.Timeout != 10*time.Second {
 		t.Fatalf("original timeout changed to %s", original.Timeout)
+	}
+}
+
+func TestProxyMutationRequiresMatchingActiveTurn(t *testing.T) {
+	tm := newTaskManager()
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, "http://example.invalid", "")
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusConflict, resp.Body.String())
+	}
+
+	tm.SetActionScope(actionScope{RunID: "run-1", AgentID: "agent-1", ChannelID: "other-channel"})
+	req = httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"task_claim","channel_id":"channel-1","task_number":1
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	resp = httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusConflict {
+		t.Fatalf("wrong-channel status = %d, want %d; body=%s", resp.Code, http.StatusConflict, resp.Body.String())
+	}
+}
+
+func TestProxyMutationInjectsDaemonOwnedOriginRun(t *testing.T) {
+	var gotRunID string
+	var gotSignature string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRunID = r.Header.Get(causal.RunHeader)
+		gotSignature = r.Header.Get(causal.SignatureHeader)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"message-1"}`))
+	}))
+	defer upstream.Close()
+
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-actual", AgentID: "agent-1", ChannelID: "channel-1"})
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, upstream.URL, "test-internal-secret")
+	agentToken, err := auth.GenerateAgentToken("agent-1", "Agent One")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.agentTokens["agent-1"] = &agentTokenState{accessToken: agentToken, expiresAt: time.Now().Add(time.Hour)}
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("Authorization", "Bearer "+agentToken)
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusCreated, resp.Body.String())
+	}
+	if gotRunID != "run-actual" {
+		t.Fatalf("origin header = %q, want %q", gotRunID, "run-actual")
+	}
+	if !causal.Verify("test-internal-secret", gotRunID, "agent-1", "channel-1", gotSignature) {
+		t.Fatalf("invalid daemon origin signature %q", gotSignature)
+	}
+}
+
+func TestProxyRejectsCallerTokenForDifferentAgent(t *testing.T) {
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-1", AgentID: "agent-1", ChannelID: "channel-1"})
+	h := newDaemonHandler(nil, tm, fakeStreamProvider{}, "http://example.invalid", "test-internal-secret")
+	otherToken, err := auth.GenerateAgentToken("agent-2", "Agent Two")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", bytes.NewBufferString(`{
+		"agent_id":"agent-1","action":"message_send","channel_id":"channel-1","content":"hello"
+	}`))
+	req.RemoteAddr = "127.0.0.1:12345"
+	req.Header.Set("Authorization", "Bearer "+otherToken)
+	resp := httptest.NewRecorder()
+	h.ProxyRequest(resp, req)
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body=%s", resp.Code, http.StatusUnauthorized, resp.Body.String())
+	}
+}
+
+func TestClearActionScopeDoesNotDeleteNewerTurn(t *testing.T) {
+	tm := newTaskManager()
+	tm.SetActionScope(actionScope{RunID: "run-old", AgentID: "agent-1"})
+	tm.ClearActionScope("agent-1", "run-old")
+	tm.SetActionScope(actionScope{RunID: "run-new", AgentID: "agent-1"})
+	tm.ClearActionScope("agent-1", "run-old")
+
+	scope, ok := tm.GetActionScope("agent-1")
+	if !ok || scope.RunID != "run-new" {
+		t.Fatalf("scope = %+v, ok=%v; want run-new", scope, ok)
+	}
+}
+
+func TestSetActionScopeRejectsConcurrentTurn(t *testing.T) {
+	tm := newTaskManager()
+	if !tm.SetActionScope(actionScope{RunID: "run-old", AgentID: "agent-1"}) {
+		t.Fatal("first scope was rejected")
+	}
+	if tm.SetActionScope(actionScope{RunID: "run-new", AgentID: "agent-1"}) {
+		t.Fatal("concurrent scope was accepted")
+	}
+	scope, ok := tm.GetActionScope("agent-1")
+	if !ok || scope.RunID != "run-old" {
+		t.Fatalf("scope = %+v, ok=%v; want run-old", scope, ok)
 	}
 }
 

--- a/cmd/daemon/task.go
+++ b/cmd/daemon/task.go
@@ -46,6 +46,15 @@ type sseSubscriber struct {
 	done   chan struct{}
 }
 
+type actionScope struct {
+	RunID     string
+	AgentID   string
+	ChannelID string
+	ThreadID  string
+	NodeID    string
+	TaskID    string
+}
+
 // taskManager manages task states and SSE subscribers in the daemon.
 type taskManager struct {
 	mu           sync.RWMutex
@@ -53,6 +62,7 @@ type taskManager struct {
 	subscribers  map[string][]*sseSubscriber   // taskID -> subscribers
 	eventHistory map[string][]sseEvent         // taskID -> replayable SSE control events
 	cancelFuncs  map[string]context.CancelFunc // taskID -> cancel func
+	actionScopes map[string]actionScope        // agentID -> current provider turn
 }
 
 // newTaskManager creates a new task manager.
@@ -62,6 +72,35 @@ func newTaskManager() *taskManager {
 		subscribers:  make(map[string][]*sseSubscriber),
 		eventHistory: make(map[string][]sseEvent),
 		cancelFuncs:  make(map[string]context.CancelFunc),
+		actionScopes: make(map[string]actionScope),
+	}
+}
+
+func (tm *taskManager) SetActionScope(scope actionScope) bool {
+	if scope.AgentID == "" || scope.RunID == "" {
+		return false
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if _, exists := tm.actionScopes[scope.AgentID]; exists {
+		return false
+	}
+	tm.actionScopes[scope.AgentID] = scope
+	return true
+}
+
+func (tm *taskManager) GetActionScope(agentID string) (actionScope, bool) {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+	scope, ok := tm.actionScopes[agentID]
+	return scope, ok
+}
+
+func (tm *taskManager) ClearActionScope(agentID, runID string) {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if scope, ok := tm.actionScopes[agentID]; ok && scope.RunID == runID {
+		delete(tm.actionScopes, agentID)
 	}
 }
 

--- a/internal/causal/origin.go
+++ b/internal/causal/origin.go
@@ -1,0 +1,37 @@
+package causal
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+)
+
+const (
+	RunHeader       = "X-Solo-Origin-Run-ID"
+	SignatureHeader = "X-Solo-Origin-Signature"
+)
+
+func SharedSecret() string {
+	if secret := os.Getenv("INTERNAL_TOKEN_SECRET"); secret != "" {
+		return secret
+	}
+	return os.Getenv("JWT_SECRET")
+}
+
+func Sign(secret, runID, actorID, channelID string) string {
+	if secret == "" || runID == "" || actorID == "" || channelID == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(runID + "\n" + actorID + "\n" + channelID))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func Verify(secret, runID, actorID, channelID, signature string) bool {
+	expected := Sign(secret, runID, actorID, channelID)
+	if expected == "" || signature == "" {
+		return false
+	}
+	return hmac.Equal([]byte(expected), []byte(signature))
+}

--- a/internal/causal/origin_test.go
+++ b/internal/causal/origin_test.go
@@ -1,0 +1,28 @@
+package causal
+
+import "testing"
+
+func TestOriginSignatureBindsRunActorAndChannel(t *testing.T) {
+	signature := Sign("secret", "run-1", "agent-1", "channel-1")
+	if !Verify("secret", "run-1", "agent-1", "channel-1", signature) {
+		t.Fatal("valid origin signature was rejected")
+	}
+	for _, altered := range []struct{ run, actor, channel string }{
+		{"run-2", "agent-1", "channel-1"},
+		{"run-1", "agent-2", "channel-1"},
+		{"run-1", "agent-1", "channel-2"},
+	} {
+		if Verify("secret", altered.run, altered.actor, altered.channel, signature) {
+			t.Fatalf("altered origin was accepted: %+v", altered)
+		}
+	}
+}
+
+func TestOriginSignatureRejectsMissingSecretOrSignature(t *testing.T) {
+	if Sign("", "run-1", "agent-1", "channel-1") != "" {
+		t.Fatal("empty secret produced a signature")
+	}
+	if Verify("secret", "run-1", "agent-1", "channel-1", "") {
+		t.Fatal("empty signature was accepted")
+	}
+}

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -125,6 +125,7 @@ type MessageResponse struct {
 	TaskClaimerDeleted bool             `json:"task_claimer_deleted"`
 	HasUnreadThread    bool             `json:"has_unread_thread,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
+	OriginRunID        string           `json:"origin_run_id,omitempty"`
 }
 
 type MessageListResponse struct {
@@ -214,6 +215,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		`SELECT EXISTS(SELECT 1 FROM agents WHERE id = $1)`, userID,
 	).Scan(&isAgent)
 	senderType := "user"
+	originRunID := strings.TrimSpace(r.Header.Get(service.OriginRunHeader))
 	if isAgent {
 		senderType = "agent"
 		thinkingNodeID, err = reconcileThinkingNodeScope(r.Context(), h.pool, userID, channelID, thinkingNodeID)
@@ -221,6 +223,12 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeThinkingScopeError(w, err)
 			return
 		}
+		if err := service.NewAgentRunService(h.pool).ValidateActionOrigin(r.Context(), originRunID, r.Header.Get(service.OriginSignatureHeader), userID, channelID); err != nil {
+			writeError(w, http.StatusConflict, "origin run does not match active Agent runtime")
+			return
+		}
+	} else {
+		originRunID = ""
 	}
 	if thinkingNodeID != "" && (req.ThreadID != "" || req.AsTask) {
 		writeError(w, http.StatusBadRequest, "thinking node messages cannot also be threads or tasks")
@@ -404,9 +412,9 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		nullableThreadID = threadID
 	}
 	_, err = h.pool.Exec(r.Context(),
-		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::uuid[], $9::uuid[], $10, $10)`,
-		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), now,
+		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, origin_run_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::uuid[], $10::uuid[], $11, $11)`,
+		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), nullableUUIDString(originRunID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), now,
 	)
 	if err != nil {
 		slog.Error("failed to persist message", "error", err)
@@ -485,6 +493,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 				SenderName:    displayName,
 				Content:       content,
 				ContentType:   "text",
+				OriginRunID:   originRunID,
 				AttachmentIDs: attachmentIDs,
 				Attachments:   toWSAttachmentMeta(attachments),
 				CreatedAt:     now.UTC().Format(time.RFC3339),
@@ -558,6 +567,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			ContentType:       "text",
 			ThreadID:          threadID,
 			ThinkingNodeID:    thinkingNodeID,
+			OriginRunID:       originRunID,
 			MentionedAgentIDs: mentionedAgentIDs,
 			AttachmentIDs:     attachmentIDs,
 			Attachments:       toWSAttachmentMeta(attachments),
@@ -610,7 +620,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	resp := MessageResponse{
 		ID:                messageID,
 		ChannelID:         channelID,
-		SenderType:        "user",
+		SenderType:        senderType,
 		SenderID:          userID,
 		SenderName:        displayName,
 		Content:           content,
@@ -619,6 +629,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs:     attachmentIDs,
 		Attachments:       attachments,
 		ThinkingNodeID:    thinkingNodeID,
+		OriginRunID:       originRunID,
 		CreatedAt:         now.Format(time.RFC3339),
 	}
 
@@ -737,6 +748,7 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		                 END as sender_name,
 		                 COALESCE(a.is_active, false) AS sender_active,
 		                 COALESCE(m.thinking_node_id::text, '') AS thinking_node_id,
+		                 COALESCE(m.origin_run_id::text, '') AS origin_run_id,
 	                 m.content, m.content_type, COALESCE(m.attachment_ids, '{}') as attachment_ids, m.created_at,
 		                 COALESCE(t.reply_count, 0) AS reply_count,
 		                 COALESCE(tasks.task_number, 0) AS task_number,
@@ -783,7 +795,7 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		var msg MessageResponse
 		var createdAt time.Time
 		err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.SenderType, &msg.SenderID,
-			&msg.SenderName, &msg.SenderActive, &msg.ThinkingNodeID, &msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt,
+			&msg.SenderName, &msg.SenderActive, &msg.ThinkingNodeID, &msg.OriginRunID, &msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt,
 			&msg.ReplyCount, &msg.TaskNumber, &msg.TaskStatus, &msg.TaskClaimerName, &msg.TaskClaimerDeleted, &msg.HasUnreadThread)
 		if err != nil {
 			slog.Error("failed to scan message row", "error", err)
@@ -1093,6 +1105,7 @@ func (h *MessageHandler) broadcastDMIfNeeded(channelID string, msg ws.MessageNew
 		AttachmentIDs: msg.AttachmentIDs,
 		Attachments:   msg.Attachments,
 		ThreadID:      msg.ThreadID,
+		OriginRunID:   msg.OriginRunID,
 		CreatedAt:     msg.CreatedAt,
 	}
 	h.hub.BroadcastToChannel(channelID, ws.Envelope(ws.EventDMMessageNew, dmPayload))

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -548,7 +548,11 @@ func (h *TaskHandler) Claim(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	task, err := h.svc.ClaimTask(r.Context(), channelID, t.ID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "claim")
+	if !ok {
+		return
+	}
+	task, err := h.svc.ClaimTask(actionCtx, channelID, t.ID, userID)
 	if err != nil {
 		switch {
 		case err == service.ErrTaskNotFound:
@@ -631,7 +635,11 @@ func (h *TaskHandler) Unclaim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	task, err := h.svc.UnclaimTask(r.Context(), channelID, t.ID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "unclaim")
+	if !ok {
+		return
+	}
+	task, err := h.svc.UnclaimTask(actionCtx, channelID, t.ID, userID)
 	if err != nil {
 		switch {
 		case err == service.ErrTaskNotFound:
@@ -688,11 +696,11 @@ func (h *TaskHandler) Unclaim(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *TaskHandler) Submit(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.SubmitTask)
+	h.lifecycleAction(w, r, "submit", h.svc.SubmitTask)
 }
 
 func (h *TaskHandler) Accept(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.AcceptTask)
+	h.lifecycleAction(w, r, "accept", h.svc.AcceptTask)
 }
 
 func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
@@ -714,7 +722,11 @@ func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	task, err := h.svc.RejectTask(r.Context(), channelID, taskID, userID, strings.TrimSpace(req.Reason))
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, "reject")
+	if !ok {
+		return
+	}
+	task, err := h.svc.RejectTask(actionCtx, channelID, taskID, userID, strings.TrimSpace(req.Reason))
 	if err != nil {
 		h.writeTaskLifecycleError(w, err)
 		return
@@ -723,11 +735,11 @@ func (h *TaskHandler) Reject(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *TaskHandler) Close(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.CloseTask)
+	h.lifecycleAction(w, r, "close", h.svc.CloseTask)
 }
 
 func (h *TaskHandler) Reopen(w http.ResponseWriter, r *http.Request) {
-	h.lifecycleAction(w, r, h.svc.ReopenTask)
+	h.lifecycleAction(w, r, "reopen", h.svc.ReopenTask)
 }
 
 func (h *TaskHandler) AcceptGlobal(w http.ResponseWriter, r *http.Request) {
@@ -765,6 +777,7 @@ func (h *TaskHandler) ReopenGlobal(w http.ResponseWriter, r *http.Request) {
 func (h *TaskHandler) lifecycleAction(
 	w http.ResponseWriter,
 	r *http.Request,
+	actionName string,
 	action func(context.Context, string, string, string) (*service.Task, error),
 ) {
 	userID, ok := requireUserID(r)
@@ -779,13 +792,33 @@ func (h *TaskHandler) lifecycleAction(
 		return
 	}
 
-	task, err := action(r.Context(), channelID, taskID, userID)
+	actionCtx, ok := h.taskActionContext(w, r, userID, channelID, actionName)
+	if !ok {
+		return
+	}
+	task, err := action(actionCtx, channelID, taskID, userID)
 	if err != nil {
 		h.writeTaskLifecycleError(w, err)
 		return
 	}
 
 	h.writeTaskUpdate(w, task)
+}
+
+func (h *TaskHandler) taskActionContext(w http.ResponseWriter, r *http.Request, actorID, channelID, action string) (context.Context, bool) {
+	runID := strings.TrimSpace(r.Header.Get(service.OriginRunHeader))
+	if runID == "" {
+		return r.Context(), true
+	}
+	if err := service.NewAgentRunService(h.pool).ValidateActionOrigin(r.Context(), runID, r.Header.Get(service.OriginSignatureHeader), actorID, channelID); err != nil {
+		writeError(w, http.StatusConflict, "origin run is not the active agent turn")
+		return nil, false
+	}
+	return service.WithTaskActionOrigin(r.Context(), service.TaskActionOrigin{
+		RunID:   runID,
+		ActorID: actorID,
+		Action:  action,
+	}), true
 }
 
 func (h *TaskHandler) lifecycleActionGlobal(
@@ -838,6 +871,8 @@ func (h *TaskHandler) writeTaskLifecycleError(w http.ResponseWriter, err error) 
 		writeError(w, http.StatusConflict, err.Error())
 	case err == service.ErrTaskReasonRequired:
 		writeError(w, http.StatusBadRequest, err.Error())
+	case err == service.ErrInvalidAgentRunOrigin:
+		writeError(w, http.StatusConflict, err.Error())
 	default:
 		slog.Error("failed task lifecycle action", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to update task")

--- a/internal/server/handler/thread.go
+++ b/internal/server/handler/thread.go
@@ -64,6 +64,7 @@ type ThreadReplyResponse struct {
 	SenderActive  bool             `json:"sender_active"`
 	Content       string           `json:"content"`
 	ContentType   string           `json:"content_type"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
@@ -472,7 +473,8 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 	query := `SELECT m.id, m.channel_id, m.thread_id, m.sender_type, m.sender_id,
 	                 COALESCE(u.display_name, a.name, '') as sender_name,
 	                 COALESCE(a.is_active, false) AS sender_active,
-	                 m.content, m.content_type, COALESCE(m.attachment_ids, '{}') as attachment_ids,
+	                 m.content, m.content_type, COALESCE(m.origin_run_id::text, '') AS origin_run_id,
+	                 COALESCE(m.attachment_ids, '{}') as attachment_ids,
                  m.created_at
 	          FROM messages m
 	          LEFT JOIN users u ON m.sender_type = 'user' AND m.sender_id = u.id
@@ -506,7 +508,7 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 		err := rows.Scan(&msg.ID, &msg.ChannelID, &msg.ThreadID,
 			&msg.SenderType, &msg.SenderID, &msg.SenderName,
 			&msg.SenderActive,
-			&msg.Content, &msg.ContentType, &msg.AttachmentIDs, &createdAt)
+			&msg.Content, &msg.ContentType, &msg.OriginRunID, &msg.AttachmentIDs, &createdAt)
 		if err != nil {
 			slog.Error("failed to scan thread message row", "error", err)
 			continue

--- a/internal/server/service/agent_run.go
+++ b/internal/server/service/agent_run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/solo-ai/solo/internal/causal"
 	agentruntime "github.com/solo-ai/solo/pkg/agent"
 )
 
@@ -72,6 +73,12 @@ var nonPrimaryTaskRunStatuses = []string{
 var (
 	ErrAmbiguousAgentRunScope  = errors.New("multiple executing runs for one Agent and channel")
 	ErrAgentRunAlreadyFinished = errors.New("agent run already finished")
+	ErrInvalidAgentRunOrigin   = errors.New("origin run does not match active Agent runtime")
+)
+
+const (
+	OriginRunHeader       = causal.RunHeader
+	OriginSignatureHeader = causal.SignatureHeader
 )
 
 type AgentSession struct {
@@ -478,6 +485,51 @@ func (s *AgentRunService) LinkTask(ctx context.Context, input LinkRunTaskInput) 
 		input.RunID, input.TaskID, input.Role, input.Confidence,
 	)
 	return err
+}
+
+func (s *AgentRunService) ValidateActionRun(ctx context.Context, runID, agentID, channelID string) error {
+	if runID == "" {
+		return nil
+	}
+	var valid bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM agent_runs
+			 WHERE id = $1 AND agent_id = $2 AND channel_id = $3
+			   AND finished_at IS NULL
+			   AND status = ANY($4)
+		)`,
+		runID,
+		agentID,
+		channelID,
+		executingAgentRunStatuses(),
+	).Scan(&valid)
+	if err != nil {
+		return err
+	}
+	if !valid {
+		return ErrInvalidAgentRunOrigin
+	}
+	return nil
+}
+
+func (s *AgentRunService) ValidateActionOrigin(ctx context.Context, runID, signature, agentID, channelID string) error {
+	if runID == "" {
+		return nil
+	}
+	if !causal.Verify(causal.SharedSecret(), runID, agentID, channelID, signature) {
+		return ErrInvalidAgentRunOrigin
+	}
+	return s.ValidateActionRun(ctx, runID, agentID, channelID)
+}
+
+func safeRunTaskAction(action string) bool {
+	switch action {
+	case "claim", "unclaim", "submit", "accept", "reject", "close", "reopen":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *AgentRunService) FinishRun(ctx context.Context, input FinishRunInput) (*AgentRun, error) {

--- a/internal/server/service/task.go
+++ b/internal/server/service/task.go
@@ -82,6 +82,41 @@ var (
 	ErrTaskLifecyclePatch    = errors.New("task lifecycle status changes must use lifecycle endpoints")
 )
 
+type taskActionOriginKey struct{}
+
+type TaskActionOrigin struct {
+	RunID   string
+	ActorID string
+	Action  string
+}
+
+func WithTaskActionOrigin(ctx context.Context, origin TaskActionOrigin) context.Context {
+	if origin.RunID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, taskActionOriginKey{}, origin)
+}
+
+func recordTaskActionInTx(ctx context.Context, tx pgx.Tx, taskID string) error {
+	origin, ok := ctx.Value(taskActionOriginKey{}).(TaskActionOrigin)
+	if !ok || origin.RunID == "" {
+		return nil
+	}
+	if !safeRunTaskAction(origin.Action) || origin.ActorID == "" {
+		return ErrInvalidAgentRunOrigin
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_run_task_links (run_id, task_id, role, confidence)
+		VALUES ($1, $2, 'executor', 1)
+		ON CONFLICT (run_id, task_id) DO NOTHING`, origin.RunID, taskID); err != nil {
+		return err
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO agent_run_task_actions (run_id, task_id, actor_id, action)
+		VALUES ($1, $2, $3, $4)`, origin.RunID, taskID, origin.ActorID, origin.Action)
+	return err
+}
+
 // Task represents a task in a channel.
 type Task struct {
 	ID               string     `json:"id"`
@@ -428,6 +463,9 @@ func (s *TaskService) ClaimTask(ctx context.Context, channelID, taskID, userID s
 	if err != nil {
 		return nil, fmt.Errorf("update claim: %w", err)
 	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record claim origin: %w", err)
+	}
 
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("commit: %w", err)
@@ -457,29 +495,41 @@ func (s *TaskService) UnclaimTask(ctx context.Context, channelID, taskID, userID
 		return nil, err
 	}
 
-	current, err := s.GetTask(ctx, channelID, taskID, userID)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	if current.ClaimerID == "" {
+	defer tx.Rollback(ctx)
+	var currentStatus, currentClaimerID string
+	if err := tx.QueryRow(ctx, `
+		SELECT status, COALESCE(claimer_id::text, '')
+		  FROM tasks WHERE id = $1 AND channel_id = $2 FOR UPDATE`, taskID, channelID,
+	).Scan(&currentStatus, &currentClaimerID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrTaskNotFound
+		}
+		return nil, err
+	}
+	if currentClaimerID == "" || currentClaimerID != userID {
 		return nil, ErrTaskNotClaimer
 	}
-	if current.ClaimerID != userID {
-		return nil, ErrTaskNotClaimer
-	}
-
-	if TerminalStatuses[current.Status] {
+	if TerminalStatuses[currentStatus] {
 		return nil, ErrTaskInTerminalState
 	}
 
 	now := time.Now()
-	_, err = s.pool.Exec(ctx,
+	_, err = tx.Exec(ctx,
 		`UPDATE tasks SET claimer_id = NULL, status = $1, updated_at = $2
 		 WHERE id = $3 AND channel_id = $4`,
 		TaskStatusTodo, now, taskID, channelID,
 	)
 	if err != nil {
+		return nil, err
+	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record unclaim origin: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return nil, err
 	}
 
@@ -540,6 +590,9 @@ func (s *TaskService) SubmitTask(ctx context.Context, channelID, taskID, userID 
 	}
 	if _, err := tx.Exec(ctx, `UPDATE tasks SET status = $1, updated_at = now() WHERE id = $2`, TaskStatusInReview, task.ID); err != nil {
 		return nil, err
+	}
+	if err := recordTaskActionInTx(ctx, tx, task.ID); err != nil {
+		return nil, fmt.Errorf("record submit origin: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err
@@ -659,7 +712,12 @@ func (s *TaskService) setTaskStatus(ctx context.Context, channelID, taskID, user
 	if err := s.requireChannelMember(ctx, channelID, userID); err != nil {
 		return nil, err
 	}
-	tag, err := s.pool.Exec(ctx,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	tag, err := tx.Exec(ctx,
 		`UPDATE tasks SET status = $1, updated_at = now() WHERE id = $2 AND channel_id = $3`,
 		status, taskID, channelID,
 	)
@@ -668,6 +726,12 @@ func (s *TaskService) setTaskStatus(ctx context.Context, channelID, taskID, user
 	}
 	if tag.RowsAffected() == 0 {
 		return nil, ErrTaskNotFound
+	}
+	if err := recordTaskActionInTx(ctx, tx, taskID); err != nil {
+		return nil, fmt.Errorf("record task action origin: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
 	}
 	return s.GetTask(ctx, channelID, taskID, userID)
 }

--- a/internal/server/service/task_causal_evidence_test.go
+++ b/internal/server/service/task_causal_evidence_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestTaskMutationRecordsCausalEvidenceAtomically(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		VALUES ($1, 'user', $2, 'owner'), ($1, 'agent', $3, 'member')`, channelID, ownerID, agentID); err != nil {
+		t.Fatalf("add members: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	taskSvc := NewTaskService(pool)
+	task, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "causal task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	run, err := NewAgentRunService(pool).StartRun(ctx, StartRunInput{
+		AgentID: agentID, TriggerType: AgentRunTriggerTask, ChannelID: channelID,
+		Status: AgentRunStatusRunning, ActivityText: "working",
+	})
+	if err != nil {
+		t.Fatalf("start run: %v", err)
+	}
+
+	claimCtx := WithTaskActionOrigin(ctx, TaskActionOrigin{RunID: run.ID, ActorID: agentID, Action: "claim"})
+	claimed, err := taskSvc.ClaimTask(claimCtx, channelID, task.ID, agentID)
+	if err != nil {
+		t.Fatalf("claim task: %v", err)
+	}
+	if claimed.Status != TaskStatusInProgress || claimed.ClaimerID != agentID {
+		t.Fatalf("claimed task = %+v", claimed)
+	}
+	var actionCount, linkCount int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_actions WHERE run_id = $1 AND task_id = $2 AND action = 'claim'`, run.ID, task.ID).Scan(&actionCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_links WHERE run_id = $1 AND task_id = $2 AND role = 'executor'`, run.ID, task.ID).Scan(&linkCount); err != nil {
+		t.Fatal(err)
+	}
+	if actionCount != 1 || linkCount != 1 {
+		t.Fatalf("action_count=%d link_count=%d, want 1/1", actionCount, linkCount)
+	}
+}
+
+func TestTaskMutationRollsBackWhenCausalEvidenceCannotBeStored(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO channel_members (channel_id, member_type, member_id, role)
+		VALUES ($1, 'user', $2, 'owner'), ($1, 'agent', $3, 'member')`, channelID, ownerID, agentID); err != nil {
+		t.Fatalf("add members: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	taskSvc := NewTaskService(pool)
+	task, err := taskSvc.CreateTask(ctx, channelID, ownerID, TaskCreateRequest{Title: "rollback task"})
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	badRunID := uuid.NewString()
+	claimCtx := WithTaskActionOrigin(ctx, TaskActionOrigin{RunID: badRunID, ActorID: agentID, Action: "claim"})
+	if _, err := taskSvc.ClaimTask(claimCtx, channelID, task.ID, agentID); err == nil {
+		t.Fatal("claim unexpectedly succeeded with missing origin run")
+	}
+
+	unchanged, err := taskSvc.GetTask(ctx, channelID, task.ID, ownerID)
+	if err != nil {
+		t.Fatalf("reload task: %v", err)
+	}
+	if unchanged.Status != TaskStatusTodo || unchanged.ClaimerID != "" {
+		t.Fatalf("task mutation was not rolled back: %+v", unchanged)
+	}
+	var actionCount, linkCount int
+	_ = pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_actions WHERE task_id = $1`, task.ID).Scan(&actionCount)
+	_ = pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_run_task_links WHERE task_id = $1`, task.ID).Scan(&linkCount)
+	if actionCount != 0 || linkCount != 0 {
+		t.Fatalf("partial evidence remained: action_count=%d link_count=%d", actionCount, linkCount)
+	}
+}

--- a/internal/server/ws/message.go
+++ b/internal/server/ws/message.go
@@ -157,6 +157,7 @@ type MessageNewPayload struct {
 	ContentType        string           `json:"content_type"`
 	ThreadID           string           `json:"thread_id,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
+	OriginRunID        string           `json:"origin_run_id,omitempty"`
 	MentionedAgentIDs  []string         `json:"mentioned_agent_ids,omitempty"`
 	AttachmentIDs      []string         `json:"attachment_ids,omitempty"`
 	Attachments        []AttachmentMeta `json:"attachments,omitempty"`
@@ -253,6 +254,7 @@ type ThreadMessageItem struct {
 	SenderName    string           `json:"sender_name,omitempty"`
 	Content       string           `json:"content"`
 	ContentType   string           `json:"content_type"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
@@ -334,6 +336,7 @@ type DMMessageNewPayload struct {
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	ThreadID      string           `json:"thread_id,omitempty"`
+	OriginRunID   string           `json:"origin_run_id,omitempty"`
 	CreatedAt     string           `json:"created_at"`
 }
 

--- a/migrations/000034_add_agent_run_causal_evidence.down.sql
+++ b/migrations/000034_add_agent_run_causal_evidence.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS agent_run_task_actions;
+DROP INDEX IF EXISTS idx_messages_origin_run;
+ALTER TABLE messages DROP COLUMN IF EXISTS origin_run_id;

--- a/migrations/000034_add_agent_run_causal_evidence.up.sql
+++ b/migrations/000034_add_agent_run_causal_evidence.up.sql
@@ -1,0 +1,21 @@
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS origin_run_id UUID REFERENCES agent_runs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_messages_origin_run
+    ON messages(origin_run_id, created_at ASC)
+    WHERE origin_run_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS agent_run_task_actions (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    run_id     UUID NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    task_id    UUID NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+    actor_id   UUID NOT NULL,
+    action     TEXT NOT NULL CHECK (action IN ('claim', 'unclaim', 'submit', 'accept', 'reject', 'close', 'reopen')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_task_actions_task_created
+    ON agent_run_task_actions(task_id, created_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_task_actions_run_created
+    ON agent_run_task_actions(run_id, created_at ASC);


### PR DESCRIPTION
## Summary

This PR replaces the old mixed #55 draft with a causal-only change. It makes Agent-originated messages and task lifecycle mutations attributable to the active Agent run that caused them. The daemon, not the Agent process, owns the active run scope and forwards a signed origin header to the server when the Agent mutates Solo state.

Refs #59. Supersedes #55.

## What Changed

- Added `internal/causal` HMAC helpers for daemon-to-server origin headers.
- Added `messages.origin_run_id`.
- Added `agent_run_task_actions` receipts for task lifecycle mutations.
- Added daemon-side active action scopes keyed by Agent ID.
- Made proxy mutations fail closed unless they match the active provider turn.
- Injected signed `X-Solo-Origin-Run-ID` and `X-Solo-Origin-Signature` headers from daemon proxy requests.
- Validated origin headers on server against the active run, actor Agent, and channel.
- Stored `origin_run_id` on Agent messages; human callers cannot spoof it.
- Recorded task action receipts in the same transaction as task state changes.
- Exposed optional `origin_run_id` in channel/thread/DM WebSocket/read responses.

## Out Of Scope

- No `task trajectory` schema changes.
- No CLI trajectory changes.
- No timestamp/latest-run inference.
- No raw message content or transcript export changes.

## Validation

```bash
git diff --check
go test ./internal/causal ./cmd/daemon ./internal/server/service ./internal/server/handler ./internal/server/ws -count=1
go test ./... -count=1
```
