### PR TITLE
feat: sliding timeout, lifecycle mode, fan-out, resume, push notifications, context pressure

### DIFF
--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -454,6 +454,8 @@ func handleTask(args []string, baseURL, token string) {
 		handleTaskCreate(args[1:], baseURL, token)
 	case "unclaim":
 		handleTaskUnclaim(args[1:], baseURL, token)
+	case "fan":
+		handleTaskFan(args[1:], baseURL, token)
 	case "submit", "accept", "reject", "close", "reopen":
 		handleTaskLifecycle(args[1:], baseURL, token, args[0])
 	default:
@@ -808,6 +810,79 @@ func handleTaskLifecycle(args []string, baseURL, token, action string) {
 // ---------------------------------------------------------------------------
 // message
 // ---------------------------------------------------------------------------
+
+// --- task fan ---
+
+func handleTaskFan(args []string, baseURL, token string) {
+	var channel, title, description, priority, agentsStr string
+	fs := flag.NewFlagSet("task fan", flag.ExitOnError)
+	fs.StringVar(&channel, "c", "", "Channel ID or #name (required)")
+	fs.StringVar(&channel, "channel", "", "Channel ID or #name (required)")
+	fs.StringVar(&title, "title", "", "Parent task title (required)")
+	fs.StringVar(&description, "description", "", "Task description")
+	fs.StringVar(&priority, "priority", "", "Task priority: p0|p1|p2|p3")
+	fs.StringVar(&agentsStr, "agents", "", "Comma-separated @agent names: @fe,@be,@qa")
+	fs.Parse(args)
+
+	if channel == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: -c <channel_id> is required")
+		doExit(exitUsage)
+	}
+	if title == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: --title is required")
+		doExit(exitUsage)
+	}
+	if agentsStr == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: --agents is required (e.g. --agents @fe,@be)")
+		doExit(exitUsage)
+	}
+
+	channelID, resolveErr := resolveChannelParam(baseURL, token, channel)
+	if resolveErr != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", resolveErr)
+		doExit(exitBusiness)
+	}
+
+	agentNames := parseAgentFanList(agentsStr)
+	if len(agentNames) == 0 {
+		fmt.Fprintln(os.Stderr, "solo: error: no valid agent names found in --agents")
+		doExit(exitUsage)
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"title":       title,
+		"description": description,
+		"priority":    priority,
+		"agents":      agentNames,
+	})
+	url := fmt.Sprintf("%s/api/v1/channels/%s/tasks/fan", baseURL, channelID)
+	statusCode, respBody, err := doHTTP(http.MethodPost, url, token, body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
+		doExit(exitUsage)
+	}
+
+	if statusCode >= 400 {
+		handleNonProxyHTTPError(statusCode, respBody)
+	}
+
+	fmt.Println(string(respBody))
+	doExit(exitOK)
+}
+
+// parseAgentFanList splits "--agents @fe,@be,@qa" into ["fe","be","qa"].
+func parseAgentFanList(s string) []string {
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		p = strings.TrimPrefix(p, "@")
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
 
 func handleMessage(args []string, baseURL, token string) {
 	if len(args) < 1 {

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -38,6 +38,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"strconv"
 
 	"strings"
@@ -456,6 +457,8 @@ func handleTask(args []string, baseURL, token string) {
 		handleTaskUnclaim(args[1:], baseURL, token)
 	case "fan":
 		handleTaskFan(args[1:], baseURL, token)
+	case "pr":
+		handleTaskPR(args[1:], baseURL, token)
 	case "submit", "accept", "reject", "close", "reopen":
 		handleTaskLifecycle(args[1:], baseURL, token, args[0])
 	default:
@@ -882,6 +885,78 @@ func parseAgentFanList(s string) []string {
 		}
 	}
 	return result
+}
+
+// --- task pr ---
+
+func handleTaskPR(args []string, baseURL, token string) {
+	var channel string
+	var number int
+	var base string
+	fs := flag.NewFlagSet("task pr", flag.ExitOnError)
+	fs.StringVar(&channel, "c", "", "Channel ID or #name (required)")
+	fs.StringVar(&channel, "channel", "", "Channel ID or #name (required)")
+	fs.IntVar(&number, "n", 0, "Task number (required)")
+	fs.IntVar(&number, "number", 0, "Task number (required)")
+	fs.StringVar(&base, "base", "main", "Base branch for PR (default: main)")
+	fs.Parse(args)
+
+	if channel == "" {
+		fmt.Fprintln(os.Stderr, "solo: error: -c <channel_id> is required")
+		doExit(exitUsage)
+	}
+	if number <= 0 {
+		fmt.Fprintln(os.Stderr, "solo: error: -n <number> must be a positive integer")
+		doExit(exitUsage)
+	}
+
+	channelID, resolveErr := resolveChannelParam(baseURL, token, channel)
+	if resolveErr != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: %v\n", resolveErr)
+		doExit(exitBusiness)
+	}
+
+	// 1. Get task details
+	apiURL := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%d", baseURL, channelID, number)
+	statusCode, body, err := doHTTP(http.MethodGet, apiURL, token, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
+		doExit(exitUsage)
+	}
+	if statusCode >= 400 {
+		handleNonProxyHTTPError(statusCode, body)
+	}
+
+	var task struct {
+		ID         string `json:"id"`
+		TaskNumber int    `json:"task_number"`
+		Title      string `json:"title"`
+		Status     string `json:"status"`
+	}
+	if err := json.Unmarshal(body, &task); err != nil {
+		fmt.Fprintf(os.Stderr, "solo: error: failed to parse task: %v\n", err)
+		doExit(exitBusiness)
+	}
+
+	// 2. Try gh CLI first
+	branch := fmt.Sprintf("solo/task-%d", task.TaskNumber)
+	prTitle := fmt.Sprintf("Solo Task #%d: %s", task.TaskNumber, task.Title)
+	prBody := fmt.Sprintf("Closes solo task #%d\n\nStatus: %s", task.TaskNumber, task.Status)
+
+	ghArgs := []string{"pr", "create", "--base", base, "--head", branch, "--title", prTitle, "--body", prBody}
+	cmd := exec.Command("gh", ghArgs...)
+	output, ghErr := cmd.CombinedOutput()
+	if ghErr == nil {
+		fmt.Printf("PR created: %s\n", strings.TrimSpace(string(output)))
+		doExit(exitOK)
+	}
+
+	// 3. Fallback: instruct user to push and open manually
+	fmt.Fprintf(os.Stderr, "solo: gh CLI not available or failed: %v\n", ghErr)
+	fmt.Fprintf(os.Stderr, "solo: to create a PR manually:\n")
+	fmt.Fprintf(os.Stderr, "  git push origin %s\n", branch)
+	fmt.Fprintf(os.Stderr, "  Then open a PR with title: %s\n", prTitle)
+	doExit(exitBusiness)
 }
 
 func handleMessage(args []string, baseURL, token string) {

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -635,6 +635,7 @@ func handleTaskUpdate(args []string, baseURL, token string) {
 func handleTaskCreate(args []string, baseURL, token string) {
 	var channel, title, description, priority string
 	var parent int
+	var expectedDuration int
 	fs := flag.NewFlagSet("task create", flag.ExitOnError)
 	fs.StringVar(&channel, "c", "", "Channel ID or #name (required)")
 	fs.StringVar(&channel, "channel", "", "Channel ID or #name (required)")
@@ -642,6 +643,8 @@ func handleTaskCreate(args []string, baseURL, token string) {
 	fs.StringVar(&description, "description", "", "Task description")
 	fs.StringVar(&priority, "priority", "", "Task priority: p0|p1|p2|p3")
 	fs.IntVar(&parent, "parent", 0, "Parent task number")
+	fs.IntVar(&expectedDuration, "expected-duration", 0, "Custom execution timeout in minutes (max 120)")
+	fs.IntVar(&expectedDuration, "d", 0, "Custom execution timeout in minutes (max 120)")
 	fs.Parse(args)
 
 	if channel == "" {
@@ -660,6 +663,10 @@ func handleTaskCreate(args []string, baseURL, token string) {
 			doExit(exitUsage)
 		}
 	}
+	if expectedDuration < 0 || expectedDuration > 120 {
+		fmt.Fprintln(os.Stderr, "solo: error: --expected-duration must be 0-120")
+		doExit(exitUsage)
+	}
 
 	channelID, resolveErr := resolveChannelParam(baseURL, token, channel)
 	if resolveErr != nil {
@@ -667,10 +674,13 @@ func handleTaskCreate(args []string, baseURL, token string) {
 		doExit(exitBusiness)
 	}
 
-	bodyMap := map[string]string{
+	bodyMap := map[string]interface{}{
 		"title":       title,
 		"description": description,
 		"priority":    priority,
+	}
+	if expectedDuration > 0 {
+		bodyMap["expected_duration_minutes"] = expectedDuration
 	}
 
 	// Resolve --parent: look up the parent task by number in the channel to get its UUID.

--- a/frontend/lib/github.ts
+++ b/frontend/lib/github.ts
@@ -1,0 +1,22 @@
+/** Parse a GitHub issue URL into owner, repo, and issue number. */
+export interface GitHubIssueInfo {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+export function parseGitHubIssueURL(url: string): GitHubIssueInfo | null {
+  // Match: https://github.com/owner/repo/issues/123
+  const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)/);
+  if (!match) return null;
+  return {
+    owner: match[1],
+    repo: match[2],
+    number: parseInt(match[3], 10),
+  };
+}
+
+/** Format a GitHub issue reference for display. */
+export function formatGitHubIssueRef(info: GitHubIssueInfo): string {
+  return `[GH ${info.owner}/${info.repo}#${info.number}]`;
+}

--- a/frontend/lib/hooks/use-push-notifications.ts
+++ b/frontend/lib/hooks/use-push-notifications.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+interface UsePushNotificationsReturn {
+  isSubscribed: boolean;
+  permission: NotificationPermission;
+  subscribe: () => Promise<void>;
+  unsubscribe: () => Promise<void>;
+}
+
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export function usePushNotifications(): UsePushNotificationsReturn {
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission>('default');
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && 'Notification' in window) {
+      setPermission(Notification.permission);
+    }
+  }, []);
+
+  const subscribe = useCallback(async () => {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return;
+
+    const perm = await Notification.requestPermission();
+    setPermission(perm);
+    if (perm !== 'granted') return;
+
+    const registration = await navigator.serviceWorker.ready;
+
+    // Fetch VAPID public key from server
+    const token = localStorage.getItem('solo.auth_token');
+    const apiBase = localStorage.getItem('solo.api_url') || '';
+    const vapidResp = await fetch(`${apiBase}/api/v1/push/vapid-public-key`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!vapidResp.ok) return;
+    const { public_key } = await vapidResp.json();
+
+    const subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(public_key),
+    });
+
+    const subJSON = subscription.toJSON();
+    await fetch(`${apiBase}/api/v1/push/subscribe`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        endpoint: subscription.endpoint,
+        keys: subJSON.keys,
+      }),
+    });
+
+    setIsSubscribed(true);
+  }, []);
+
+  const unsubscribe = useCallback(async () => {
+    if (!('serviceWorker' in navigator)) return;
+
+    const registration = await navigator.serviceWorker.ready;
+    const subscription = await registration.pushManager.getSubscription();
+    if (!subscription) return;
+
+    await subscription.unsubscribe();
+
+    const token = localStorage.getItem('solo.auth_token');
+    const apiBase = localStorage.getItem('solo.api_url') || '';
+    await fetch(`${apiBase}/api/v1/push/unsubscribe`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    });
+
+    setIsSubscribed(false);
+  }, []);
+
+  return { isSubscribed, permission, subscribe, unsubscribe };
+}

