### PR TITLE
feat: add Trae CLI agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,18 @@ Backends are auto-detected from your `PATH` at daemon startup.
 | OpenCode CLI | `opencode` | ACP |
 | Hermes CLI | `hermes` | ACP |
 | OpenClaw Agent | `openclaw` | ACP |
+| Trae CLI | `traex` | ACP |
 
 Each agent can override `system_prompt`, `model_name`, `custom_env`, and `custom_args`.
+
+Install and authenticate Trae CLI before selecting it as a runtime:
+
+```bash
+curl -fsSL https://code.byted.org/api/tos-proxy/download/traex_install.sh | sh
+traex login --sso
+```
+
+Solo detects `traex` from `PATH`. Set `TRAEX_BIN` to use a different binary path.
 
 ## Core Concepts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,8 +118,18 @@ Daemon 启动时会从 `PATH` 自动检测后端。
 | OpenCode CLI | `opencode` | ACP |
 | Hermes CLI | `hermes` | ACP |
 | OpenClaw Agent | `openclaw` | ACP |
+| Trae CLI | `traex` | ACP |
 
 每个智能体都可以覆盖 `system_prompt`、`model_name`、`custom_env` 和 `custom_args`。
+
+选择 Trae CLI 作为运行时前，请先安装并登录：
+
+```bash
+curl -fsSL https://code.byted.org/api/tos-proxy/download/traex_install.sh | sh
+traex login --sso
+```
+
+Solo 会从 `PATH` 检测 `traex`；如需指定其他二进制路径，可设置 `TRAEX_BIN`。
 
 ## 核心概念
 

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -1222,12 +1222,8 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		case string(agent.MessageToolUse):
 			if chunk.Tool != nil {
 				// Detect solo message send for routing
-				if chunk.Tool.Name == "Bash" {
-					if input, ok := chunk.Tool.Input["command"].(string); ok {
-						if strings.Contains(input, "solo message send") {
-							messageSentViaCLI = true
-						}
-					}
+				if isSoloMessageSendToolCall(chunk.Tool) {
+					messageSentViaCLI = true
 				}
 				// Forward tool_use as SSE for agent view
 				inputJSON, _ := json.Marshal(chunk.Tool.Input)
@@ -1510,6 +1506,38 @@ func appendMaterializedAttachmentPaths(content string, attachments []agent.Attac
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+func isSoloMessageSendToolCall(tool *agent.ToolInfo) bool {
+	if tool == nil {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(tool.Name)) {
+	case "bash", "terminal":
+	default:
+		return false
+	}
+
+	command, ok := tool.Input["command"]
+	if !ok {
+		return false
+	}
+	switch value := command.(type) {
+	case string:
+		return strings.Contains(value, "solo message send")
+	case []string:
+		return strings.Contains(strings.Join(value, " "), "solo message send")
+	case []interface{}:
+		parts := make([]string, 0, len(value))
+		for _, part := range value {
+			if text, ok := part.(string); ok {
+				parts = append(parts, text)
+			}
+		}
+		return strings.Contains(strings.Join(parts, " "), "solo message send")
+	default:
+		return false
+	}
 }
 
 func backendFinalStatus(result *agent.Result) string {

--- a/cmd/daemon/handler_test.go
+++ b/cmd/daemon/handler_test.go
@@ -44,6 +44,63 @@ func TestBackendFinalStatusMapping(t *testing.T) {
 	}
 }
 
+func TestIsSoloMessageSendToolCallSupportsTraeTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		tool *agent.ToolInfo
+		want bool
+	}{
+		{
+			name: "claude bash",
+			tool: &agent.ToolInfo{
+				Name:  "Bash",
+				Input: map[string]interface{}{"command": "solo message send --target '#general' -c hello"},
+			},
+			want: true,
+		},
+		{
+			name: "trae terminal command string",
+			tool: &agent.ToolInfo{
+				Name:  "terminal",
+				Input: map[string]interface{}{"command": "solo message send --target '#general' -c hello"},
+			},
+			want: true,
+		},
+		{
+			name: "trae terminal command argv",
+			tool: &agent.ToolInfo{
+				Name: "terminal",
+				Input: map[string]interface{}{
+					"command": []interface{}{"/bin/zsh", "-c", "solo message send --target '#general' -c hello"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "unrelated terminal command",
+			tool: &agent.ToolInfo{
+				Name:  "terminal",
+				Input: map[string]interface{}{"command": "solo message read --target '#general'"},
+			},
+		},
+		{
+			name: "non-shell tool",
+			tool: &agent.ToolInfo{
+				Name:  "read_file",
+				Input: map[string]interface{}{"command": "solo message send"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSoloMessageSendToolCall(tt.tool); got != tt.want {
+				t.Fatalf("isSoloMessageSendToolCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProcessTaskWithProviderFailsWhenStreamClosesWithoutDone(t *testing.T) {
 	taskID := "task-missing-done"
 	tm := newTaskManager()

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -488,6 +488,11 @@ func agentGlobalRoots(provider, home string) []skillloader.SkillRoot {
 		return []skillloader.SkillRoot{
 			{Path: filepath.Join(home, ".hermes", "skills"), Kind: "hermes", Priority: 35},
 		}
+	case "trae":
+		return []skillloader.SkillRoot{
+			{Path: filepath.Join(home, ".trae", "skills"), Kind: "trae", Priority: 35},
+			{Path: filepath.Join(home, ".agents", "skills"), Kind: "agents", Priority: 25},
+		}
 	case "pi":
 		return []skillloader.SkillRoot{
 			{Path: filepath.Join(home, ".pi", "agent", "skills"), Kind: "pi", Priority: 35},
@@ -536,6 +541,11 @@ func agentWorkspaceRoots(provider, wsDir string) []skillloader.SkillRoot {
 	case "hermes":
 		return []skillloader.SkillRoot{
 			{Path: filepath.Join(wsDir, ".hermes", "skills"), Kind: "ws-hermes", Priority: 100},
+		}
+	case "trae":
+		return []skillloader.SkillRoot{
+			{Path: filepath.Join(wsDir, ".trae", "skills"), Kind: "ws-trae", Priority: 100},
+			{Path: filepath.Join(wsDir, ".agents", "skills"), Kind: "ws-trae", Priority: 80},
 		}
 	case "pi":
 		return []skillloader.SkillRoot{

--- a/docs/superpowers/specs/2026-07-29-space-containing-agent-mentions-design.md
+++ b/docs/superpowers/specs/2026-07-29-space-containing-agent-mentions-design.md
@@ -1,0 +1,190 @@
+# Space-Containing Agent Mentions Design
+
+## Problem
+
+Solo currently inserts a selected agent mention into message text as
+`@<display name>`, but both the frontend and backend parsers stop at the first
+whitespace character. An agent named `dataleap-global coding developer`
+therefore appears correctly in the UI while being parsed as
+`@dataleap-global`.
+
+The resulting message has an empty `mentioned_agent_ids` array. When that
+message becomes a task, Solo routes it to the channel coordinator instead of
+the intended agent. The task remains unclaimed by the named Trae role even
+though its card visually contains the full `@name`.
+
+## Goals
+
+- Support agent display names containing spaces across channel messages,
+  threads, direct messages, task creation, and message-to-task conversion.
+- Resolve manually typed exact full names as well as names inserted from the
+  mention suggestion list.
+- Preserve readable `@display name` message text and the current database/API
+  representation.
+- Route mentioned tasks to the intended active channel agents.
+- Avoid prefix matches and accidental fuzzy matches.
+- Recognize Trae ACP terminal calls that execute `solo message send`.
+
+## Non-Goals
+
+- Migrating message text to an embedded ID syntax such as `<@agent-id>`.
+- Fuzzy matching misspelled or partial agent names.
+- Automatically changing or rerunning historical tasks.
+- Changing task claim-window or coordinator-selection semantics.
+
+## Chosen Approach
+
+Use channel-member-aware longest exact matching.
+
+The parser receives message content and the active agent members visible in the
+conversation. At each `@` position it considers member display names and
+selects the longest exact name whose end is followed by the end of the message
+or a valid mention boundary. Matches are returned in message order and
+deduplicated by agent ID.
+
+This approach keeps current storage and APIs intact, supports existing readable
+message text, and fixes both suggestion-selected and manually typed mentions.
+
+Alternatives rejected:
+
+- Quoted syntax such as `@"Agent Name"` would be unergonomic and would not fix
+  existing user input.
+- Embedded ID tokens would be robust against renames but require a broader
+  message-format, editor, renderer, search, and migration redesign.
+
+## Mention Semantics
+
+### Matching
+
+- Matching is exact and case-sensitive, consistent with current agent-name
+  resolution.
+- Longer matching names take precedence over their prefixes.
+- A match must start immediately after `@`.
+- A match must end at end-of-content or before whitespace or punctuation.
+- Supported names naturally include Unicode letters, digits, spaces, hyphens,
+  underscores, and dots because matching uses stored names rather than a
+  restricted name regex.
+- Unknown `@text` remains ordinary message text and produces no agent ID.
+- Repeated mentions of the same agent produce one ID.
+- Multiple matching agents with the same active display name produce all
+  matching IDs; the parser does not silently choose one.
+
+### Scope
+
+Only active agent members of the current channel or DM are eligible. Users are
+not returned as agent mentions. Existing user-mention handling remains
+independent.
+
+## Architecture
+
+### Backend
+
+`MentionService.ResolveMentions` becomes the canonical server-side resolver:
+
+1. Detect whether the content contains any `@` character.
+2. Load active agent members for the supplied channel.
+3. Sort candidate names by descending character length.
+4. Scan each `@` position and apply exact name plus boundary matching.
+5. Return deduplicated IDs in message order.
+
+All existing callers retain the same method contract. This covers REST channel
+messages, direct messages, message conversion, and task routing without
+duplicating parsing logic.
+
+For message creation requests that already contain explicit
+`mentioned_agent_ids`, the server continues to respect and validate those IDs.
+Server-side text resolution remains the compatibility path for manually typed
+mentions and message-to-task conversion.
+
+### Frontend
+
+The mention hook continues to insert `@<full display name>` when a suggestion
+is selected. Its highlighting and `mentionedAgentIds` derivation use the same
+member-aware longest-match semantics instead of `/@(\S+)/`.
+
+Channel, DM, and thread composers continue sending the existing
+`mentioned_agent_ids` field. No wire-format change is required.
+
+### Task Routing
+
+Task routing behavior remains unchanged after resolution:
+
+- If one or more agent IDs are resolved, only those agents are immediately
+  triggered and receive the priority claim window.
+- If none are resolved, Solo triggers the channel coordinator.
+- The triggered agent decides whether to claim through `solo task claim`.
+
+### Trae CLI Message Detection
+
+Daemon message-send detection is extracted into a small provider-neutral
+helper. It recognizes shell-like tool names used by supported backends,
+including `Bash` and Trae ACP's `terminal`, and checks their normalized command
+payload for `solo message send`.
+
+This does not create channel messages itself. It accurately records that the
+agent already created the visible message through the Solo CLI and prevents
+misleading suppression diagnostics.
+
+## Error Handling
+
+- Database errors while loading channel agents are returned to callers.
+- No match is a normal result, not an error.
+- Unknown or incomplete `@` fragments never trigger an agent.
+- A failed task mention resolution preserves the existing coordinator fallback
+  instead of dropping the task.
+- The parser operates on Unicode text and does not split stored display names
+  on whitespace.
+
+## Testing
+
+### Backend Resolver
+
+Tests cover:
+
+- a full name containing spaces;
+- manual exact input;
+- prefix conflicts such as `data` and `data engineer`;
+- Chinese and mixed-language names;
+- punctuation and end-of-content boundaries;
+- multiple and duplicate mentions;
+- unknown or partial names;
+- active channel membership filtering;
+- duplicate active display names.
+
+### Handlers and Routing
+
+Tests cover:
+
+- channel message creation;
+- thread messages;
+- direct messages;
+- direct `as_task` creation;
+- message-to-task conversion;
+- resolved IDs passed to `TriggerAllAgentsForTask`;
+- coordinator fallback when no exact match exists.
+
+### Frontend
+
+Tests cover suggestion selection, manual full-name input, highlighting, prefix
+conflicts, and the outgoing `mentioned_agent_ids` payload.
+
+### Trae Regression
+
+Tests verify that a `terminal` ACP tool call containing `solo message send` is
+recognized as a CLI-sent message.
+
+A real end-to-end check creates or uses a Trae agent whose display name
+contains spaces, sends it a task mention, and verifies:
+
+- the message stores the Trae agent ID;
+- the task run uses provider `trae`;
+- the Trae agent claims the task;
+- the task moves to `in_progress`;
+- the reply is visible in the task thread.
+
+## Rollout and Compatibility
+
+No schema migration or API version change is required. Historical messages and
+tasks remain unchanged. After deployment, newly sent messages and newly
+converted tasks use the corrected resolver. Existing task #3 may be explicitly
+retriggered after the fix if desired.

--- a/docs/superpowers/specs/2026-07-29-trae-cli-backend-design.md
+++ b/docs/superpowers/specs/2026-07-29-trae-cli-backend-design.md
@@ -1,0 +1,271 @@
+# Trae CLI Backend Design
+
+## Goal
+
+Add Trae CLI as a first-class Solo agent backend. A user with `traex` installed
+and authenticated can select **Trae CLI** when creating or editing an agent and
+receive the same persistent, streaming, tool-capable experience as Solo's
+existing ACP backends.
+
+The integration uses Trae CLI's native ACP stdio server:
+
+```text
+traex acp serve
+```
+
+It does not parse terminal UI output and does not use a new process for every
+turn.
+
+## Scope
+
+The feature includes:
+
+- backend registration and local CLI detection;
+- one-shot and persistent execution;
+- multi-turn session continuity and persisted provider session IDs;
+- streaming text, thinking, tool activity, tool results, and usage;
+- session-level automatic approval, matching Solo's current ACP behavior;
+- model selection, custom environment, and safe custom arguments;
+- readable startup, authentication, protocol, and recovery failures;
+- frontend runtime selection through the existing metadata-driven UI;
+- English and Chinese setup documentation;
+- real full-stack validation with Trae CLI and PostgreSQL.
+
+It does not add a Trae-specific settings page, store Trae credentials in Solo,
+change the database schema, or introduce a generic user-configurable ACP
+backend.
+
+## Alternatives Considered
+
+### Dedicated Trae backend over shared ACP transport — selected
+
+Add `TraeBackend` and reuse Solo's ACP JSON-RPC transport and event conversion.
+Trae-specific command construction, argument filtering, error handling, and
+session behavior remain isolated in the adapter. This follows the existing
+provider boundary while retaining mature shared protocol handling.
+
+### Generic configurable ACP backend
+
+A generic command-and-arguments adapter appears smaller initially, but existing
+ACP CLIs differ in invocation, model switching, stderr errors, session resume,
+and tool naming. A generic adapter would move provider-specific branching into
+shared infrastructure and weaken its interface.
+
+### `traex exec` JSON event mode
+
+Launching `traex exec` for each turn could support basic tasks, but it would
+give weaker interruption, latency, streaming, process ownership, and recovery
+semantics than Trae's long-running ACP server. It does not satisfy the requested
+complete integration.
+
+## Domain Model
+
+`trae` is a new agent provider value:
+
+- registry type: `trae`;
+- display name: `Trae CLI`;
+- required binary: `traex`;
+- binary override: `TRAEX_BIN`;
+- protocol family: `acp`;
+- process command: `traex acp serve`.
+
+An existing Solo `Agent` owns configuration such as provider, model, custom
+environment, and custom arguments. Existing channel-scoped and Thinking-node
+session keys own runtime isolation. An existing `agent_sessions` row owns the
+persisted Trae provider session ID and lifecycle status. No new entity is
+introduced.
+
+Trae authentication remains owned by Trae CLI under the user's home directory.
+Solo neither reads nor stores credentials directly.
+
+## Architecture and Ownership
+
+### Registry and factory
+
+The built-in registry adds Trae metadata and a factory. The factory resolves
+the executable from `BackendConfig.ExecPath`, then `TRAEX_BIN`, then `traex`.
+`NewBackend("trae", ...)` and `NewPersistentBackend("trae")` both produce a
+Trae backend. Supported-provider error text and tests include `trae`.
+
+### Trae adapter
+
+A dedicated adapter owns:
+
+- the fixed `acp serve` invocation;
+- Trae-specific blocked arguments;
+- process startup and stderr diagnostics;
+- ACP initialization, new/resumed sessions, and model selection;
+- one-shot and persistent lifecycle methods;
+- provider-specific error wording.
+
+Protocol framing, permission replies, event conversion, usage parsing, and
+turn serialization remain in shared ACP code.
+
+### Daemon and session managers
+
+Daemon startup enumerates registered persistent backends, so registering Trae
+causes a Trae `SessionManager` to be created without a parallel lifecycle
+system. Existing keys preserve isolation among channels, DMs, and Thinking
+nodes. Stop, idle sleep, force close, and process-exit paths use the current
+session manager contracts.
+
+### Server and API
+
+The existing backend metadata and detection endpoints expose Trae. Agent CRUD
+already accepts string provider identifiers and needs no Trae-specific route.
+Run requests continue carrying `model_config.provider = "trae"`.
+
+### Frontend state
+
+The agent form consumes backend registry metadata and detection status. Trae
+therefore appears as a runtime option with its installed/unavailable state
+without a hard-coded form branch. Existing agent hooks persist `"trae"` through
+normal create and update requests.
+
+Activity rendering treats Trae as an ACP-family backend so tool names and
+status text follow the same normalization as other ACP providers.
+
+## Data Flow
+
+1. The user selects **Trae CLI** in the agent form.
+2. The server persists `agents.model_provider = "trae"` with the selected model,
+   `custom_env`, and `custom_args`.
+3. On the first run for a session key, the daemon creates a Trae backend and
+   starts `traex acp serve` in the agent workspace.
+4. The ACP client sends `initialize`, followed by `session/resume` when a
+   persisted provider session ID is available, or `session/new` otherwise.
+5. If a non-empty model is configured, the client sends `session/set_model`.
+   An unsupported model is a visible failure; it is not silently replaced.
+6. Solo composes system instructions, memory, channel context, attachments, and
+   the user turn into ACP prompt blocks and sends `session/prompt`.
+7. ACP notifications become Solo output chunks for text, thinking, tool calls,
+   tool results, status, and usage. Existing WebSocket/SSE and observability
+   paths publish them to the frontend.
+8. The provider session ID is stored in `agent_sessions.external_session_id`.
+   Subsequent turns reuse the live process and session.
+
+## Permissions and Argument Safety
+
+ACP `session/request_permission` receives Solo's existing
+`approve_for_session` response. The adapter does not add
+`--dangerously-bypass-approvals-and-sandbox`.
+
+The adapter owns the protocol command and blocks custom arguments that could
+replace, duplicate, or disrupt `acp serve`. Other supported Trae flags remain
+available through `custom_args`. Agent `custom_env` values merge through the
+existing environment builder and are never logged by value.
+
+## Persistence and Migration
+
+No database migration is required:
+
+- `agents.model_provider` is a string field that can store `trae`;
+- `agents.model_name`, `custom_env`, and `custom_args` already cover runtime
+  configuration;
+- `agent_sessions.provider` and `external_session_id` already cover provider
+  lifecycle persistence;
+- existing run and transcript metadata remain applicable.
+
+Old rows and every existing provider retain their current behavior.
+
+## Failure Recovery
+
+- **Binary missing:** detection marks Trae unavailable; direct execution reports
+  that `traex` was not found and mentions `TRAEX_BIN`.
+- **Not authenticated:** startup/provider stderr is converted to a concise
+  instruction to run `traex login --sso`; credentials and raw tokens are not
+  exposed.
+- **ACP handshake failure:** the task fails, the child process is closed, and no
+  live session is recorded.
+- **Invalid model:** the turn fails with the requested model name and Trae's
+  diagnostic. Solo does not fall back silently.
+- **Process exit during a turn:** the active run is marked failed and all
+  waiters are closed exactly once. The next turn may start a new process.
+- **Idle sleep or daemon restart:** the persisted provider session ID is offered
+  to `session/resume`.
+- **Resume rejected or session missing:** the old runtime is marked ended and a
+  new provider session is created. The run continues with Solo's persisted
+  conversation context rather than remaining stuck.
+- **Timeout or cancellation:** Solo interrupts the active turn, closes stdin,
+  and force-kills the process if graceful shutdown does not complete.
+- **Late ACP events:** the existing per-turn controller ignores events after a
+  terminal result, preventing sends to closed channels.
+
+stderr is retained for backend diagnostics but never appended to the agent's
+answer.
+
+## Compatibility
+
+The feature is additive. It does not change API shapes, database constraints,
+provider defaults, session keys, or semantics for existing agents. Trae uses
+the established ACP family behavior for event and activity normalization.
+
+An unavailable Trae binary is represented like any other unavailable registered
+CLI. An installed but logged-out CLI is detectable as installed; authentication
+failure is reported when a run starts because detection must not inspect or
+export credentials.
+
+English and Chinese READMEs document the `traex` binary, ACP protocol, install
+command, and `traex login --sso` prerequisite.
+
+## Validation
+
+### Automated Go coverage
+
+Tests cover:
+
+- registry metadata, factory creation, persistent-backend creation, and
+  `TRAEX_BIN`;
+- fixed arguments and filtering of protocol-conflicting custom arguments;
+- missing binary and authentication/provider error promotion;
+- ACP initialize, session creation, model selection, prompt streaming, usage,
+  and session ID propagation;
+- two sequential persistent turns;
+- graceful close, force close, process exit, late events, and resume fallback;
+- ACP-family activity and tool-name normalization.
+
+The shared persistent turn contract test includes Trae.
+
+### Real full-stack E2E
+
+Validation uses:
+
+- the real frontend and API server;
+- the real daemon and make-managed service lifecycle;
+- real PostgreSQL and migrations;
+- the installed, authenticated `traex` binary;
+- no mocked HTTP route, backend, database, or agent process.
+
+The stack is rebuilt only with `make rebuild`. The test creates a Trae agent
+from the UI, asks it to create a uniquely named file in its workspace, observes
+streaming output and tool activity, then sends a follow-up that depends on the
+first turn.
+
+Success requires all of:
+
+- the UI shows the Trae runtime and completed replies;
+- the requested workspace file contains the expected content;
+- the second turn demonstrates context continuity;
+- `agents.model_provider` is `trae`;
+- `agent_sessions` contains a Trae provider session ID and valid lifecycle
+  status;
+- run records reach their terminal completed state;
+- stop and subsequent resume/restart behavior is observed through the real
+  provider path.
+
+If authentication, service availability, account quota, or Trae server behavior
+blocks the real run, the blocker is reported explicitly and partial checks are
+not described as full E2E success.
+
+## Documentation and Operational Notes
+
+The supported-backend tables list Trae CLI with command `traex` and protocol
+ACP. Setup instructions include:
+
+```bash
+curl -fsSL https://code.byted.org/api/tos-proxy/download/traex_install.sh | sh
+traex login --sso
+```
+
+Operators may override the binary with `TRAEX_BIN`. Solo service lifecycle
+continues to use `make rebuild`, `make start`, and `make stop`.

--- a/frontend/e2e/trae-space-mention.spec.ts
+++ b/frontend/e2e/trae-space-mention.spec.ts
@@ -1,0 +1,188 @@
+import { execFileSync } from 'node:child_process';
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const credentials = {
+  email: 'trae-space-mention-e2e@solo.local',
+  password: 'SoloTraeE2E-2026!',
+};
+
+interface AuthResponse {
+  access_token: string;
+}
+
+interface Entity {
+  id: string;
+}
+
+interface TaskEntity extends Entity {
+  message_id: string;
+}
+
+interface RoutingState {
+  mentioned: boolean;
+  runs: number;
+  claimed: boolean;
+  status: string;
+}
+
+async function authenticate(request: APIRequestContext): Promise<AuthResponse> {
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, {
+    data: credentials,
+  });
+  if (login.ok()) return login.json();
+
+  const register = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: { ...credentials, display_name: 'Trae Space Mention E2E' },
+  });
+  if (!register.ok()) {
+    throw new Error(
+      `E2E authentication failed: ${register.status()} ${await register.text()}`,
+    );
+  }
+  return register.json();
+}
+
+async function api<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'post' | 'delete',
+  path: string,
+  data?: unknown,
+): Promise<T> {
+  const response = await request[method](`${apiBase}${path}`, {
+    headers: { authorization: `Bearer ${token}` },
+    data,
+  });
+  if (!response.ok()) {
+    throw new Error(
+      `${method.toUpperCase()} ${path}: ${response.status()} ${await response.text()}`,
+    );
+  }
+  if (response.status() === 204) return undefined as T;
+  return response.json();
+}
+
+function databaseJSON<T>(query: string): T {
+  const output = execFileSync('docker', [
+    'exec',
+    process.env.SOLO_POSTGRES_CONTAINER ?? 'solo-postgres',
+    'psql',
+    '-U',
+    process.env.POSTGRES_USER ?? 'solo',
+    '-d',
+    process.env.POSTGRES_DB ?? 'solo',
+    '-tA',
+    '-c',
+    query,
+  ], { encoding: 'utf8' }).trim();
+  return JSON.parse(output) as T;
+}
+
+function greetingFinished(agentID: string): boolean {
+  return databaseJSON<{ done: boolean }>(`
+    SELECT json_build_object('done', EXISTS(
+      SELECT 1
+        FROM agent_runs run
+       WHERE run.agent_id = '${agentID}'
+         AND run.finished_at IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM agent_run_task_links link WHERE link.run_id = run.id
+         )
+    ))::text
+  `).done;
+}
+
+function routingState(taskID: string, messageID: string, agentID: string): RoutingState {
+  return databaseJSON<RoutingState>(`
+    SELECT json_build_object(
+      'mentioned', '${agentID}'::uuid = ANY(message.mentioned_agent_ids),
+      'runs', (
+        SELECT COUNT(*)
+          FROM agent_runs run
+          JOIN agent_run_task_links link ON link.run_id = run.id
+         WHERE link.task_id = task.id
+           AND run.agent_id = '${agentID}'
+      ),
+      'claimed', task.claimer_id = '${agentID}'::uuid,
+      'status', task.status
+    )::text
+      FROM tasks task
+      JOIN messages message ON message.id = '${messageID}'
+     WHERE task.id = '${taskID}'
+  `);
+}
+
+test('task text mentioning a Trae agent with spaces routes and claims correctly', async ({ request }) => {
+  test.skip(
+    process.env.SOLO_E2E_REAL_TRAE_SPACE_MENTION !== '1',
+    'requires the make-managed stack and authenticated local Trae runtime',
+  );
+  test.setTimeout(420000);
+
+  const auth = await authenticate(request);
+  const suffix = Date.now().toString(36);
+  const agentName = `Trae Coding Developer ${suffix}`;
+  let channel: Entity | null = null;
+
+  try {
+    channel = await api<Entity>(
+      request,
+      auth.access_token,
+      'post',
+      '/api/v1/channels',
+      {
+        name: `trae-space-mention-${suffix}`,
+        description: 'Trae space-containing mention routing E2E',
+      },
+    );
+    const agent = await api<Entity>(
+      request,
+      auth.access_token,
+      'post',
+      `/api/v1/channels/${channel.id}/agents`,
+      {
+        name: agentName,
+        model_provider: 'trae',
+        model_name: '',
+        system_prompt:
+          'For every assigned task, immediately claim it with solo task claim, then reply in the task thread.',
+      },
+    );
+
+    await expect.poll(() => greetingFinished(agent.id), {
+      timeout: 120000,
+      intervals: [1000, 2000, 5000],
+    }).toBe(true);
+
+    const task = await api<TaskEntity>(
+      request,
+      auth.access_token,
+      'post',
+      `/api/v1/channels/${channel.id}/messages`,
+      {
+        content: `@${agentName} claim this routing test task and reply ROUTING_OK.`,
+        as_task: true,
+      },
+    );
+
+    await expect.poll(() => routingState(task.id, task.message_id, agent.id), {
+      timeout: 300000,
+      intervals: [1000, 2000, 5000],
+    }).toMatchObject({
+      mentioned: true,
+      runs: 1,
+      claimed: true,
+      status: 'in_progress',
+    });
+  } finally {
+    if (channel) {
+      await api<void>(
+        request,
+        auth.access_token,
+        'delete',
+        `/api/v1/channels/${channel.id}`,
+      );
+    }
+  }
+});

--- a/frontend/lib/hooks/use-cli-detection.ts
+++ b/frontend/lib/hooks/use-cli-detection.ts
@@ -20,7 +20,7 @@ export interface CliDetectionState {
 }
 
 /** Whitelist of runtimes available for agent creation. */
-const ALLOWED_RUNTIMES = new Set(["openclaw", "hermes", "claude", "opencode", "codex"]);
+const ALLOWED_RUNTIMES = new Set(["openclaw", "hermes", "trae", "claude", "opencode", "codex"]);
 
 /** Raw shape from backend — matches GET /api/v1/agent-backends/detect */
 interface DetectResponseItem {

--- a/frontend/lib/hooks/use-mentions.ts
+++ b/frontend/lib/hooks/use-mentions.ts
@@ -24,6 +24,12 @@ interface TextPart {
   member?: ChannelMember;
 }
 
+interface ResolvedMention {
+  start: number;
+  end: number;
+  members: ChannelMember[];
+}
+
 interface UseMentionsResult {
   /**
    * Parsed text parts with mention highlighting.
@@ -67,7 +73,49 @@ interface UseMentionsResult {
 
 // ---- Constants ----
 
-const MENTION_REGEX = /@(\w*)$/;
+const MENTION_REGEX = /@([\p{L}\p{N}_.-]*)$/u;
+const MENTION_BOUNDARY_REGEX = /[\s\p{P}]/u;
+
+function isMentionBoundary(value: string | undefined): boolean {
+  return value === undefined || MENTION_BOUNDARY_REGEX.test(value);
+}
+
+export function resolveAgentMentions(
+  value: string,
+  members: ChannelMember[],
+): ResolvedMention[] {
+  const agents = members
+    .filter((member) => member.member_type === 'agent' && member.display_name)
+    .sort(
+      (left, right) =>
+        Array.from(right.display_name).length -
+        Array.from(left.display_name).length,
+    );
+  const matches: ResolvedMention[] = [];
+
+  for (let at = value.indexOf('@'); at >= 0; at = value.indexOf('@', at + 1)) {
+    if (!isMentionBoundary(at === 0 ? undefined : value.at(at - 1))) continue;
+
+    const afterAt = value.slice(at + 1);
+    const longest = agents.find(
+      (member) =>
+        afterAt.startsWith(member.display_name) &&
+        isMentionBoundary(afterAt.at(member.display_name.length)),
+    );
+    if (!longest) continue;
+
+    const sameNameMembers = agents.filter(
+      (member) => member.display_name === longest.display_name,
+    );
+    matches.push({
+      start: at,
+      end: at + 1 + longest.display_name.length,
+      members: sameNameMembers,
+    });
+  }
+
+  return matches;
+}
 
 // ---- Hook ----
 
@@ -171,29 +219,23 @@ export function useMentions(
   // Parse all @mentions in the full text for highlighted display
   const parsedParts = useMemo(() => {
     const parts: TextPart[] = [];
-    const globalRegex = /@(\S+)/g;
     let lastIndex = 0;
-    let matchResult: RegExpExecArray | null;
-
-    while ((matchResult = globalRegex.exec(value)) !== null) {
-      const m = matchResult;
+    for (const mention of resolveAgentMentions(value, members)) {
       // Text before this mention
-      if (m.index > lastIndex) {
-        parts.push({ text: value.slice(lastIndex, m.index), isMention: false });
+      if (mention.start > lastIndex) {
+        parts.push({
+          text: value.slice(lastIndex, mention.start),
+          isMention: false,
+        });
       }
 
-      // Find matching member
-      const matchedMember = members.find(
-        (member) => member.display_name === m[1] || member.member_id === m[1],
-      );
-
       parts.push({
-        text: m[0],
+        text: value.slice(mention.start, mention.end),
         isMention: true,
-        member: matchedMember,
+        member: mention.members[0],
       });
 
-      lastIndex = m.index + m[0].length;
+      lastIndex = mention.end;
     }
 
     // Remaining text after last mention
@@ -207,18 +249,11 @@ export function useMentions(
   // Extract mentioned agent IDs from the full text
   const mentionedAgentIds = useMemo(() => {
     const ids: string[] = [];
-    const globalRegex = /@(\S+)/g;
-    let matchResult: RegExpExecArray | null;
-
-    while ((matchResult = globalRegex.exec(value)) !== null) {
-      const m = matchResult;
-      const member = members.find((mem) => mem.display_name === m[1]);
-      if (
-        member &&
-        member.member_type === 'agent' &&
-        !ids.includes(member.member_id)
-      ) {
-        ids.push(member.member_id);
+    for (const mention of resolveAgentMentions(value, members)) {
+      for (const member of mention.members) {
+        if (!ids.includes(member.member_id)) {
+          ids.push(member.member_id);
+        }
       }
     }
 

--- a/internal/server/service/mention.go
+++ b/internal/server/service/mention.go
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"regexp"
+	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -11,6 +14,11 @@ import (
 // Pattern for matching @mentions in message content.
 // Supports alphanumeric names with underscores, hyphens, dots, and Unicode characters.
 var mentionPattern = regexp.MustCompile(`@([\p{L}\p{N}_\-\.]+)`)
+
+type agentMentionCandidate struct {
+	ID   string
+	Name string
+}
 
 // MentionService handles @mention parsing and resolution.
 type MentionService struct {
@@ -33,68 +41,101 @@ func NewMentionService(pool *pgxpool.Pool) *MentionService {
 // Only resolves Agent mentions (not user mentions). Only returns IDs of
 // agents that are active members of the channel.
 func (s *MentionService) ResolveMentions(ctx context.Context, content, channelID string) (mentionedIDs []string, hasMentions bool, err error) {
-	// Parse @names from content
-	matches := mentionPattern.FindAllStringSubmatch(content, -1)
-	if len(matches) == 0 {
+	if !strings.Contains(content, "@") {
 		return nil, false, nil
 	}
 
 	hasMentions = true
 
-	// Deduplicate mention names
-	nameSet := make(map[string]bool, len(matches))
-	for _, m := range matches {
-		name := strings.TrimSpace(m[1])
-		if name != "" {
-			nameSet[name] = true
-		}
-	}
-
-	if len(nameSet) == 0 {
-		return []string{}, true, nil
-	}
-
-	// Build query arguments
-	names := make([]string, 0, len(nameSet))
-	for n := range nameSet {
-		names = append(names, n)
-	}
-
-	// Resolve @names to agent IDs by joining agents with channel_members
+	// Load eligible names first so display names containing whitespace can be
+	// matched exactly instead of being truncated by a token regex.
 	query := `SELECT a.id, a.name
 	           FROM agents a
 	           JOIN channel_members cm ON cm.member_id = a.id AND cm.member_type = 'agent'
 	           WHERE cm.channel_id = $1
-	             AND a.is_active = true
-	             AND a.name = ANY($2)`
+	             AND a.is_active = true`
 
-	rows, err := s.pool.Query(ctx, query, channelID, names)
+	rows, err := s.pool.Query(ctx, query, channelID)
 	if err != nil {
 		return nil, true, err
 	}
 	defer rows.Close()
 
-	var agentIDs []string
-	seen := make(map[string]bool)
+	var candidates []agentMentionCandidate
 	for rows.Next() {
 		var id, name string
 		if err := rows.Scan(&id, &name); err != nil {
 			return nil, true, err
 		}
-		if !seen[id] {
-			agentIDs = append(agentIDs, id)
-			seen[id] = true
-		}
+		candidates = append(candidates, agentMentionCandidate{ID: id, Name: name})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, true, err
 	}
 
-	if agentIDs == nil {
+	agentIDs := resolveAgentMentionCandidates(content, candidates)
+	if len(agentIDs) == 0 {
 		return []string{}, true, nil
 	}
 
 	return agentIDs, true, nil
+}
+
+func resolveAgentMentionCandidates(content string, candidates []agentMentionCandidate) []string {
+	ordered := append([]agentMentionCandidate(nil), candidates...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return utf8.RuneCountInString(ordered[i].Name) > utf8.RuneCountInString(ordered[j].Name)
+	})
+
+	var resolved []string
+	seen := make(map[string]bool, len(ordered))
+	for offset := 0; offset < len(content); {
+		relative := strings.IndexByte(content[offset:], '@')
+		if relative < 0 {
+			break
+		}
+		at := offset + relative
+		offset = at + 1
+		if !isMentionStartBoundary(content, at) {
+			continue
+		}
+
+		afterAt := content[at+1:]
+		var longestName string
+		for _, candidate := range ordered {
+			if candidate.Name == "" || !strings.HasPrefix(afterAt, candidate.Name) {
+				continue
+			}
+			if !isMentionEndBoundary(afterAt[len(candidate.Name):]) {
+				continue
+			}
+			if longestName == "" {
+				longestName = candidate.Name
+			}
+			if candidate.Name != longestName || seen[candidate.ID] {
+				continue
+			}
+			resolved = append(resolved, candidate.ID)
+			seen[candidate.ID] = true
+		}
+	}
+	return resolved
+}
+
+func isMentionStartBoundary(content string, at int) bool {
+	if at == 0 {
+		return true
+	}
+	r, _ := utf8.DecodeLastRuneInString(content[:at])
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
+}
+
+func isMentionEndBoundary(remaining string) bool {
+	if remaining == "" {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(remaining)
+	return unicode.IsSpace(r) || unicode.IsPunct(r)
 }
 
 // ResolveUserMentions parses @mention patterns in content, resolves them to

--- a/internal/server/service/mention_test.go
+++ b/internal/server/service/mention_test.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestResolveAgentMentionsLongestExactName(t *testing.T) {
+	candidates := []agentMentionCandidate{
+		{ID: "short", Name: "data"},
+		{ID: "long", Name: "data engineer"},
+		{ID: "trae", Name: "dataleap-global coding developer"},
+	}
+
+	got := resolveAgentMentionCandidates(
+		"请 @dataleap-global coding developer 实现初始化，再让 @data engineer review。",
+		candidates,
+	)
+	want := []string{"trae", "long"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveAgentMentionCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveAgentMentionsBoundariesAndDeduplication(t *testing.T) {
+	candidates := []agentMentionCandidate{
+		{ID: "data", Name: "data"},
+		{ID: "cn", Name: "研发 工程师"},
+		{ID: "duplicate-1", Name: "Same Name"},
+		{ID: "duplicate-2", Name: "Same Name"},
+	}
+
+	got := resolveAgentMentionCandidates(
+		"@database 不匹配；@data, 匹配；@研发 工程师。@data 重复；@Same Name!",
+		candidates,
+	)
+	want := []string{"data", "cn", "duplicate-1", "duplicate-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resolveAgentMentionCandidates() = %#v, want %#v", got, want)
+	}
+}
+
+func TestResolveAgentMentionsUnknownAndPartialNames(t *testing.T) {
+	candidates := []agentMentionCandidate{
+		{ID: "trae", Name: "dataleap-global coding developer"},
+	}
+
+	for _, content := range []string{
+		"@unknown do work",
+		"@dataleap-global do work",
+		"email@example.com",
+	} {
+		if got := resolveAgentMentionCandidates(content, candidates); len(got) != 0 {
+			t.Fatalf("resolveAgentMentionCandidates(%q) = %#v, want no matches", content, got)
+		}
+	}
+}

--- a/pkg/agent/acp.go
+++ b/pkg/agent/acp.go
@@ -364,17 +364,29 @@ func (c *acpClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	var resp map[string]any
 	switch method {
 	case "session/request_permission":
+		optionID := selectACPPermissionOption(raw["params"])
+		if optionID == "" {
+			resp = map[string]any{
+				"jsonrpc": "2.0",
+				"id":      json.RawMessage(rawID),
+				"result": map[string]any{
+					"outcome": map[string]any{"outcome": "cancelled"},
+				},
+			}
+			c.logger.Warn("agent permission request contained no approvable option", "method", method)
+			break
+		}
 		resp = map[string]any{
 			"jsonrpc": "2.0",
 			"id":      json.RawMessage(rawID),
 			"result": map[string]any{
 				"outcome": map[string]any{
 					"outcome":  "selected",
-					"optionId": "approve_for_session",
+					"optionId": optionID,
 				},
 			},
 		}
-		c.logger.Debug("auto-approved agent permission request", "method", method)
+		c.logger.Debug("auto-approved agent permission request", "method", method, "option_id", optionID)
 	default:
 		resp = map[string]any{
 			"jsonrpc": "2.0",
@@ -396,6 +408,51 @@ func (c *acpClient) handleAgentRequest(raw map[string]json.RawMessage) {
 	if err := c.writeLine(data); err != nil {
 		c.logger.Warn("write agent-request response", "method", method, "error", err)
 	}
+}
+
+func selectACPPermissionOption(rawParams json.RawMessage) string {
+	var params struct {
+		Options []struct {
+			OptionID string `json:"optionId"`
+			Kind     string `json:"kind"`
+			Name     string `json:"name"`
+		} `json:"options"`
+	}
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return ""
+	}
+
+	score := func(optionID, kind, name string) int {
+		value := strings.ToLower(optionID + " " + kind + " " + name)
+		switch {
+		case strings.Contains(value, "reject"), strings.Contains(value, "deny"):
+			return -1
+		case strings.Contains(value, "allow_always"),
+			strings.Contains(value, "approve_for_session"),
+			strings.Contains(value, "session"),
+			strings.Contains(value, "always"):
+			return 3
+		case strings.Contains(value, "allow_once"),
+			strings.Contains(value, "approve_once"),
+			strings.Contains(value, "once"),
+			strings.Contains(value, "allow"),
+			strings.Contains(value, "approve"):
+			return 2
+		default:
+			return 1
+		}
+	}
+
+	bestID, bestScore := "", -1
+	for _, option := range params.Options {
+		if option.OptionID == "" {
+			continue
+		}
+		if candidateScore := score(option.OptionID, option.Kind, option.Name); candidateScore > bestScore {
+			bestID, bestScore = option.OptionID, candidateScore
+		}
+	}
+	return bestID
 }
 
 func (c *acpClient) handleResponse(raw map[string]json.RawMessage) {

--- a/pkg/agent/acp_permission_test.go
+++ b/pkg/agent/acp_permission_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func TestACPRequestPermissionSelectsProviderSessionOption(t *testing.T) {
+	var stdin bytes.Buffer
+	client := &acpClient{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		stdin:  &stdin,
+	}
+
+	client.handleLine(`{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{"options":[{"optionId":"trae-deny","name":"Deny","kind":"reject_once"},{"optionId":"trae-once","name":"Allow once","kind":"allow_once"},{"optionId":"trae-session","name":"Allow for this session","kind":"allow_always"}]}}`)
+
+	var response struct {
+		Result struct {
+			Outcome struct {
+				Outcome  string `json:"outcome"`
+				OptionID string `json:"optionId"`
+			} `json:"outcome"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(stdin.Bytes(), &response); err != nil {
+		t.Fatalf("decode permission response: %v", err)
+	}
+	if response.Result.Outcome.Outcome != "selected" {
+		t.Fatalf("outcome = %q, want selected", response.Result.Outcome.Outcome)
+	}
+	if response.Result.Outcome.OptionID != "trae-session" {
+		t.Fatalf("optionId = %q, want trae-session", response.Result.Outcome.OptionID)
+	}
+}
+
+func TestACPRequestPermissionFallsBackToAllowOnce(t *testing.T) {
+	raw := json.RawMessage(`{"options":[{"optionId":"deny","kind":"reject_once"},{"optionId":"opaque-42","name":"Allow once","kind":"allow_once"}]}`)
+	if got := selectACPPermissionOption(raw); got != "opaque-42" {
+		t.Fatalf("selectACPPermissionOption() = %q, want opaque-42", got)
+	}
+}

--- a/pkg/agent/builtins.go
+++ b/pkg/agent/builtins.go
@@ -97,6 +97,15 @@ func init() {
 		Protocols:      []string{"acp"},
 	}, hermesFactory)
 
+	// ── trae — Trae CLI via ACP ─────────────────────────────────────
+	r.Register(AdapterMeta{
+		Type:           "trae",
+		DisplayName:    "Trae CLI",
+		RequiresBinary: "traex",
+		DetectCommand:  "--version",
+		Protocols:      []string{"acp"},
+	}, traeFactory)
+
 	// ── pi — Pi CLI via JSONL ───────────────────────────────────────
 	r.Register(AdapterMeta{
 		Type:           "pi",
@@ -193,6 +202,11 @@ func openclawFactory(cfg BackendConfig) (Backend, error) {
 func hermesFactory(cfg BackendConfig) (Backend, error) {
 	execPath := execPathOrDefault(cfg.ExecPath, "HERMES_BIN")
 	return NewHermesBackend(execPath, logOrDefault(cfg.Logger)), nil
+}
+
+func traeFactory(cfg BackendConfig) (Backend, error) {
+	execPath := execPathOrDefault(cfg.ExecPath, "TRAEX_BIN")
+	return NewTraeBackend(execPath, logOrDefault(cfg.Logger)), nil
 }
 
 func piFactory(cfg BackendConfig) (Backend, error) {

--- a/pkg/agent/factory.go
+++ b/pkg/agent/factory.go
@@ -21,6 +21,7 @@ import (
 //   - "opencode" — OpenCode CLI via ACP protocol
 //   - "openclaw" — OpenClaw Agent CLI via ACP protocol
 //   - "hermes"   — Hermes CLI via ACP protocol
+//   - "trae"     — Trae CLI via ACP protocol
 //   - "pi"       — Pi CLI via JSON event stream
 //   - "openai"   — not yet implemented via Backend; use llm.NewProvider
 //   - "anthropic" — not yet implemented via Backend; use llm.NewProvider
@@ -46,7 +47,7 @@ func NewBackend(providerType, apiKey string) (Backend, error) {
 		// The registry error format is "unknown backend type: ...".
 		// Wrap to the original format for backward compatibility with
 		// callers that inspect the error string.
-		return nil, fmt.Errorf("unknown backend provider type: %q (supported: claude, local, codex, cursor, gemini, kimi, kiro, copilot, opencode, openclaw, hermes, pi, openai, anthropic)", providerType)
+		return nil, fmt.Errorf("unknown backend provider type: %q (supported: claude, local, codex, cursor, gemini, kimi, kiro, copilot, opencode, openclaw, hermes, trae, pi, openai, anthropic)", providerType)
 	}
 	return backend, nil
 }
@@ -70,7 +71,7 @@ func newClaudeBackendFromEnv() *ClaudeBackend {
 // It delegates to the global BackendRegistry and checks whether the created
 // Backend satisfies the PersistentBackend interface.
 //
-// Supported: claude, codex, opencode, hermes, kimi, kiro, openclaw.
+// Supported: claude, codex, opencode, hermes, trae, kimi, kiro, openclaw.
 func NewPersistentBackend(providerType string) (PersistentBackend, error) {
 	backend, err := GlobalRegistry().Create(providerType, BackendConfig{ProviderType: providerType})
 	if err != nil {
@@ -78,7 +79,7 @@ func NewPersistentBackend(providerType string) (PersistentBackend, error) {
 	}
 	pb, ok := backend.(PersistentBackend)
 	if !ok {
-		return nil, fmt.Errorf("persistent backend not supported for provider %q (supported: claude, local, codex, opencode, hermes, kimi, kiro, openclaw)", providerType)
+		return nil, fmt.Errorf("persistent backend not supported for provider %q (supported: claude, local, codex, opencode, hermes, trae, kimi, kiro, openclaw)", providerType)
 	}
 	return pb, nil
 }

--- a/pkg/agent/factory_test.go
+++ b/pkg/agent/factory_test.go
@@ -230,6 +230,22 @@ func TestNewBackend_Hermes(t *testing.T) {
 	}
 }
 
+func TestNewBackend_Trae(t *testing.T) {
+	b, err := NewBackend("trae", "")
+	if err != nil {
+		t.Fatalf("NewBackend(\"trae\") failed: %v", err)
+	}
+	if b == nil {
+		t.Fatal("expected non-nil backend")
+	}
+	if b.Name() != "trae" {
+		t.Errorf("expected name 'trae', got %q", b.Name())
+	}
+	if _, ok := b.(*TraeBackend); !ok {
+		t.Error("expected *TraeBackend type")
+	}
+}
+
 func TestNewBackend_Pi(t *testing.T) {
 	b, err := NewBackend("pi", "")
 	if err != nil {
@@ -390,6 +406,16 @@ func TestNewHermesBackend_Defaults(t *testing.T) {
 	}
 	if b.Name() != "hermes" {
 		t.Errorf("expected name 'hermes', got %q", b.Name())
+	}
+}
+
+func TestNewTraeBackend_Defaults(t *testing.T) {
+	b := NewTraeBackend("", nil)
+	if b.executablePath != "traex" {
+		t.Errorf("expected executablePath 'traex', got %q", b.executablePath)
+	}
+	if b.Name() != "trae" {
+		t.Errorf("expected name 'trae', got %q", b.Name())
 	}
 }
 

--- a/pkg/agent/hermes.go
+++ b/pkg/agent/hermes.go
@@ -25,6 +25,10 @@ var hermesBlockedArgs = map[string]blockedArgMode{
 type HermesBackend struct {
 	executablePath string
 	logger         *slog.Logger
+	providerName   string
+	baseArgs       []string
+	blockedArgs    map[string]blockedArgMode
+	extraEnv       map[string]string
 }
 
 // NewHermesBackend creates a new HermesBackend.
@@ -37,11 +41,36 @@ func NewHermesBackend(executablePath string, logger *slog.Logger) *HermesBackend
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &HermesBackend{executablePath: executablePath, logger: logger}
+	return &HermesBackend{
+		executablePath: executablePath,
+		logger:         logger,
+		providerName:   "hermes",
+		baseArgs:       []string{"acp"},
+		blockedArgs:    hermesBlockedArgs,
+		extraEnv:       map[string]string{"HERMES_YOLO_MODE": "1"},
+	}
 }
 
 // Name returns "hermes".
-func (b *HermesBackend) Name() string { return "hermes" }
+func (b *HermesBackend) Name() string { return b.providerName }
+
+func (b *HermesBackend) commandArgs(opts *ExecuteOptions) []string {
+	args := append([]string(nil), b.baseArgs...)
+	args = append(args, filterCustomArgs(opts.ExtraArgs, b.blockedArgs)...)
+	args = append(args, filterCustomArgs(opts.CustomArgs, b.blockedArgs)...)
+	return args
+}
+
+func (b *HermesBackend) processEnv(opts *ExecuteOptions) map[string]string {
+	env := make(map[string]string, len(opts.Env)+len(b.extraEnv))
+	for k, v := range opts.Env {
+		env[k] = v
+	}
+	for k, v := range b.extraEnv {
+		env[k] = v
+	}
+	return env
+}
 
 // Execute launches the hermes CLI subprocess, sends the prompt via ACP,
 // streams output events through Session.Messages, and delivers the final
@@ -49,7 +78,7 @@ func (b *HermesBackend) Name() string { return "hermes" }
 func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *ExecuteOptions) (*Session, error) {
 	execPath := b.executablePath
 	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("hermes executable not found at %q: %w", execPath, err)
+		return nil, fmt.Errorf("%s executable not found at %q: %w", b.Name(), execPath, err)
 	}
 
 	timeout := 20 * time.Minute
@@ -61,47 +90,46 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 	runCtx, cancel := context.WithTimeout(ctx, timeout)
 
 	prompt := buildPrompt(req, opts)
-	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs)...)
+	commandArgs := b.commandArgs(opts)
 
-	cmd := exec.CommandContext(runCtx, execPath, hermesArgs...)
+	cmd := exec.CommandContext(runCtx, execPath, commandArgs...)
 	cmd.WaitDelay = 10 * time.Second
 	if opts.WorkspaceDir != "" {
 		cmd.Dir = opts.WorkspaceDir
 	}
-	cmd.Env = buildEnvAt(opts.WorkspaceDir, opts.Env)
-	cmd.Env = append(cmd.Env, "HERMES_YOLO_MODE=1")
+	cmd.Env = buildEnvAt(opts.WorkspaceDir, b.processEnv(opts))
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("hermes: stdout pipe: %w", err)
+		return nil, fmt.Errorf("%s: stdout pipe: %w", b.Name(), err)
 	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("hermes: stdin pipe: %w", err)
+		return nil, fmt.Errorf("%s: stdin pipe: %w", b.Name(), err)
 	}
 
-	providerErr := newACPProviderErrorSniffer("hermes")
+	providerErr := newACPProviderErrorSniffer(b.Name())
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("hermes: stderr pipe: %w", err)
+		return nil, fmt.Errorf("%s: stderr pipe: %w", b.Name(), err)
 	}
 
 	if err := cmd.Start(); err != nil {
 		cancel()
-		return nil, fmt.Errorf("hermes: start: %w", err)
+		return nil, fmt.Errorf("%s: start: %w", b.Name(), err)
 	}
 
-	stderrSink := io.MultiWriter(newLogWriter(b.logger, "[hermes:stderr] "), providerErr)
+	stderrSink := io.MultiWriter(newLogWriter(b.logger, "["+b.Name()+":stderr] "), providerErr)
 	stderrDone := make(chan struct{})
 	go func() {
 		defer close(stderrDone)
 		_, _ = io.Copy(stderrSink, stderr)
 	}()
 
-	b.logger.Info("hermes: started", "pid", cmd.Process.Pid, "cwd", cmd.Dir)
+	b.logger.Info(b.Name()+": started", "pid", cmd.Process.Pid, "cwd", cmd.Dir)
 
 	msgCh := make(chan OutputChunk, 256)
 	resCh := make(chan *Result, 1)
@@ -149,7 +177,7 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 			}
 			cl.handleLine(line)
 		}
-		cl.closeAllPending(fmt.Errorf("hermes process exited"))
+		cl.closeAllPending(fmt.Errorf("%s process exited", b.Name()))
 	}()
 
 	var stopOnce sync.Once
@@ -188,7 +216,7 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 		})
 		if err != nil {
 			finalStatus = "failed"
-			finalError = fmt.Sprintf("hermes initialize failed: %v", err)
+			finalError = fmt.Sprintf("%s initialize failed: %v", b.Name(), err)
 			resCh <- &Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 			return
 		}
@@ -210,21 +238,21 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 			result, err := cl.request(runCtx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 			if err != nil {
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/new failed: %v", err)
+				finalError = fmt.Sprintf("%s session/new failed: %v", b.Name(), err)
 				resCh <- &Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
 			sessionID = extractACPSessionID(result)
 			if sessionID == "" {
 				finalStatus = "failed"
-				finalError = "hermes session/new returned no session ID"
+				finalError = b.Name() + " session/new returned no session ID"
 				resCh <- &Result{Status: finalStatus, Error: finalError, DurationMs: time.Since(startTime).Milliseconds()}
 				return
 			}
 		}
 
 		cl.sessionID = sessionID
-		b.logger.Info("hermes: session created", "session_id", sessionID)
+		b.logger.Info(b.Name()+": session created", "session_id", sessionID)
 		trySend(msgCh, OutputChunk{Type: string(MessageStatus), Content: "running", SessionID: sessionID})
 
 		// 3. Set model if specified.
@@ -233,9 +261,9 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 				"sessionId": sessionID,
 				"modelId":   opts.Model,
 			}); err != nil {
-				b.logger.Warn("hermes: set_session_model failed", "error", err, "requested_model", opts.Model)
+				b.logger.Warn(b.Name()+": set_session_model failed", "error", err, "requested_model", opts.Model)
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes could not switch to model %q: %v", opts.Model, err)
+				finalError = fmt.Sprintf("%s could not switch to model %q: %v", b.Name(), opts.Model, err)
 				resCh <- &Result{
 					Status:     finalStatus,
 					Error:      finalError,
@@ -243,7 +271,7 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 				}
 				return
 			}
-			b.logger.Info("hermes: session model set", "model", opts.Model)
+			b.logger.Info(b.Name()+": session model set", "model", opts.Model)
 		}
 
 		// 4. Build prompt blocks with role-based format so the agent
@@ -266,20 +294,20 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 		if err != nil {
 			if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
 				finalStatus = "timeout"
-				finalError = fmt.Sprintf("hermes timed out after %s", timeout)
+				finalError = fmt.Sprintf("%s timed out after %s", b.Name(), timeout)
 			} else if errors.Is(runCtx.Err(), context.Canceled) {
 				finalStatus = "cancelled"
 				finalError = "execution cancelled"
 			} else {
 				finalStatus = "failed"
-				finalError = fmt.Sprintf("hermes session/prompt failed: %v", err)
+				finalError = fmt.Sprintf("%s session/prompt failed: %v", b.Name(), err)
 			}
 		} else {
 			select {
 			case pr := <-promptDone:
 				if pr.stopReason == "cancelled" {
 					finalStatus = "cancelled"
-					finalError = "hermes cancelled the prompt"
+					finalError = b.Name() + " cancelled the prompt"
 				}
 				cl.usageMu.Lock()
 				cl.usage.InputTokens += pr.usage.InputTokens
@@ -290,7 +318,7 @@ func (b *HermesBackend) Execute(ctx context.Context, req *ExecuteRequest, opts *
 		}
 
 		duration := time.Since(startTime)
-		b.logger.Info("hermes: finished",
+		b.logger.Info(b.Name()+": finished",
 			"status", finalStatus,
 			"session_id", sessionID,
 			"duration", duration.Round(time.Millisecond).String(),
@@ -369,19 +397,10 @@ func (s *hermesPersistentState) Notify(msg string) error { return s.runner.write
 func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *ExecuteOptions) (*PersistentSession, error) {
 	execPath := b.executablePath
 	if _, err := exec.LookPath(execPath); err != nil {
-		return nil, fmt.Errorf("hermes executable not found at %q: %w", execPath, err)
+		return nil, fmt.Errorf("%s executable not found at %q: %w", b.Name(), execPath, err)
 	}
 
-	hermesArgs := append([]string{"acp"}, filterCustomArgs(opts.ExtraArgs, hermesBlockedArgs)...)
-	hermesArgs = append(hermesArgs, filterCustomArgs(opts.CustomArgs, hermesBlockedArgs)...)
-
-	extraEnv := make(map[string]string, len(opts.Env)+1)
-	for k, v := range opts.Env {
-		extraEnv[k] = v
-	}
-	extraEnv["HERMES_YOLO_MODE"] = "1"
-
-	runner, err := startPersistent(ctx, execPath, hermesArgs, opts.WorkspaceDir, extraEnv, b.logger)
+	runner, err := startPersistent(ctx, execPath, b.commandArgs(opts), opts.WorkspaceDir, b.processEnv(opts), b.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +410,7 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 	turn, turnErr := state.turns.begin(opts.Model)
 	if turnErr != nil {
 		_ = runner.close()
-		return nil, fmt.Errorf("hermes: begin initial turn: %w", turnErr)
+		return nil, fmt.Errorf("%s: begin initial turn: %w", b.Name(), turnErr)
 	}
 
 	cl := &acpClient{
@@ -414,8 +433,8 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 			}
 			cl.handleLine(line)
 		}
-		cl.closeAllPending(fmt.Errorf("hermes process exited"))
-		state.turns.failActive("hermes process exited unexpectedly")
+		cl.closeAllPending(fmt.Errorf("%s process exited", b.Name()))
+		state.turns.failActive(b.Name() + " process exited unexpectedly")
 	}()
 
 	handleError := func(errMsg string) {
@@ -432,7 +451,7 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 		"clientCapabilities": map[string]any{},
 	})
 	if err != nil {
-		handleError(fmt.Sprintf("hermes initialize failed: %v", err))
+		handleError(fmt.Sprintf("%s initialize failed: %v", b.Name(), err))
 		_ = runner.close()
 		return &PersistentSession{Messages: turn.msgCh, Result: turn.resCh, state: state}, nil
 	}
@@ -454,20 +473,20 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 	if sessionID == "" {
 		result, err := cl.request(ctx, "session/new", buildHermesSessionParams(cwd, opts.Model))
 		if err != nil {
-			handleError(fmt.Sprintf("hermes session/new failed: %v", err))
+			handleError(fmt.Sprintf("%s session/new failed: %v", b.Name(), err))
 			_ = runner.close()
 			return &PersistentSession{Messages: turn.msgCh, Result: turn.resCh, state: state}, nil
 		}
 		sessionID = extractACPSessionID(result)
 		if sessionID == "" {
-			handleError("hermes session/new returned no session ID")
+			handleError(b.Name() + " session/new returned no session ID")
 			_ = runner.close()
 			return &PersistentSession{Messages: turn.msgCh, Result: turn.resCh, state: state}, nil
 		}
 	}
 	cl.sessionID = sessionID
 	state.sessionID = sessionID
-	b.logger.Info("hermes: persistent session created", "session_id", sessionID)
+	b.logger.Info(b.Name()+": persistent session created", "session_id", sessionID)
 
 	// 3. Set model if specified (session/new already passes model, but
 	// explicit set_model provides a clearer error path).
@@ -476,7 +495,7 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 			"sessionId": sessionID,
 			"modelId":   opts.Model,
 		}); err != nil {
-			b.logger.Warn("hermes: set_session_model failed", "error", err)
+			b.logger.Warn(b.Name()+": set_session_model failed", "error", err)
 		}
 	}
 
@@ -495,7 +514,7 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 
 	startACPInitialPromptTurn(acpInitialPromptTurn{
 		ctx:          ctx,
-		provider:     "hermes",
+		provider:     b.Name(),
 		sessionID:    sessionID,
 		promptBlocks: promptBlocks,
 		client:       cl,
@@ -519,16 +538,16 @@ func (b *HermesBackend) Start(ctx context.Context, req *ExecuteRequest, opts *Ex
 func (b *HermesBackend) Send(ctx context.Context, ps *PersistentSession, messages []Message) (*PersistentSession, error) {
 	state, ok := ps.state.(*hermesPersistentState)
 	if !ok || state == nil {
-		return nil, fmt.Errorf("hermes: invalid session state")
+		return nil, fmt.Errorf("%s: invalid session state", b.Name())
 	}
 	if !state.runner.isAlive() {
-		return nil, fmt.Errorf("hermes: session process has exited")
+		return nil, fmt.Errorf("%s: session process has exited", b.Name())
 	}
 
 	prompt := buildPromptFromMessages(messages)
 	turn, err := state.turns.begin("")
 	if err != nil {
-		return nil, fmt.Errorf("hermes: %w", err)
+		return nil, fmt.Errorf("%s: %w", b.Name(), err)
 	}
 
 	_, err = state.client.request(ctx, "session/prompt", map[string]any{
@@ -539,12 +558,12 @@ func (b *HermesBackend) Send(ctx context.Context, ps *PersistentSession, message
 	})
 	if err != nil {
 		state.turns.finish(turn, acpPromptErrorStatus(ctx), err.Error())
-		return nil, fmt.Errorf("hermes persistent session/prompt: %w", err)
+		return nil, fmt.Errorf("%s persistent session/prompt: %w", b.Name(), err)
 	}
 
 	state.turns.finish(turn, "completed", "")
 
-	b.logger.Info("hermes: persistent turn completed via Send",
+	b.logger.Info(b.Name()+": persistent turn completed via Send",
 		"session_id", state.sessionID,
 		"duration", time.Since(turn.startedAt).Round(time.Millisecond).String(),
 	)
@@ -565,7 +584,7 @@ func (b *HermesBackend) Send(ctx context.Context, ps *PersistentSession, message
 func (b *HermesBackend) Close(ps *PersistentSession) error {
 	state, ok := ps.state.(*hermesPersistentState)
 	if !ok || state == nil {
-		return fmt.Errorf("hermes: invalid session state")
+		return fmt.Errorf("%s: invalid session state", b.Name())
 	}
 	return state.runner.close()
 }
@@ -574,7 +593,7 @@ func (b *HermesBackend) Close(ps *PersistentSession) error {
 func (b *HermesBackend) ForceClose(ps *PersistentSession) error {
 	state, ok := ps.state.(*hermesPersistentState)
 	if !ok || state == nil {
-		return fmt.Errorf("hermes: invalid session state")
+		return fmt.Errorf("%s: invalid session state", b.Name())
 	}
 	return state.runner.forceClose()
 }

--- a/pkg/agent/island.go
+++ b/pkg/agent/island.go
@@ -86,7 +86,7 @@ func InferActivityText(chunk OutputChunk) string {
 //
 // Solo currently ships 12 CLI backends grouped into 3 protocol families:
 // stream-json (Claude / OpenCode / Cursor / Gemini / OpenClaw), jsonl
-// (Copilot / Pi), and acp (Kimi / Kiro / Hermes). Codex is technically
+// (Copilot / Pi), and acp (Kimi / Kiro / Hermes / Trae). Codex is technically
 // JSON-RPC but its backend implementation already emits the canonical
 // OutputChunk types so it falls through to the generic path.
 //
@@ -107,7 +107,7 @@ func InferActivityText(chunk OutputChunk) string {
 const (
 	familyStreamJSON = "stream-json" // claude, local, opencode, cursor, gemini, openclaw
 	familyJSONL      = "jsonl"       // copilot, pi
-	familyACP        = "acp"         // kimi, kiro, hermes
+	familyACP        = "acp"         // kimi, kiro, hermes, trae
 	familyOther      = "other"       // codex (already emits canonical OutputChunk) + unknown
 )
 
@@ -117,7 +117,7 @@ func backendFamily(provider string) string {
 		return familyStreamJSON
 	case "copilot", "pi":
 		return familyJSONL
-	case "kimi", "kiro", "hermes":
+	case "kimi", "kiro", "hermes", "trae":
 		return familyACP
 	default:
 		return familyOther

--- a/pkg/agent/island_test.go
+++ b/pkg/agent/island_test.go
@@ -434,7 +434,7 @@ func TestInferActivityTextForBackend_StreamJSON(t *testing.T) {
 }
 
 func TestInferActivityTextForBackend_ACP(t *testing.T) {
-	for _, provider := range []string{"kimi", "kiro", "hermes"} {
+	for _, provider := range []string{"kimi", "kiro", "hermes", "trae"} {
 		t.Run(provider+"/tool_use normalises snake_case", func(t *testing.T) {
 			chunk := OutputChunk{
 				Type: string(MessageToolUse),

--- a/pkg/agent/trae.go
+++ b/pkg/agent/trae.go
@@ -1,0 +1,41 @@
+package agent
+
+import "log/slog"
+
+// traeBlockedArgs are protocol-owned positional arguments. Users may pass
+// other Trae CLI flags through custom_args, but cannot replace the ACP server
+// command that Solo communicates with over stdio.
+var traeBlockedArgs = map[string]blockedArgMode{
+	"acp":   blockedStandalone,
+	"serve": blockedStandalone,
+}
+
+// TraeBackend is Solo's dedicated Trae CLI adapter. Trae's native ACP server
+// shares the transport and persistent-session implementation used by Hermes,
+// while retaining its own provider identity, invocation, and diagnostics.
+type TraeBackend struct {
+	*HermesBackend
+}
+
+// NewTraeBackend creates a Trae CLI backend. If executablePath is empty it
+// defaults to "traex".
+func NewTraeBackend(executablePath string, logger *slog.Logger) *TraeBackend {
+	if executablePath == "" {
+		executablePath = "traex"
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &TraeBackend{
+		HermesBackend: &HermesBackend{
+			executablePath: executablePath,
+			logger:         logger,
+			providerName:   "trae",
+			baseArgs:       []string{"acp", "serve"},
+			blockedArgs:    traeBlockedArgs,
+		},
+	}
+}
+
+var _ Backend = (*TraeBackend)(nil)
+var _ PersistentBackend = (*TraeBackend)(nil)

--- a/pkg/agent/trae_integration_test.go
+++ b/pkg/agent/trae_integration_test.go
@@ -1,0 +1,75 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTraeRealPersistentSession exercises the installed, authenticated Trae
+// CLI. It is opt-in because it uses a real account and remote model.
+func TestTraeRealPersistentSession(t *testing.T) {
+	if os.Getenv("SOLO_TRAE_E2E") != "1" {
+		t.Skip("set SOLO_TRAE_E2E=1 to run against the real Trae CLI")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	backend := NewTraeBackend(os.Getenv("TRAEX_BIN"), nil)
+	workspace := t.TempDir()
+	initial, err := backend.Start(ctx, &ExecuteRequest{
+		AgentID:  "trae-real-integration",
+		Messages: []Message{{Role: RoleUser, Content: "In the current workspace, create TRAE_ACP_PERMISSION_E2E.txt containing exactly TRAE_FILE_OK. Then reply with exactly TRAE_OK."}},
+	}, &ExecuteOptions{WorkspaceDir: workspace})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer backend.ForceClose(initial)
+
+	initialResult := awaitTraeResult(t, initial)
+	if initialResult.Status != "completed" || !strings.Contains(initialResult.Output, "TRAE_OK") {
+		t.Fatalf("initial result = %+v", initialResult)
+	}
+	fileContent, err := os.ReadFile(workspace + "/TRAE_ACP_PERMISSION_E2E.txt")
+	if err != nil {
+		t.Fatalf("read file created by Trae: %v", err)
+	}
+	if strings.TrimSpace(string(fileContent)) != "TRAE_FILE_OK" {
+		t.Fatalf("created file content = %q, want TRAE_FILE_OK", fileContent)
+	}
+
+	second, err := backend.Send(ctx, initial, []Message{{
+		Role:    RoleUser,
+		Content: "Read TRAE_ACP_PERMISSION_E2E.txt from the current workspace and reply with exactly TRAE_SECOND_OK: followed by its contents.",
+	}})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	secondResult := awaitTraeResult(t, second)
+	if secondResult.Status != "completed" ||
+		!strings.Contains(secondResult.Output, "TRAE_SECOND_OK:TRAE_FILE_OK") {
+		t.Fatalf("second result = %+v", secondResult)
+	}
+	if second.SessionID == "" || second.SessionID != initial.SessionID {
+		t.Fatalf("session IDs initial=%q second=%q", initial.SessionID, second.SessionID)
+	}
+}
+
+func awaitTraeResult(t *testing.T, session *PersistentSession) *Result {
+	t.Helper()
+	for range session.Messages {
+	}
+	select {
+	case result := <-session.Result:
+		if result == nil {
+			t.Fatal("result channel returned nil")
+		}
+		return result
+	case <-time.After(5 * time.Minute):
+		t.Fatal("timed out waiting for Trae result")
+		return nil
+	}
+}

--- a/pkg/agent/trae_test.go
+++ b/pkg/agent/trae_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTraeCommandArgs(t *testing.T) {
+	b := NewTraeBackend("", nil)
+	opts := &ExecuteOptions{
+		ExtraArgs:  []string{"--enable", "memory", "acp"},
+		CustomArgs: []string{"serve", "--profile", "solo"},
+	}
+
+	got := b.commandArgs(opts)
+	want := []string{"acp", "serve", "--enable", "memory", "--profile", "solo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("commandArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTraeFactoryUsesEnvironmentOverride(t *testing.T) {
+	t.Setenv("TRAEX_BIN", "/custom/bin/traex")
+
+	backend, err := GlobalRegistry().Create("trae", BackendConfig{ProviderType: "trae"})
+	if err != nil {
+		t.Fatalf("Create(\"trae\") failed: %v", err)
+	}
+	trae, ok := backend.(*TraeBackend)
+	if !ok {
+		t.Fatalf("backend type = %T, want *TraeBackend", backend)
+	}
+	if trae.executablePath != "/custom/bin/traex" {
+		t.Fatalf("executablePath = %q, want /custom/bin/traex", trae.executablePath)
+	}
+}
+
+func TestTraeMetadata(t *testing.T) {
+	var found *AdapterMeta
+	for _, meta := range GlobalRegistry().ListMeta() {
+		if meta.Type == "trae" {
+			copy := meta
+			found = &copy
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("trae metadata not registered")
+	}
+	if found.DisplayName != "Trae CLI" || found.RequiresBinary != "traex" {
+		t.Fatalf("unexpected metadata: %+v", *found)
+	}
+	if !reflect.DeepEqual(found.Protocols, []string{"acp"}) {
+		t.Fatalf("protocols = %#v, want [acp]", found.Protocols)
+	}
+}

--- a/pkg/agent/turn_contract_test.go
+++ b/pkg/agent/turn_contract_test.go
@@ -188,6 +188,7 @@ func TestStableACPPersistentProviderTurnContract(t *testing.T) {
 	}{
 		{name: "opencode", new: func(path string) PersistentBackend { return NewOpenCodeBackend(path, slog.Default()) }},
 		{name: "hermes", new: func(path string) PersistentBackend { return NewHermesBackend(path, slog.Default()) }},
+		{name: "trae", new: func(path string) PersistentBackend { return NewTraeBackend(path, slog.Default()) }},
 		{name: "openclaw", new: func(path string) PersistentBackend { return NewOpenClawBackend(path, slog.Default()) }},
 	}
 

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -206,6 +206,8 @@ func skillTargetRoots(workDir, provider string) []string {
 		return []string{filepath.Join(workDir, ".opencode", "skills"), filepath.Join(workDir, ".claude", "skills"), agentsSkills}
 	case "openclaw":
 		return []string{filepath.Join(workDir, "skills"), agentsSkills}
+	case "trae":
+		return []string{filepath.Join(workDir, ".trae", "skills"), agentsSkills}
 	default:
 		return []string{agentsSkills}
 	}


### PR DESCRIPTION
## Summary

- add a native Trae CLI ACP agent backend with `traex login --sso` setup
- support persistent sessions, automatic permission approval, skills, and workspace integration
- route agent mentions containing spaces correctly and improve Trae terminal message detection

## Type of change

- [x] New feature
- [x] Bug fix
- [x] Documentation
- [x] Tests

## Validation

- `go test ./...`
- `npm run lint`
- `npm run build`
- real Trae persistent-session integration test
- end-to-end spaced-mention task claim test