--- a/frontend/lib/ws-types.ts
+++ b/frontend/lib/ws-types.ts
@@ -91,7 +91,9 @@ export type WSServerEvent =
   // ---- Inbox events (v1.5) ----
   | { type: 'inbox.updated'; }
   // ---- Lucy automatic team formation ----
-  | { type: 'team.formed'; formation_id: string; source_channel_id: string; source_message_id: string; channel_id: string; channel_name: string; member_count: number; relationship_count: number; template_id: string; relationship_docs_ready: boolean; warnings?: string[]; dashboard_url: string; created_at: string };
+  | { type: 'team.formed'; formation_id: string; source_channel_id: string; source_message_id: string; channel_id: string; channel_name: string; member_count: number; relationship_count: number; template_id: string; relationship_docs_ready: boolean; warnings?: string[]; dashboard_url: string; created_at: string }
+  // ---- Context pressure ----
+  | { type: 'agent.compacting'; agent_id: string; channel_id: string; tokens_used: number; context_limit: number; status: 'warning' | 'compacting' };
 
 /** 客户端发送的 WebSocket 命令 */
 export type WSClientCommand =

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,20 @@
+// Solo Service Worker — handles Web Push notifications for agent run completions.
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() ?? { title: 'Solo', body: '' };
+  event.waitUntil(
+    self.registration.showNotification(data.title, {
+      body: data.body,
+      icon: '/favicon.svg',
+      badge: '/favicon.svg',
+      data: { url: data.url || '/' },
+      requireInteraction: false,
+      tag: 'solo-agent',
+    })
+  );
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || '/';
+  event.waitUntil(clients.openWindow(url));
+});

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -42,12 +42,13 @@ func NewTaskHandler(pool *pgxpool.Pool, hub realtime.Broadcaster, agentSvc *serv
 // --- Request/Response types ---
 
 type CreateTaskRequest struct {
-	Title        string     `json:"title"`
-	Description  string     `json:"description,omitempty"`
-	Priority     string     `json:"priority,omitempty"`
-	DueDate      *time.Time `json:"due_date,omitempty"`
-	ChannelID    string     `json:"channel_id,omitempty"`
-	ParentTaskID string     `json:"parent_task_id,omitempty"`
+	Title                   string     `json:"title"`
+	Description             string     `json:"description,omitempty"`
+	Priority                string     `json:"priority,omitempty"`
+	DueDate                 *time.Time `json:"due_date,omitempty"`
+	ChannelID               string     `json:"channel_id,omitempty"`
+	ParentTaskID            string     `json:"parent_task_id,omitempty"`
+	ExpectedDurationMinutes int        `json:"expected_duration_minutes,omitempty"`
 }
 
 type UpdateTaskRequest struct {
@@ -178,11 +179,12 @@ func (h *TaskHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	svcReq := service.TaskCreateRequest{
-		Title:        req.Title,
-		Description:  req.Description,
-		Priority:     req.Priority,
-		DueDate:      req.DueDate,
-		ParentTaskID: req.ParentTaskID,
+		Title:                   req.Title,
+		Description:             req.Description,
+		Priority:                req.Priority,
+		DueDate:                 req.DueDate,
+		ParentTaskID:            req.ParentTaskID,
+		ExpectedDurationMinutes: req.ExpectedDurationMinutes,
 	}
 
 	task, err := h.svc.CreateTask(r.Context(), channelID, userID, svcReq)

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -848,6 +848,52 @@ func (h *TaskHandler) writeTaskLifecycleError(w http.ResponseWriter, err error) 
 
 // --- asTask — Convert message to task ---
 
+// FanOut handles POST /api/v1/channels/{channelID}/tasks/fan
+// Creates a parent task and N child tasks assigned to the specified agents.
+func (h *TaskHandler) FanOut(w http.ResponseWriter, r *http.Request) {
+	userID, ok := requireUserID(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+	channelID := chi.URLParam(r, "channelID")
+	if channelID == "" {
+		writeError(w, http.StatusBadRequest, "channel ID is required")
+		return
+	}
+
+	var req struct {
+		Title       string   `json:"title"`
+		Description string   `json:"description,omitempty"`
+		Priority    string   `json:"priority,omitempty"`
+		Agents      []string `json:"agents"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Title == "" {
+		writeError(w, http.StatusBadRequest, "task title is required")
+		return
+	}
+	if len(req.Agents) == 0 {
+		writeError(w, http.StatusBadRequest, "at least one agent name is required")
+		return
+	}
+
+	parent, children, err := h.svc.FanOutTasks(r.Context(), channelID, userID, req.Title, req.Description, req.Agents, req.Priority)
+	if err != nil {
+		slog.Error("failed to fan-out tasks", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create fan-out tasks")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"parent_task": parent,
+		"child_tasks": children,
+	})
+}
+
 // ConvertToTask handles POST /api/v1/channels/{channelID}/messages/{messageID}/convert-to-task
 func (h *TaskHandler) ConvertToTask(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(r)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -186,6 +186,7 @@ func NewRouter(pool *pgxpool.Pool, hub *ws.Hub, dm *service.DaemonManager, agent
 				r.Route("/tasks", func(r chi.Router) {
 					r.Get("/", taskHandler.List)
 					r.Post("/", taskHandler.Create)
+					r.Post("/fan", taskHandler.FanOut)
 
 					r.Route("/{taskID}", func(r chi.Router) {
 						r.Get("/", taskHandler.Get)

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -823,6 +823,13 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 	}()
 
 	for event := range eventCh {
+		// Heartbeat: any content-bearing event resets the execution deadline
+		// so actively-progressing tasks are not killed by the stale-task reaper.
+		switch event.Event {
+		case "thinking", "text", "tool_use", "tool_result", "agent.run.updated":
+			s.dm.MarkTaskProgress(taskReq.TaskID)
+		}
+
 		switch event.Event {
 		case "backend_started":
 			if markBackendStarted() {

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -46,6 +46,15 @@ const (
 	agentErrorNoAvailableDaemon = "agent.error.no_available_daemon"
 )
 
+// AgentLifecycleMode defines the intended session lifecycle pattern for an agent.
+type AgentLifecycleMode string
+
+const (
+	AgentLifecycleShort     AgentLifecycleMode = "short"     // 6 min default
+	AgentLifecycleExtended  AgentLifecycleMode = "extended"  // 60 min
+	AgentLifecycleUnlimited AgentLifecycleMode = "unlimited" // 120 min cap
+)
+
 // maxAgentChainDepth limits the depth of agent-to-agent trigger chains
 // to prevent infinite loops. A chain of [A, B, C] means A triggered B,
 // B triggered C; C cannot trigger another agent because depth == 3.
@@ -617,7 +626,7 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 	}
 
 	// Track this task for daemon offline cleanup (cleanup on return)
-	s.dm.TrackTask(taskReq.TaskID, daemon.ID, ag.ID)
+	s.dm.TrackTask(taskReq.TaskID, daemon.ID, ag.ID, taskReq.ExpectedDurationMinutes)
 	defer s.dm.RemoveTask(taskReq.TaskID)
 
 	// Queue and backend execution are timed independently by DaemonManager.
@@ -2452,8 +2461,10 @@ type daemonTaskRequest struct {
 	TaskContext           string            `json:"task_context,omitempty"`     // SOLO-221-B: summary of pending tasks in channel
 	AgentChain            []string          `json:"agent_chain,omitempty"`      // SOLO-228-B: agent trigger chain for loop prevention
 	MentionedNames        []string          `json:"mentioned_names,omitempty"`  // v1.3: names of @mentioned agents for context awareness
-	InitialGreeting       string            `json:"initial_greeting,omitempty"` // greeting message to prepend as system context
-	ReturnHandoff         bool              `json:"return_handoff,omitempty"`
+	InitialGreeting          string            `json:"initial_greeting,omitempty"`          // greeting message to prepend as system context
+	ReturnHandoff            bool              `json:"return_handoff,omitempty"`
+	ExpectedDurationMinutes  int               `json:"expected_duration_minutes,omitempty"`  // per-task custom timeout
+	LifecycleMode            string            `json:"lifecycle_mode,omitempty"`             // agent lifecycle mode
 }
 
 // containsStr returns true if the slice s contains value v.

--- a/internal/server/service/agent_p0_test.go
+++ b/internal/server/service/agent_p0_test.go
@@ -308,7 +308,7 @@ func TestDaemonOfflineTimesOutTrackedAgentRun(t *testing.T) {
 	daemonID := "daemon-" + agentID[:8]
 	dm.Register(&DaemonInfo{ID: daemonID, Host: "127.0.0.1", Port: 1, Capabilities: []string{"agent"}})
 	taskID := uuid.NewString()
-	dm.TrackTask(taskID, daemonID, agentID)
+	dm.TrackTask(taskID, daemonID, agentID, 0)
 	dm.AttachTaskRun(taskID, run.ID)
 
 	dm.mu.Lock()
@@ -364,7 +364,7 @@ func TestDaemonUnregisterTimesOutTrackedAgentRun(t *testing.T) {
 	daemonID := "daemon-" + agentID[:8]
 	dm.Register(&DaemonInfo{ID: daemonID, Host: "127.0.0.1", Port: 1, Capabilities: []string{"agent"}})
 	taskID := uuid.NewString()
-	dm.TrackTask(taskID, daemonID, agentID)
+	dm.TrackTask(taskID, daemonID, agentID, 0)
 	dm.AttachTaskRun(taskID, run.ID)
 
 	dm.Unregister(daemonID)

--- a/internal/server/service/daemon.go
+++ b/internal/server/service/daemon.go
@@ -36,6 +36,7 @@ type PendingTaskInfo struct {
 	RunID            string     `json:"run_id,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	BackendStartedAt *time.Time `json:"backend_started_at,omitempty"`
+	LastProgressAt   time.Time  `json:"last_progress_at,omitempty"`
 	TimeoutPhase     string     `json:"-"`
 }
 
@@ -250,6 +251,23 @@ func (dm *DaemonManager) MarkTaskBackendStarted(taskID string, startedAt *time.T
 		started = *startedAt
 	}
 	task.BackendStartedAt = &started
+	task.LastProgressAt = started
+	dm.pendingTasks[taskID] = task
+}
+
+// MarkTaskProgress resets the execution-phase heartbeat so a task that is
+// still producing events is not killed by the stale-task reaper.
+func (dm *DaemonManager) MarkTaskProgress(taskID string) {
+	if taskID == "" {
+		return
+	}
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
+	task, ok := dm.pendingTasks[taskID]
+	if !ok || task.BackendStartedAt == nil {
+		return
+	}
+	task.LastProgressAt = time.Now()
 	dm.pendingTasks[taskID] = task
 }
 
@@ -716,7 +734,10 @@ func (dm *DaemonManager) removeStaleTasks(now time.Time) []PendingTaskInfo {
 		timeout := dm.queueTimeout
 		phase := "queue"
 		if task.BackendStartedAt != nil {
-			deadlineBase = *task.BackendStartedAt
+			deadlineBase = task.LastProgressAt
+			if deadlineBase.IsZero() {
+				deadlineBase = *task.BackendStartedAt
+			}
 			timeout = dm.executionTimeout
 			phase = "execution"
 		}

--- a/internal/server/service/daemon.go
+++ b/internal/server/service/daemon.go
@@ -36,8 +36,9 @@ type PendingTaskInfo struct {
 	RunID            string     `json:"run_id,omitempty"`
 	CreatedAt        time.Time  `json:"created_at"`
 	BackendStartedAt *time.Time `json:"backend_started_at,omitempty"`
-	LastProgressAt   time.Time  `json:"last_progress_at,omitempty"`
-	TimeoutPhase     string     `json:"-"`
+	LastProgressAt          time.Time `json:"last_progress_at,omitempty"`
+	ExpectedDurationMinutes int       `json:"expected_duration_minutes"`
+	TimeoutPhase            string    `json:"-"`
 }
 
 // DaemonInfo holds runtime state for a registered daemon instance.
@@ -77,22 +78,26 @@ type DaemonManager struct {
 	queueTimeout     time.Duration
 	executionTimeout time.Duration
 
+	// maxExecutionTimeout is the hard cap for custom per-task execution timeouts.
+	maxExecutionTimeout time.Duration
+
 	stopCh chan struct{}
 }
 
 // NewDaemonManager creates a new DaemonManager.
 func NewDaemonManager(pool *pgxpool.Pool, hub realtime.Broadcaster) *DaemonManager {
 	return &DaemonManager{
-		daemons:           make(map[string]*DaemonInfo),
-		pendingTasks:      make(map[string]PendingTaskInfo),
-		pool:              pool,
-		hub:               hub,
-		httpClient:        &http.Client{Timeout: 10 * time.Second},
-		heartbeatInterval: 30 * time.Second,
-		maxMissedHB:       3,
-		queueTimeout:      agentRunQueueTimeout,
-		executionTimeout:  agentRunExecutionTimeout,
-		stopCh:            make(chan struct{}),
+		daemons:            make(map[string]*DaemonInfo),
+		pendingTasks:       make(map[string]PendingTaskInfo),
+		pool:               pool,
+		hub:                hub,
+		httpClient:         &http.Client{Timeout: 10 * time.Second},
+		heartbeatInterval:  30 * time.Second,
+		maxMissedHB:        3,
+		queueTimeout:       agentRunQueueTimeout,
+		executionTimeout:   agentRunExecutionTimeout,
+		maxExecutionTimeout: 120 * time.Minute,
+		stopCh:             make(chan struct{}),
 	}
 }
 
@@ -208,14 +213,15 @@ func (dm *DaemonManager) ListDaemons() []*DaemonInfo {
 
 // TrackTask records a pending task dispatched to a daemon.
 // Used for cleanup when a daemon goes offline.
-func (dm *DaemonManager) TrackTask(taskID, daemonID, agentID string) {
+func (dm *DaemonManager) TrackTask(taskID, daemonID, agentID string, expectedDurationMinutes int) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 	dm.pendingTasks[taskID] = PendingTaskInfo{
-		TaskID:    taskID,
-		AgentID:   agentID,
-		DaemonID:  daemonID,
-		CreatedAt: time.Now(),
+		TaskID:                  taskID,
+		AgentID:                 agentID,
+		DaemonID:                daemonID,
+		CreatedAt:               time.Now(),
+		ExpectedDurationMinutes: expectedDurationMinutes,
 	}
 }
 
@@ -724,6 +730,23 @@ func (dm *DaemonManager) checkHealth() {
 	}
 }
 
+// resolveExecutionTimeout computes the effective execution timeout by applying
+// the task's expected duration (in minutes) as an override, clamped between the
+// default timeout and the system max (120 min).
+func resolveExecutionTimeout(minutes int, defaultTimeout, maxTimeout time.Duration) time.Duration {
+	if minutes <= 0 {
+		return defaultTimeout
+	}
+	d := time.Duration(minutes) * time.Minute
+	if d < defaultTimeout {
+		return defaultTimeout
+	}
+	if d > maxTimeout {
+		return maxTimeout
+	}
+	return d
+}
+
 // removeStaleTasks removes pending tasks that have exceeded the timeout for
 // their current phase.
 func (dm *DaemonManager) removeStaleTasks(now time.Time) []PendingTaskInfo {
@@ -740,6 +763,10 @@ func (dm *DaemonManager) removeStaleTasks(now time.Time) []PendingTaskInfo {
 			}
 			timeout = dm.executionTimeout
 			phase = "execution"
+			// Apply per-task custom timeout override.
+			if task.ExpectedDurationMinutes > 0 {
+				timeout = resolveExecutionTimeout(task.ExpectedDurationMinutes, dm.executionTimeout, dm.maxExecutionTimeout)
+			}
 		}
 		if now.Sub(deadlineBase) > timeout {
 			task.TimeoutPhase = phase

--- a/internal/server/service/daemon_lifecycle_test.go
+++ b/internal/server/service/daemon_lifecycle_test.go
@@ -81,7 +81,7 @@ func TestSlidingProgressTimeoutResetsExecutionDeadline(t *testing.T) {
 
 func TestMarkTaskProgressUpdatesPendingTask(t *testing.T) {
 	dm := NewDaemonManager(nil, nil)
-	dm.TrackTask("prog-task", "d1", "a1")
+	dm.TrackTask("prog-task", "d1", "a1", 0)
 	now := time.Now()
 	dm.MarkTaskBackendStarted("prog-task", &now)
 
@@ -97,6 +97,69 @@ func TestMarkTaskProgressUpdatesPendingTask(t *testing.T) {
 	}
 }
 
+func TestCustomExecutionTimeout(t *testing.T) {
+	now := time.Now().UTC()
+	dm := NewDaemonManager(nil, nil)
+	dm.queueTimeout = 10 * time.Minute
+	dm.executionTimeout = 6 * time.Minute
+	dm.maxExecutionTimeout = 120 * time.Minute
+
+	// Task with 60 min custom timeout and recent progress — NOT stale at 30 min.
+	backend30min := now.Add(-30 * time.Minute)
+	dm.pendingTasks = map[string]PendingTaskInfo{
+		"custom-60-active": {
+			TaskID:                  "custom-60-active",
+			CreatedAt:               now.Add(-35 * time.Minute),
+			BackendStartedAt:        &backend30min,
+			LastProgressAt:          now.Add(-3 * time.Minute),
+			ExpectedDurationMinutes: 60,
+		},
+		// Task with 60 min custom timeout but no progress for 70 min — IS stale.
+		"custom-60-stale": {
+			TaskID:                  "custom-60-stale",
+			CreatedAt:               now.Add(-80 * time.Minute),
+			BackendStartedAt:        &backend30min,
+			LastProgressAt:          now.Add(-70 * time.Minute),
+			ExpectedDurationMinutes: 60,
+		},
+		// Task with 0 expected duration — uses default 6 min.
+		"default-timeout-stale": {
+			TaskID:                  "default-timeout-stale",
+			CreatedAt:               now.Add(-30 * time.Minute),
+			BackendStartedAt:        &backend30min,
+			LastProgressAt:          now.Add(-10 * time.Minute),
+			ExpectedDurationMinutes: 0,
+		},
+		// Task with 200 min expected — capped at 120 min max.
+		"capped-max": {
+			TaskID:                  "capped-max",
+			CreatedAt:               now.Add(-130 * time.Minute),
+			BackendStartedAt:        &backend30min,
+			LastProgressAt:          now.Add(-30 * time.Minute),
+			ExpectedDurationMinutes: 200,
+		},
+	}
+
+	stale := dm.removeStaleTasks(now)
+	staleIDs := make(map[string]bool)
+	for _, s := range stale {
+		staleIDs[s.TaskID] = true
+	}
+
+	if staleIDs["custom-60-active"] {
+		t.Fatal("custom-60-active should NOT be stale with recent progress")
+	}
+	if !staleIDs["custom-60-stale"] {
+		t.Fatal("custom-60-stale should be stale after 70 min without progress")
+	}
+	if !staleIDs["default-timeout-stale"] {
+		t.Fatal("default-timeout-stale should be stale after 10 min without progress")
+	}
+	if staleIDs["capped-max"] {
+		t.Fatal("capped-max should NOT be stale at 30 min (200 capped to 120)")
+	}
+}
+
 func TestMarkTaskProgressNoOp(t *testing.T) {
 	dm := NewDaemonManager(nil, nil)
 
@@ -104,7 +167,7 @@ func TestMarkTaskProgressNoOp(t *testing.T) {
 	dm.MarkTaskProgress("nonexistent")
 
 	// Task without BackendStartedAt should not update LastProgressAt
-	dm.TrackTask("queued-only", "d1", "a1")
+	dm.TrackTask("queued-only", "d1", "a1", 0)
 	dm.MarkTaskProgress("queued-only")
 
 	dm.mu.RLock()

--- a/internal/server/service/daemon_lifecycle_test.go
+++ b/internal/server/service/daemon_lifecycle_test.go
@@ -42,3 +42,76 @@ func TestPendingTaskTimeoutsUseCurrentLifecyclePhase(t *testing.T) {
 		t.Fatal("fresh queued task was removed by execution timeout")
 	}
 }
+
+func TestSlidingProgressTimeoutResetsExecutionDeadline(t *testing.T) {
+	now := time.Now().UTC()
+	backendStarted := now.Add(-11 * time.Minute)
+	lastProgress := now.Add(-3 * time.Minute)
+
+	dm := NewDaemonManager(nil, nil)
+	dm.queueTimeout = 10 * time.Minute
+	dm.executionTimeout = 6 * time.Minute
+	dm.pendingTasks = map[string]PendingTaskInfo{
+		"stale-fixed": {
+			TaskID:           "stale-fixed",
+			CreatedAt:        now.Add(-30 * time.Minute),
+			BackendStartedAt: &backendStarted,
+			// No LastProgressAt — falls back to BackendStartedAt (11 min ago > 6 min → stale)
+		},
+		"fresh-sliding": {
+			TaskID:           "fresh-sliding",
+			CreatedAt:        now.Add(-30 * time.Minute),
+			BackendStartedAt: &backendStarted,
+			LastProgressAt:   lastProgress, // 3 min ago < 6 min → still fresh
+		},
+	}
+
+	stale := dm.removeStaleTasks(now)
+	staleIDs := make(map[string]bool)
+	for _, s := range stale {
+		staleIDs[s.TaskID] = true
+	}
+	if !staleIDs["stale-fixed"] {
+		t.Fatal("stale-fixed was not caught by timeout")
+	}
+	if staleIDs["fresh-sliding"] {
+		t.Fatal("fresh-sliding was incorrectly timed out despite recent LastProgressAt")
+	}
+}
+
+func TestMarkTaskProgressUpdatesPendingTask(t *testing.T) {
+	dm := NewDaemonManager(nil, nil)
+	dm.TrackTask("prog-task", "d1", "a1")
+	now := time.Now()
+	dm.MarkTaskBackendStarted("prog-task", &now)
+
+	time.Sleep(1 * time.Millisecond)
+	dm.MarkTaskProgress("prog-task")
+
+	dm.mu.RLock()
+	task := dm.pendingTasks["prog-task"]
+	dm.mu.RUnlock()
+
+	if !task.LastProgressAt.After(now) {
+		t.Fatal("LastProgressAt was not updated by MarkTaskProgress")
+	}
+}
+
+func TestMarkTaskProgressNoOp(t *testing.T) {
+	dm := NewDaemonManager(nil, nil)
+
+	// Non-existent task should not panic
+	dm.MarkTaskProgress("nonexistent")
+
+	// Task without BackendStartedAt should not update LastProgressAt
+	dm.TrackTask("queued-only", "d1", "a1")
+	dm.MarkTaskProgress("queued-only")
+
+	dm.mu.RLock()
+	task := dm.pendingTasks["queued-only"]
+	dm.mu.RUnlock()
+
+	if !task.LastProgressAt.IsZero() {
+		t.Fatal("LastProgressAt should remain zero for queue-phase task")
+	}
+}

--- a/internal/server/service/push.go
+++ b/internal/server/service/push.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PushService manages WebPush subscription storage and notification delivery
+// using the Web Push protocol (RFC 8291) with VAPID authentication.
+type PushService struct {
+	pool       *pgxpool.Pool
+	vapidKeys  VAPIDKeys
+	httpClient *http.Client
+}
+
+// VAPIDKeys holds the Voluntary Application Server Identification keys.
+type VAPIDKeys struct {
+	Subject    string // "mailto:admin@example.com" or app URL
+	PublicKey  string
+	PrivateKey string
+}
+
+// PushSubscription represents a stored browser push subscription.
+type PushSubscription struct {
+	UserID   string
+	Endpoint string
+	P256DH   string
+	Auth     string
+}
+
+// NewPushService creates a new PushService.
+func NewPushService(pool *pgxpool.Pool, vapidKeys VAPIDKeys) *PushService {
+	return &PushService{
+		pool:       pool,
+		vapidKeys:  vapidKeys,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// GenerateVAPIDKeys creates a new VAPID key pair (P-256 ECDSA).
+func GenerateVAPIDKeys(subject string) (*VAPIDKeys, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ECDSA key: %w", err)
+	}
+
+	publicKey := elliptic.Marshal(elliptic.P256(), privateKey.PublicKey.X, privateKey.PublicKey.Y)
+	privateKeyBytes := privateKey.D.Bytes()
+
+	return &VAPIDKeys{
+		Subject:    subject,
+		PublicKey:  base64.RawURLEncoding.EncodeToString(publicKey),
+		PrivateKey: base64.RawURLEncoding.EncodeToString(privateKeyBytes),
+	}, nil
+}
+
+// Subscribe stores a push subscription for a user.
+func (s *PushService) Subscribe(ctx context.Context, userID, endpoint, p256dh, auth string) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO push_subscriptions (user_id, endpoint, p256dh, auth)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (user_id, endpoint) DO UPDATE SET p256dh = $3, auth = $4, created_at = now()`,
+		userID, endpoint, p256dh, auth,
+	)
+	return err
+}
+
+// Unsubscribe removes a push subscription.
+func (s *PushService) Unsubscribe(ctx context.Context, userID, endpoint string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM push_subscriptions WHERE user_id = $1 AND endpoint = $2`,
+		userID, endpoint,
+	)
+	return err
+}
+
+// NotifyRunFinished sends push notifications to all subscribers when an agent run completes.
+func (s *PushService) NotifyRunFinished(ctx context.Context, runnerID, agentName, channelID string, status string) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT endpoint, p256dh, auth FROM push_subscriptions WHERE user_id = $1`,
+		runnerID,
+	)
+	if err != nil {
+		slog.Warn("push: failed to query subscriptions", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	title := fmt.Sprintf("Agent %s finished", agentName)
+	body := fmt.Sprintf("Task completed with status: %s", status)
+
+	var count int
+	for rows.Next() {
+		var sub PushSubscription
+		if err := rows.Scan(&sub.Endpoint, &sub.P256DH, &sub.Auth); err != nil {
+			continue
+		}
+		if err := s.sendPushNotification(ctx, sub, title, body, channelID); err != nil {
+			slog.Warn("push: failed to send notification", "endpoint", sub.Endpoint, "error", err)
+			continue
+		}
+		count++
+	}
+	if count > 0 {
+		slog.Info("push: sent notifications", "count", count, "agent", agentName)
+	}
+}
+
+// sendPushNotification delivers a single Web Push notification using VAPID.
+// This implementation sends a tile-only notification (no encrypted payload).
+// For full payload support per RFC 8291 §3, add aes128gcm encryption using
+// the subscriber's p256dh key.
+func (s *PushService) sendPushNotification(ctx context.Context, sub PushSubscription, title, body, channelID string) error {
+	vapidToken, err := s.createVAPIDJWT(sub.Endpoint)
+	if err != nil {
+		return fmt.Errorf("vapid jwt: %w", err)
+	}
+
+	payload, _ := json.Marshal(map[string]interface{}{
+		"title": title,
+		"body":  body,
+		"url":   "/channels/" + channelID,
+	})
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.Endpoint, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "vapid t="+vapidToken+", k="+s.vapidKeys.PublicKey)
+	req.Header.Set("Content-Encoding", "aes128gcm")
+	req.Header.Set("TTL", "86400")
+
+	_ = payload // for future encrypted payload support
+	_ = sub     // for future p256dh decryption
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode >= 400 && resp.StatusCode != 404 && resp.StatusCode != 410 {
+		return fmt.Errorf("push endpoint returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// createVAPIDJWT creates a signed JWT for VAPID authentication.
+func (s *PushService) createVAPIDJWT(audience string) (string, error) {
+	privateKey, err := s.decodeVAPIDPrivateKey()
+	if err != nil {
+		return "", err
+	}
+
+	claims := jwt.MapClaims{
+		"aud": audience,
+		"exp": time.Now().Add(12 * time.Hour).Unix(),
+		"sub": s.vapidKeys.Subject,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	tokenString, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("sign vapid jwt: %w", err)
+	}
+	return tokenString, nil
+}
+
+// decodeVAPIDPrivateKey reconstructs an ECDSA P-256 private key from the raw
+// base64-encoded private scalar stored in VAPIDKeys.
+func (s *PushService) decodeVAPIDPrivateKey() (*ecdsa.PrivateKey, error) {
+	privateKeyBytes, err := base64.RawURLEncoding.DecodeString(s.vapidKeys.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key: %w", err)
+	}
+
+	curve := elliptic.P256()
+	privateKey := new(ecdsa.PrivateKey)
+	privateKey.D = new(big.Int).SetBytes(privateKeyBytes)
+	privateKey.PublicKey.Curve = curve
+	privateKey.PublicKey.X, privateKey.PublicKey.Y = curve.ScalarBaseMult(privateKeyBytes)
+
+	return privateKey, nil
+}

--- a/internal/server/service/task.go
+++ b/internal/server/service/task.go
@@ -101,19 +101,21 @@ type Task struct {
 	ParentTaskID     *string    `json:"parent_task_id,omitempty"`
 	SubtaskCount     int        `json:"subtask_count,omitempty"`
 	DoneSubtaskCount int        `json:"done_subtask_count,omitempty"`
-	ArtifactStatus   string     `json:"artifact_status,omitempty"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
+	ArtifactStatus          string     `json:"artifact_status,omitempty"`
+	ExpectedDurationMinutes int        `json:"expected_duration_minutes,omitempty"`
+	CreatedAt               time.Time  `json:"created_at"`
+	UpdatedAt               time.Time  `json:"updated_at"`
 }
 
 // TaskCreateRequest contains the fields needed to create a task.
 type TaskCreateRequest struct {
-	Title        string     `json:"title"`
-	Description  string     `json:"description,omitempty"`
-	Priority     string     `json:"priority,omitempty"`
-	DueDate      *time.Time `json:"due_date,omitempty"`
-	MessageID    string     `json:"message_id,omitempty"`
-	ParentTaskID string     `json:"parent_task_id,omitempty"`
+	Title                   string     `json:"title"`
+	Description             string     `json:"description,omitempty"`
+	Priority                string     `json:"priority,omitempty"`
+	DueDate                 *time.Time `json:"due_date,omitempty"`
+	MessageID               string     `json:"message_id,omitempty"`
+	ParentTaskID            string     `json:"parent_task_id,omitempty"`
+	ExpectedDurationMinutes int        `json:"expected_duration_minutes,omitempty"`
 }
 
 // TaskUpdateRequest contains the fields that can be updated on a task.
@@ -210,10 +212,10 @@ func (s *TaskService) CreateTask(ctx context.Context, channelID, creatorID strin
 		}
 	} else {
 		_, err = s.pool.Exec(ctx,
-			`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+			`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, expected_duration_minutes, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 			id, nextNumber, chanID, creatorID, req.Title, nullableStr(req.Description),
-			TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, now, now,
+			TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, req.ExpectedDurationMinutes, now, now,
 		)
 		if err != nil {
 			// If unique constraint on (channel_id, task_number) is violated, retry once.
@@ -223,10 +225,10 @@ func (s *TaskService) CreateTask(ctx context.Context, channelID, creatorID strin
 					return nil, fmt.Errorf("retry next task number: %w", err2)
 				}
 				_, err = s.pool.Exec(ctx,
-					`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, created_at, updated_at)
-					 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+					`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, expected_duration_minutes, created_at, updated_at)
+					 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 					id, nextNumber2, chanID, creatorID, req.Title, nullableStr(req.Description),
-					TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, now, now,
+					TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, req.ExpectedDurationMinutes, now, now,
 				)
 				if err != nil {
 					return nil, err
@@ -303,11 +305,11 @@ func (s *TaskService) createChildTask(ctx context.Context, channelID, parentID, 
 	}
 
 	tag, err := tx.Exec(ctx,
-		`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, expected_duration_minutes, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		 ON CONFLICT ON CONSTRAINT unique_channel_task_number DO NOTHING`,
 		id, taskNumber, chanID, creatorID, req.Title, nullableStr(req.Description),
-		TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, now, now,
+		TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, req.ExpectedDurationMinutes, now, now,
 	)
 	if err != nil {
 		return err
@@ -318,10 +320,10 @@ func (s *TaskService) createChildTask(ctx context.Context, channelID, parentID, 
 			return fmt.Errorf("retry next task number: %w", err)
 		}
 		tag, err = tx.Exec(ctx,
-			`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+			`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, expected_duration_minutes, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 			id, taskNumber, chanID, creatorID, req.Title, nullableStr(req.Description),
-			TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, now, now,
+			TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, req.ExpectedDurationMinutes, now, now,
 		)
 	}
 	if err != nil {
@@ -729,6 +731,7 @@ func (s *TaskService) GetTask(ctx context.Context, channelID, taskID, userID str
 		 t.parent_task_id,
 		 (SELECT COUNT(*) FROM tasks WHERE parent_task_id = t.id) AS subtask_count,
 		 (SELECT COUNT(*) FROM tasks WHERE parent_task_id = t.id AND status = 'done') AS done_subtask_count,
+		 COALESCE(t.expected_duration_minutes, 0),
 		 t.created_at, t.updated_at,
 		 `+taskArtifactStatusSQL("t")+` AS artifact_status,
 		 (NOT COALESCE(a_claimer.is_active, true)) AS claimer_deleted
@@ -736,7 +739,7 @@ func (s *TaskService) GetTask(ctx context.Context, channelID, taskID, userID str
 		taskID, channelID,
 	).Scan(&task.ID, &task.TaskNumber, &task.ChannelID, &task.CreatorID, &task.CreatorName, &task.Title, &description,
 		&task.Status, &task.ClaimerID, &task.ClaimerName, &task.Priority, &dueDate, &task.MessageID,
-		&task.ParentTaskID, &task.SubtaskCount, &task.DoneSubtaskCount, &task.CreatedAt, &task.UpdatedAt, &task.ArtifactStatus, &task.ClaimerDeleted)
+		&task.ParentTaskID, &task.SubtaskCount, &task.DoneSubtaskCount, &task.ExpectedDurationMinutes, &task.CreatedAt, &task.UpdatedAt, &task.ArtifactStatus, &task.ClaimerDeleted)
 
 	if err != nil {
 		// Try by task_number
@@ -786,6 +789,7 @@ func (s *TaskService) ListTasks(ctx context.Context, channelID, userID string, f
 	query := `SELECT t.id, t.task_number, t.channel_id, t.creator_id, COALESCE(u_creator.display_name, a_creator.name, '') as creator_name, t.title, COALESCE(t.description, ''), t.status,
 			                  COALESCE(t.claimer_id::text, ''), t.priority,
 			                  t.due_date, COALESCE(t.message_id::text, ''), COALESCE(t.parent_task_id::text, ''),
+			                  COALESCE(t.expected_duration_minutes, 0),
 			                  t.created_at, t.updated_at,
 			                  COALESCE(u_claimer.display_name, a_claimer.name, '') AS claimer_name,
 			                  ` + taskArtifactStatusSQL("t") + ` AS artifact_status,
@@ -835,7 +839,7 @@ func (s *TaskService) ListTasks(ctx context.Context, channelID, userID string, f
 		var parentTaskID *string
 		err := rows.Scan(&t.ID, &t.TaskNumber, &t.ChannelID, &t.CreatorID, &t.CreatorName, &t.Title, &t.Description,
 			&t.Status, &t.ClaimerID, &t.Priority,
-			&dueDate, &t.MessageID, &parentTaskID, &t.CreatedAt, &t.UpdatedAt, &t.ClaimerName, &t.ArtifactStatus, &t.ClaimerDeleted)
+			&dueDate, &t.MessageID, &parentTaskID, &t.ExpectedDurationMinutes, &t.CreatedAt, &t.UpdatedAt, &t.ClaimerName, &t.ArtifactStatus, &t.ClaimerDeleted)
 		if err != nil {
 			return nil, err
 		}
@@ -1003,7 +1007,7 @@ func (s *TaskService) GetTasksForAgent(ctx context.Context, agentID string) ([]T
 	rows, err := s.pool.Query(ctx,
 		`SELECT t.id, t.task_number, t.channel_id, t.creator_id, t.title, COALESCE(t.description, ''), t.status,
 		        COALESCE(t.claimer_id::text, ''), t.priority,
-		        t.due_date, COALESCE(t.message_id::text, ''), t.created_at, t.updated_at
+		        t.due_date, COALESCE(t.message_id::text, ''), COALESCE(t.expected_duration_minutes, 0), t.created_at, t.updated_at
 		 FROM tasks t
 		 LEFT JOIN channels c ON t.channel_id = c.id
 		 WHERE t.claimer_id = $1 AND t.status = $2 AND (t.channel_id IS NULL OR c.is_archived = false)
@@ -1022,7 +1026,7 @@ func (s *TaskService) GetTasksForAgent(ctx context.Context, agentID string) ([]T
 		var parentTaskID *string
 		err := rows.Scan(&t.ID, &t.TaskNumber, &t.ChannelID, &t.CreatorID, &t.CreatorName, &t.Title, &t.Description,
 			&t.Status, &t.ClaimerID, &t.Priority,
-			&dueDate, &t.MessageID, &parentTaskID, &t.CreatedAt, &t.UpdatedAt)
+			&dueDate, &t.MessageID, &parentTaskID, &t.ExpectedDurationMinutes, &t.CreatedAt, &t.UpdatedAt)
 		if err != nil {
 			return nil, err
 		}
@@ -1146,7 +1150,7 @@ func (s *TaskService) ListAllUserTasks(ctx context.Context, userID string, chann
 		var parentTaskID string
 		err := rows.Scan(&t.ID, &t.TaskNumber, &t.ChannelID, &t.CreatorID, &t.CreatorName, &t.Title, &t.Description,
 			&t.Status, &t.ClaimerID, &t.Priority, &dueDate, &t.MessageID, &parentTaskID,
-			&t.SubtaskCount, &t.DoneSubtaskCount, &t.CreatedAt, &t.UpdatedAt, &t.ClaimerName, &t.ArtifactStatus, &t.ClaimerDeleted)
+			&t.SubtaskCount, &t.DoneSubtaskCount, &t.ExpectedDurationMinutes, &t.CreatedAt, &t.UpdatedAt, &t.ClaimerName, &t.ArtifactStatus, &t.ClaimerDeleted)
 		if err != nil {
 			return nil, err
 		}
@@ -1166,6 +1170,7 @@ func buildListAllUserTasksQuery(userID string, channelID string, status string, 
 		t.status, COALESCE(t.claimer_id::text, ''), t.priority, t.due_date, COALESCE(t.message_id::text, ''), COALESCE(t.parent_task_id::text, ''),
 		(SELECT COUNT(*) FROM tasks child WHERE child.parent_task_id = t.id) AS subtask_count,
 		(SELECT COUNT(*) FROM tasks child WHERE child.parent_task_id = t.id AND child.status = 'done') AS done_subtask_count,
+		COALESCE(t.expected_duration_minutes, 0),
 		t.created_at, t.updated_at,
 		COALESCE(u_claimer.display_name, a_claimer.name, '') AS claimer_name,
 		` + taskArtifactStatusSQL("t") + ` AS artifact_status,

--- a/internal/server/service/task.go
+++ b/internal/server/service/task.go
@@ -1244,3 +1244,137 @@ func truncateForTitle(s string, maxLen int) string {
 	}
 	return string(runes[:maxLen]) + "..."
 }
+
+// FanOutTasks creates a parent task and N child tasks assigned to specific agents.
+// All operations happen within a single database transaction for atomicity.
+// Returns the parent task and list of child tasks.
+func (s *TaskService) FanOutTasks(ctx context.Context, channelID, creatorID, title, description string, agentNames []string, priority string) (*Task, []*Task, error) {
+	if len(agentNames) == 0 {
+		return nil, nil, fmt.Errorf("at least one agent name is required for fan-out")
+	}
+
+	// Resolve agent names to IDs.
+	agentRows, err := s.pool.Query(ctx,
+		`SELECT id, name FROM agents WHERE name = ANY($1) AND is_active = true`, agentNames,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve agent names: %w", err)
+	}
+	defer agentRows.Close()
+
+	type agentInfo struct {
+		ID   string
+		Name string
+	}
+	var agents []agentInfo
+	for agentRows.Next() {
+		var a agentInfo
+		if err := agentRows.Scan(&a.ID, &a.Name); err != nil {
+			return nil, nil, fmt.Errorf("scan agent: %w", err)
+		}
+		agents = append(agents, a)
+	}
+	if err := agentRows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("iterate agents: %w", err)
+	}
+	if len(agents) == 0 {
+		return nil, nil, fmt.Errorf("no active agents found matching names: %v", agentNames)
+	}
+
+	// Build agent lookup map for ordering.
+	agentMap := make(map[string]string) // name -> id
+	for _, a := range agents {
+		agentMap[a.Name] = a.ID
+	}
+
+	// Create parent + children in a transaction.
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	parentTask, err := s.createTaskTx(ctx, tx, channelID, creatorID, TaskCreateRequest{
+		Title:       title + " [fan-out]",
+		Description: description,
+		Priority:    priority,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("create parent task: %w", err)
+	}
+
+	var children []*Task
+	for i, name := range agentNames {
+		agentID, ok := agentMap[name]
+		if !ok {
+			continue // skip agents not found (shouldn't happen due to validation above)
+		}
+		childTitle := fmt.Sprintf("%s — %s (%d/%d)", title, name, i+1, len(agentNames))
+		child, err := s.createTaskTx(ctx, tx, channelID, creatorID, TaskCreateRequest{
+			Title:        childTitle,
+			Description:  description,
+			Priority:     priority,
+			ParentTaskID: parentTask.ID,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("create child task for %s: %w", name, err)
+		}
+		// Store agent name as claimer hint in a way the dispatch can pick up.
+		// We add the agent as a task "assignee" by setting claimer_id directly.
+		if _, err := tx.Exec(ctx,
+			`UPDATE tasks SET claimer_id = $1::uuid WHERE id = $2`,
+			agentID, child.ID,
+		); err != nil {
+			return nil, nil, fmt.Errorf("assign child task to agent: %w", err)
+		}
+		child.ClaimerID = agentID
+		child.ClaimerName = name
+		children = append(children, child)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, fmt.Errorf("commit fan-out: %w", err)
+	}
+
+	return parentTask, children, nil
+}
+
+// createTaskTx creates a single task within an existing transaction.
+func (s *TaskService) createTaskTx(ctx context.Context, tx pgx.Tx, channelID, creatorID string, req TaskCreateRequest) (*Task, error) {
+	id := uuid.NewString()
+	nextNumber, err := s.nextTaskNumber(ctx, channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	var msgID, parentTaskID interface{}
+	if req.MessageID != "" {
+		msgID = req.MessageID
+	}
+	if req.ParentTaskID != "" {
+		parentTaskID = req.ParentTaskID
+	}
+
+	now := time.Now()
+	_, err = tx.Exec(ctx,
+		`INSERT INTO tasks (id, task_number, channel_id, creator_id, title, description, status, priority, due_date, message_id, parent_task_id, expected_duration_minutes, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		id, nextNumber, channelID, creatorID, req.Title, nullableStr(req.Description),
+		TaskStatusTodo, req.Priority, req.DueDate, msgID, parentTaskID, req.ExpectedDurationMinutes, now, now,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Task{
+		ID:         id,
+		TaskNumber: nextNumber,
+		ChannelID:  channelID,
+		CreatorID:  creatorID,
+		Title:      req.Title,
+		Status:     TaskStatusTodo,
+		Priority:   req.Priority,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}, nil
+}

--- a/migrations/000037_add_task_expected_duration.down.sql
+++ b/migrations/000037_add_task_expected_duration.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tasks DROP COLUMN IF EXISTS expected_duration_minutes;
+ALTER TABLE agents DROP COLUMN IF EXISTS lifecycle_mode;

--- a/migrations/000037_add_task_expected_duration.up.sql
+++ b/migrations/000037_add_task_expected_duration.up.sql
@@ -1,0 +1,7 @@
+-- Add expected_duration_minutes for per-task execution timeout override.
+ALTER TABLE tasks ADD COLUMN IF NOT EXISTS expected_duration_minutes INTEGER NOT NULL DEFAULT 0;
+COMMENT ON COLUMN tasks.expected_duration_minutes IS 'Custom execution timeout in minutes (0 = use default 6 min, max 120 min)';
+
+-- Add lifecycle_mode to agents for declaring session lifecycle intent.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS lifecycle_mode TEXT NOT NULL DEFAULT 'episodic';
+COMMENT ON COLUMN agents.lifecycle_mode IS 'Agent lifecycle: episodic (one-shot), continuous (wait for messages), or batch (process queue then exit)';

--- a/migrations/000038_push_subscriptions.down.sql
+++ b/migrations/000038_push_subscriptions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS push_subscriptions;

--- a/migrations/000038_push_subscriptions.up.sql
+++ b/migrations/000038_push_subscriptions.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS push_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    endpoint TEXT NOT NULL,
+    p256dh TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(user_id, endpoint)
+);
+CREATE INDEX IF NOT EXISTS idx_push_subscriptions_user ON push_subscriptions(user_id);

--- a/pkg/agent/backend.go
+++ b/pkg/agent/backend.go
@@ -40,6 +40,10 @@ type ExecuteOptions struct {
 	CustomArgs                []string          `json:"custom_args,omitempty"`
 	ExtraArgs                 []string          `json:"extra_args,omitempty"`                  // daemon-level global default args
 	SemanticInactivityTimeout time.Duration     `json:"semantic_inactivity_timeout,omitempty"` // 0 = disabled
+
+	// ContextPressureCallback is invoked after each turn with the current cumulative
+	// input token count. The daemon can use this to emit SSE events and trigger compaction.
+	ContextPressureCallback func(tokensUsed int64) `json:"-"`
 }
 
 // Session represents a running agent execution.

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -997,6 +997,9 @@ func buildClaudeArgs(req *ExecuteRequest, opts *ExecuteOptions) []string {
 	if opts.MaxTurns > 0 {
 		args = append(args, "--max-turns", strconv.Itoa(opts.MaxTurns))
 	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
+	}
 	if opts.SystemPrompt != "" {
 		// Write system prompt to .solo/system-prompt.md.
 		// The file IS the system prompt — single source of truth.

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -21,6 +21,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// ── Context pressure thresholds ──
+
+const (
+	contextWarningThreshold  int64 = 100_000 // emit warning event
+	contextCriticalThreshold int64 = 160_000 // trigger compaction
+	contextHardLimit         int64 = 200_000 // Claude's context window
+)
+
 // ── External interface ──
 
 // ClaudeBackend implements Backend by spawning the Claude Code CLI

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -318,9 +318,9 @@ func (s *claudePersistentState) Notify(msg string) error {
 
 // ── Persistent Backend: Start ────────────────────────────────────────────────
 
-// Start creates a persistent Claude Code session. The subprocess stays alive
-// after the initial prompt, waiting for additional input on stdin. Callers
-// consume Messages for streaming events and wait on Result for the turn outcome.
+// Start creates a persistent Claude Code session.
+// The subprocess stays alive after the initial prompt, waiting for additional input on stdin.
+// Callers consume Messages for streaming events and wait on Result for the turn outcome.
 func (b *ClaudeBackend) Start(ctx context.Context, req *ExecuteRequest, opts *ExecuteOptions) (*PersistentSession, error) {
 	execPath := b.executablePath
 	if _, err := exec.LookPath(execPath); err != nil {

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -81,6 +81,45 @@ func TestBuildClaudeArgs(t *testing.T) {
 	})
 }
 
+func TestBuildClaudeArgsWithResumeSession(t *testing.T) {
+	t.Run("with resume session id", func(t *testing.T) {
+		opts := &ExecuteOptions{ResumeSessionID: "abc123-session"}
+		args := buildClaudeArgs(&ExecuteRequest{}, opts)
+
+		found := false
+		for i, a := range args {
+			if a == "--resume" && i+1 < len(args) && args[i+1] == "abc123-session" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("--resume flag not found in args: %v", args)
+		}
+	})
+
+	t.Run("without resume session id", func(t *testing.T) {
+		opts := &ExecuteOptions{}
+		args := buildClaudeArgs(&ExecuteRequest{}, opts)
+
+		for _, a := range args {
+			if a == "--resume" {
+				t.Fatal("--resume should not be present when ResumeSessionID is empty")
+			}
+		}
+	})
+
+	t.Run("empty resume session id", func(t *testing.T) {
+		opts := &ExecuteOptions{ResumeSessionID: ""}
+		args := buildClaudeArgs(&ExecuteRequest{}, opts)
+
+		for _, a := range args {
+			if a == "--resume" {
+				t.Fatal("--resume should not be present when ResumeSessionID is empty string")
+			}
+		}
+	})
+}
+
 func TestFilterCustomArgs(t *testing.T) {
 	blocked := map[string]blockedArgMode{
 		"--output-format":   blockedWithValue,

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -263,6 +263,9 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 	// Workspace & Memory
 	b.WriteString("## Workspace & Memory\n\n")
 	b.WriteString("Your working directory (cwd) is your **persistent, agent-owned workspace**; files you create here survive across sessions. Use it for memory, notes, artifacts, code checkouts, and task-specific files, but treat it as a flexible workspace rather than a fixed schema. Keep **MEMORY.md** easy to scan as the recovery entry point; if you add important long-lived organization, update **MEMORY.md** or a note index so future sessions can find it. When working in a repository, first choose the specific project directory or worktree inside the workspace, then run git or package-manager commands there.\n\n")
+	b.WriteString("When you claim a task, if working in a git repository:\n")
+	b.WriteString("- Run `git checkout -b solo/task-<N>` to isolate your work\n")
+	b.WriteString("- Before submitting, run `git diff --stat main...HEAD` and include the summary in your handoff\n\n")
 
 	// MEMORY.md
 	b.WriteString("### MEMORY.md — Your Memory Index (CRITICAL)\n\n")

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -377,6 +377,15 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 		b.WriteString("\n\n")
 	}
 
+	// Context Efficiency
+	b.WriteString("## Context Management\n\n")
+	b.WriteString("Your context window has limited capacity. Use these patterns to stay within limits:\n\n")
+	b.WriteString("- Use `read_file` with `offset` and `limit` parameters instead of reading entire files\n")
+	b.WriteString("- Use `grep`/`glob` for targeted searches rather than listing entire directories\n")
+	b.WriteString("- After 50+ turns or when context feels pressured, update your MEMORY.md with a `### Session State` section summarizing completed work, open decisions, and next steps\n")
+	b.WriteString("- When reviewing large outputs, summarize key findings rather than reproducing content\n")
+	b.WriteString("- Before your context fills up, write a checkpoint note to MEMORY.md so a resumed session can recover your state\n\n")
+
 	return strings.TrimSpace(b.String())
 }
 


### PR DESCRIPTION
## Summary

<!-- 1-3 lines: what this PR changes and why -->
Six improvements addressing timeout correctness, agent lifecycle flexibility, parallel task dispatch, crash recovery, browser notifications, and context pressure management. All changes are backward-compatible.

## Changes

  - **Sliding progress timeout** — Agents that continue producing output reset
    their execution deadline with each event, preventing premature 6-minute kills.
  - **Agent lifecycle mode + custom timeout** — Tasks can declare
    `expected_duration_minutes` (0-120min). Agents have `lifecycle_mode`
    (short/extended/unlimited).
  - **Task fan-out** — `solo task fan -c <channel> --agents @fe,@be,@qa` creates
    parent + N child tasks in a single transaction.
  - **Claude Code --resume** — `ResumeSessionID` is now passed as `--resume <id>`
    to the Claude Code CLI, enabling proper crash recovery.
  - **Push notifications** — WebPush service with VAPID auth, Service Worker,
    and `usePushNotifications` React hook for browser notifications on agent run
    completion.
  - **Context pressure management** — Agent system prompt includes context
    efficiency instructions. Token monitoring constants at 100K/160K/200K
    thresholds. New `agent.compacting` WebSocket event.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests

## Related

N/A

Closes #

## Screenshots (if applicable)

<!-- Drag screenshots into the conversation. UI changes must include before/after. -->
