### PR TITLE
Harden Agent run delivery and recovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -38,6 +38,12 @@ start: ## Start all services (ensures DB, runs migrations, auto-builds if needed
 restart: stop start ## Restart all services
 
 rebuild: stop clean-pids build start ## Rebuild binaries from a clean .pids dir and restart all services
+
+test-e2e-agent-delivery: rebuild ## Rebuild and verify the real Agent result delivery contract
+	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts
+
+test-e2e-agent-session-resume: rebuild ## Rebuild and verify real Channel Session restart continuity
+	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "resumes the same real Channel provider Session"
 
 stop: ## Shut down all services
 	@bash scripts/stop-services.sh

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -54,6 +55,7 @@ type daemonHandler struct {
 	sessionManagers  map[string]*agent.AgentSessionManager // v1.4: per-provider persistent sessions
 	thinkingIdleTTL  time.Duration
 	thinkingSweep    time.Duration
+	shuttingDown     atomic.Bool
 
 	// v1.4: per-agent token store for persistent session token auto-refresh (SOLO-254-B).
 	agentTokens   map[string]*agentTokenState // agentID -> cached token + expiry
@@ -380,6 +382,7 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		Content    string `json:"content,omitempty"`
 		ThreadID   string `json:"thread_id,omitempty"`
 		NodeID     string `json:"thinking_node_id,omitempty"`
+		RunID      string `json:"run_id,omitempty"`
 		TaskNumber int    `json:"task_number,omitempty"`
 		TaskID     string `json:"task_id,omitempty"`
 		Status     string `json:"status,omitempty"`
@@ -402,6 +405,11 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			req.NodeID = runtimeNodeID
 		}
 	}
+	if req.Action == "message_send" {
+		if taskID := h.taskManager.ExecutingTaskID(req.AgentID, req.ChannelID, req.NodeID); taskID != "" {
+			req.RunID = taskID
+		}
+	}
 
 	// Generate or reuse auth token for this agent (SOLO-254-B: token store).
 	token, err := h.getOrGenerateToken(r.Context(), req.AgentID)
@@ -422,6 +430,9 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.NodeID != "" {
 			bodyMap["thinking_node_id"] = req.NodeID
+		}
+		if req.RunID != "" {
+			bodyMap["run_id"] = req.RunID
 		}
 		serverBody, _ = json.Marshal(bodyMap)
 	case "task_claim":
@@ -639,6 +650,7 @@ func (h *daemonHandler) Run(w http.ResponseWriter, r *http.Request) {
 		AgentID:    req.AgentID,
 		ChannelID:  req.ChannelID,
 		ThreadID:   req.ThreadID,
+		NodeID:     req.NodeID,
 		Status:     taskStatusQueued,
 		ReceivedAt: time.Now(),
 	})
@@ -680,6 +692,9 @@ func (h *daemonHandler) processTaskStreaming(ctx context.Context, req runTaskReq
 }
 
 func (h *daemonHandler) finishCancelledTask(req runTaskRequest) {
+	if h.shuttingDown.Load() {
+		return
+	}
 	h.taskManager.UpdateStatus(req.TaskID, taskStatusCancelled)
 	h.pushEventJSON(req.TaskID, "error", map[string]interface{}{
 		"agent_id":  req.AgentID,
@@ -964,6 +979,11 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 	} else {
 		delete(agentEnv, "SOLO_NODE_ID")
 	}
+	if req.RunID != "" {
+		agentEnv["SOLO_RUN_ID"] = req.RunID
+	} else {
+		delete(agentEnv, "SOLO_RUN_ID")
+	}
 
 	// Build system prompt using PromptBuilder
 	hostname, _ := os.Hostname()
@@ -1146,7 +1166,6 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 
 	// Stream output chunks
 	var fullContent string
-	var messageSentViaCLI bool
 
 	streamOpen := true
 	for streamOpen {
@@ -1210,6 +1229,9 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 			})
 
 		case string(agent.MessageError):
+			if h.shuttingDown.Load() {
+				return
+			}
 			slog.Error("task: backend stream error", "task_id", req.TaskID, "error", chunk.Content)
 			h.taskManager.UpdateStatus(req.TaskID, taskStatusFailed)
 			h.notifyServerError(req, chunk.Content)
@@ -1221,14 +1243,6 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 
 		case string(agent.MessageToolUse):
 			if chunk.Tool != nil {
-				// Detect solo message send for routing
-				if chunk.Tool.Name == "Bash" {
-					if input, ok := chunk.Tool.Input["command"].(string); ok {
-						if strings.Contains(input, "solo message send") {
-							messageSentViaCLI = true
-						}
-					}
-				}
 				// Forward tool_use as SSE for agent view
 				inputJSON, _ := json.Marshal(chunk.Tool.Input)
 				h.pushEventJSON(req.TaskID, "tool_use", map[string]interface{}{
@@ -1254,6 +1268,10 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		}
 	}
 
+	if h.shuttingDown.Load() {
+		return
+	}
+
 	// v1.3: - only CLI-sent messages appear in channel.
 	// If solo message send was called, API already created the message.
 	// Direct text output is internal thinking, not channel messages.
@@ -1275,7 +1293,7 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 	// v1.3: — NEVER persist text output as channel messages.
 	// Only solo message send API (via proxy) creates visible messages.
 	// All text output is internal thinking. Always skip persist.
-	if !messageSentViaCLI && strings.TrimSpace(fullContent) != "" {
+	if strings.TrimSpace(fullContent) != "" {
 		slog.Info("task: suppressing text output (not sent via CLI)", "agent_id", req.AgentID, "length", len(fullContent))
 	}
 
@@ -1285,15 +1303,16 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		"status", result.Status,
 		"content_length", len(result.Output),
 		"duration_ms", result.DurationMs,
-		"message_sent_via_cli", messageSentViaCLI,
 	)
 
 	// Extract usage from result
-	var inputTokens, outputTokens int
+	var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int
 	if result.Usage != nil {
 		for _, u := range result.Usage {
 			inputTokens += int(u.InputTokens)
 			outputTokens += int(u.OutputTokens)
+			cacheReadTokens += int(u.CacheReadTokens)
+			cacheWriteTokens += int(u.CacheWriteTokens)
 		}
 	}
 
@@ -1321,8 +1340,10 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 		"external_session_id": providerSessionID,
 		"transcript_path":     transcriptPath,
 		"usage": map[string]int{
-			"input_tokens":  inputTokens,
-			"output_tokens": outputTokens,
+			"input_tokens":       inputTokens,
+			"output_tokens":      outputTokens,
+			"cache_read_tokens":  cacheReadTokens,
+			"cache_write_tokens": cacheWriteTokens,
 		},
 	})
 

--- a/cmd/daemon/handler_test.go
+++ b/cmd/daemon/handler_test.go
@@ -44,6 +44,27 @@ func TestBackendFinalStatusMapping(t *testing.T) {
 	}
 }
 
+func TestFinishCancelledTaskDefersTerminalStateDuringShutdown(t *testing.T) {
+	taskID := "task-daemon-shutdown"
+	tm := newTaskManager()
+	tm.AddTask(taskID, &taskState{TaskID: taskID, Status: taskStatusRunning})
+	h := newDaemonHandler(nil, tm, nil, "", "")
+	h.shuttingDown.Store(true)
+
+	h.finishCancelledTask(runTaskRequest{TaskID: taskID})
+
+	task, ok := tm.GetTask(taskID)
+	if !ok {
+		t.Fatal("task was removed")
+	}
+	if task.Status != taskStatusRunning {
+		t.Fatalf("task status = %q, want server-owned daemon_lost transition", task.Status)
+	}
+	if len(tm.eventHistory[taskID]) != 0 {
+		t.Fatalf("shutdown emitted terminal events: %#v", tm.eventHistory[taskID])
+	}
+}
+
 func TestProcessTaskWithProviderFailsWhenStreamClosesWithoutDone(t *testing.T) {
 	taskID := "task-missing-done"
 	tm := newTaskManager()

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -108,6 +108,7 @@ func main() {
 	daemonH = h
 
 	// v1.4: Initialize persistent agent session managers for all registered types.
+	var sessionManagers []*agent.AgentSessionManager
 	for _, meta := range agent.GlobalRegistry().ListMeta() {
 		psBackend, err := agent.NewPersistentBackend(meta.Type)
 		if err != nil {
@@ -117,8 +118,8 @@ func main() {
 		memoryMgr := agent.NewMemoryManager("")
 		sessionMgr := agent.NewAgentSessionManager(psBackend, workspaceMgr, memoryMgr, slog.Default())
 		h.SetSessionManager(meta.Type, sessionMgr)
+		sessionManagers = append(sessionManagers, sessionMgr)
 		slog.Info("persistent agent session manager initialized", "provider", meta.Type)
-		defer sessionMgr.CloseAll()
 	}
 
 	r := chi.NewRouter()
@@ -191,8 +192,19 @@ func main() {
 	<-ctx.Done()
 	slog.Info("daemon server shutting down")
 
+	h.shuttingDown.Store(true)
+
+	// Stop every provider runtime before the server can observe daemon_lost and
+	// reassign its Runs. Keep the machine lock until all subprocesses are reaped.
+	for _, sessionMgr := range sessionManagers {
+		sessionMgr.CloseAll()
+	}
+
 	// Unregister on shutdown
 	unregisterFromServer()
+	for _, taskID := range taskMgr.ListTaskIDs() {
+		taskMgr.CloseAllSubscribers(taskID)
+	}
 
 	// Release machine lock
 	if machineLock != nil {
@@ -249,6 +261,7 @@ func registerWithServer(ctx context.Context) error {
 		CurrentLoad:   0,
 		AgentTypes:    registeredAgentTypes(),
 		SystemInfo:    collectSystemInfo(),
+		Tasks:         taskMgr.ListTaskIDs(),
 	}
 
 	payload, err := json.Marshal(req)
@@ -414,6 +427,7 @@ type daemonRegisterPayload struct {
 	CurrentLoad   int32      `json:"current_load"`
 	AgentTypes    []string   `json:"agent_types"`
 	SystemInfo    SystemInfo `json:"system_info"`
+	Tasks         []string   `json:"tasks,omitempty"`
 }
 
 type daemonRegisterResponse struct {

--- a/cmd/daemon/task.go
+++ b/cmd/daemon/task.go
@@ -27,6 +27,7 @@ type taskState struct {
 	AgentID     string
 	ChannelID   string
 	ThreadID    string
+	NodeID      string
 	Status      string
 	Result      string
 	Error       string
@@ -106,6 +107,20 @@ func (tm *taskManager) ListActiveTasks() []string {
 	return active
 }
 
+// ListTaskIDs returns the daemon's durable-recovery evidence. Terminal
+// tasks are included because their replayable completion events may not yet
+// have reached a restarted server.
+func (tm *taskManager) ListTaskIDs() []string {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	tasks := make([]string, 0, len(tm.tasks))
+	for id := range tm.tasks {
+		tasks = append(tasks, id)
+	}
+	return tasks
+}
+
 // ActiveTaskCount returns the number of currently running tasks.
 func (tm *taskManager) ActiveTaskCount() int {
 	return len(tm.ListActiveTasks())
@@ -128,6 +143,25 @@ func (tm *taskManager) ActiveAgentIDs() []string {
 		ids = []string{}
 	}
 	return ids
+}
+
+// ExecutingTaskID returns the task currently owning an agent's runtime scope.
+func (tm *taskManager) ExecutingTaskID(agentID, channelID, nodeID string) string {
+	tm.mu.RLock()
+	defer tm.mu.RUnlock()
+
+	var taskID string
+	for id, t := range tm.tasks {
+		if t.AgentID != agentID || t.ChannelID != channelID || t.NodeID != nodeID ||
+			(t.Status != taskStatusRunning && t.Status != taskStatusThinking) {
+			continue
+		}
+		if taskID != "" {
+			return ""
+		}
+		taskID = id
+	}
+	return taskID
 }
 
 // --- SSE subscriber management ---

--- a/cmd/daemon/task_test.go
+++ b/cmd/daemon/task_test.go
@@ -26,6 +26,37 @@ func TestTaskManagerReplaysBackendStartSessionAndTerminalEvents(t *testing.T) {
 	}
 }
 
+func TestTaskManagerIDsIncludeActiveAndTerminalTasks(t *testing.T) {
+	tm := newTaskManager()
+	tm.AddTask("active", &taskState{TaskID: "active", Status: taskStatusRunning})
+	tm.AddTask("done", &taskState{TaskID: "done", Status: taskStatusCompleted})
+
+	got := map[string]bool{}
+	for _, taskID := range tm.ListTaskIDs() {
+		got[taskID] = true
+	}
+	if !got["active"] || !got["done"] {
+		t.Fatalf("snapshots = %#v", got)
+	}
+}
+
+func TestTaskManagerExecutingTaskIDUsesRuntimeScope(t *testing.T) {
+	tm := newTaskManager()
+	tm.AddTask("old", &taskState{
+		AgentID: "agent-1", ChannelID: "channel-1", Status: taskStatusCompleted,
+	})
+	tm.AddTask("current", &taskState{
+		AgentID: "agent-1", ChannelID: "channel-1", Status: taskStatusThinking,
+	})
+	tm.AddTask("other-channel", &taskState{
+		AgentID: "agent-1", ChannelID: "channel-2", Status: taskStatusThinking,
+	})
+
+	if got := tm.ExecutingTaskID("agent-1", "channel-1", ""); got != "current" {
+		t.Fatalf("ExecutingTaskID = %q, want current", got)
+	}
+}
+
 func TestTaskManagerClearsCompletedTaskCancellation(t *testing.T) {
 	tm := newTaskManager()
 	called := false

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -407,6 +407,9 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 	if nodeID := os.Getenv("SOLO_NODE_ID"); nodeID != "" {
 		body["thinking_node_id"] = nodeID
 	}
+	if runID := os.Getenv("SOLO_RUN_ID"); runID != "" {
+		body["run_id"] = runID
+	}
 	if taskNumber > 0 {
 		body["task_number"] = taskNumber
 	}
@@ -855,6 +858,9 @@ func handleMessageSend(args []string, baseURL, token string) {
 	}
 	if nodeID := os.Getenv("SOLO_NODE_ID"); nodeID != "" {
 		reqBody["thinking_node_id"] = nodeID
+	}
+	if runID := os.Getenv("SOLO_RUN_ID"); runID != "" {
+		reqBody["run_id"] = runID
 	}
 
 	body, _ := json.Marshal(reqBody)

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -1264,6 +1264,31 @@ func TestProxyRequestTimeoutAllowsTeamFormationToFinish(t *testing.T) {
 	}
 }
 
+func TestProxyRequestCarriesAgentRunID(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode proxy request: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer server.Close()
+
+	t.Setenv("SOLO_DAEMON_URL", server.URL)
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+	t.Setenv("SOLO_RUN_ID", "run-1")
+	status, _, err := proxyRequest("message_send", "channel-1", "done", "", "token", 0, "")
+	if err != nil {
+		t.Fatalf("proxyRequest: %v", err)
+	}
+	if status != http.StatusCreated {
+		t.Fatalf("status = %d", status)
+	}
+	if got["run_id"] != "run-1" {
+		t.Fatalf("run_id = %#v, want run-1", got["run_id"])
+	}
+}
+
 func TestIsTeamFormationInProgress(t *testing.T) {
 	if !isTeamFormationInProgress(http.StatusConflict, []byte(`{"error":"team formation is already in progress"}`)) {
 		t.Fatal("expected in-progress response to be retryable")

--- a/docs/superpowers/specs/2026-07-27-single-daemon-run-delivery-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-27-single-daemon-run-delivery-recovery-design.md
@@ -1,0 +1,383 @@
+# Solo 单用户、单 Daemon 运行与恢复架构
+
+日期：2026-07-27
+
+## 1. 目标与边界
+
+本设计解决三个用户可感知的问题：
+
+1. Agent 后台显示完成，但消息没有真正送达频道或 Thread。
+2. Server、Daemon 或前端短暂重启后，运行状态无法可靠恢复。
+3. Agent 失败后 Task 长时间停留在已领取状态，不能自动换人继续。
+
+当前产品约束是单用户、单 Server、单 Daemon、本地 PostgreSQL。设计明确不引入多租户隔离、Daemon 选主、分布式锁、租约、消息队列或跨节点共识。以后如果产品约束改变，再在持久化状态机外增加协调层；当前状态机和结果契约可以保留。
+
+## 2. 核心判断
+
+`agent_runs.id` 是一次 Agent 尝试的唯一运行身份，也是 Server、Daemon、CLI、事件和消息之间共同使用的 `run_id`。不再为同一次尝试生成第二个独立的 Daemon `task_id`。
+
+运行成功由结果契约决定，而不是由模型进程正常退出、SSE 收到 `complete`、产生过文本，或命令文本中出现过 `solo message send` 决定。
+
+普通消息和 Task 的结果契约是 `visible_message`：只有消息已经持久化到 `messages`，且消息的 `metadata.agent_run_id` 指向本次运行，运行才能进入 `completed`。
+
+Thinking 内部交接使用 `handoff` 契约；纯后台动作使用 `none`。第一阶段只强制普通消息和 Task 的 `visible_message`，现有 Thinking 交接保持兼容；后续在 Thinking 恢复阶段把交接写入同一确认事件。
+
+## 3. 领域模型与所有权
+
+### Task
+
+Task 表示用户目标。它可以经历多次 Agent 尝试，但同一时刻最多有一个有效的主运行。
+
+- 所有者：Server。
+- 持久化：`tasks`。
+- 生命周期：`todo -> in_progress -> done`，失败重派期间保持 `in_progress`。
+- 与运行的关系：`agent_run_task_links` 记录每次尝试，不覆盖历史。
+
+### AgentRun
+
+AgentRun 表示一次不可复用的执行尝试。
+
+- 所有者：Server 创建并决定终态。
+- 执行者：唯一 Daemon。
+- 唯一身份：`agent_runs.id`。
+- 生命周期：`queued -> running/streaming -> completed|failed|cancelled|timeout`。
+- 终态不可逆，首个终态生效。
+- `usage_json` 保存本次尝试的 input、output、cache read 和 cache write token 使用量。
+
+### AgentSession
+
+Session 表示 provider 可恢复的上下文。
+
+- 所有者：Server 保存映射，Daemon/runtime 产生 provider session ID。
+- 生命周期跨多个 Run。
+- 普通频道、Thread、Thinking node 的恢复必须带明确 scope，不能仅按 Agent 找“最近一次”。
+
+### ResultContract
+
+ResultContract 是运行成功必须满足的交付条件：
+
+- `visible_message`：必须存在与 Run、Agent、Channel、Thread/Thinking scope 一致的持久化消息。
+- `handoff`：必须存在已提交的 Thinking checkpoint/fork/return 交接。
+- `none`：backend 成功即完成，限无用户交付的后台动作。
+
+第一阶段把契约写入 `run_started` 事件 payload，避免为了单个枚举扩展 `agent_runs` 以及所有扫描查询。恢复逻辑需要读取时，从首个 `run_started` 事件取得。若未来按契约做高频筛选，再提升为列。
+
+### Message
+
+Message 是 `visible_message` 的唯一交付证明。
+
+- 所有者：Message API。
+- 只有数据库 INSERT 成功后才算送达。
+- Agent 消息写入 `metadata.agent_run_id` 和 `metadata.delivery = "visible"`。
+- Message API 校验 Run、Agent、Channel 及 Thread/Thinking scope，防止伪造或串线。
+- WebSocket 只是入库后的通知，不是事实来源。
+
+### RunEvent
+
+RunEvent 是追加式时间线和恢复证据。
+
+- `assistant_message` 只表示模型内部输出，不再表示用户可见结果。
+- 新增 `visible_message_sent`，只在消息成功入库后追加，payload 含 `message_id`。
+- `run_started` payload 保存 `result_contract`。
+- `usage` 和终态事件继续作为可观测时间线。
+
+## 4. 端到端数据流
+
+### 普通消息或 Task
+
+1. 前端消息先写入 Server/PostgreSQL。
+2. Server 解析目标 Agent，创建 `agent_runs` 记录。
+3. Server 将该 `agent_runs.id` 同时作为 Daemon `task_id` 和 `run_id`。
+4. Daemon 启动本地 Agent runtime，并注入 `SOLO_RUN_ID`。
+5. Agent 用 `solo message send` 交付。
+6. CLI 将 `run_id` 传给 Daemon proxy；直连 Server 的 fallback 也携带同一值。
+7. Message API 校验 scope，在同一数据库事实链上写入消息 metadata。
+8. 消息入库成功后追加 `visible_message_sent`。
+9. Daemon 上报 provider complete 和 usage。
+10. Server 收到 complete 后检查带本次 `agent_run_id` 的持久化消息；存在才完成，否则以 `missing_visible_result` 失败。`visible_message_sent` 只作为审计事件。
+
+模型纯文本、thinking、tool use 和 tool result 仍可进入 Agent 观察面，但不进入频道，也不满足结果契约。
+
+Provider final result 没有 usage，或持久 Session 返回的是累计 usage 时，Server 使用本次 Run 时间窗口内的本地 transcript usage 作为每次尝试的权威值。
+
+### Thinking 交接
+
+Thinking node 的消息仍由现有 protocol handler 处理。目标形态是在 checkpoint/fork/return 提交成功后追加 `handoff_committed`，再满足 `handoff` 契约。第一阶段不改变其对用户隐藏的交接行为，避免把协议消息误当频道消息。
+
+## 5. 持久化设计
+
+第一阶段不新增表和列：
+
+- `agent_runs.id`：统一运行身份。
+- `agent_runs.usage_json`：保存 `{input_tokens, output_tokens, cache_read_tokens, cache_write_tokens}`。
+- `messages.metadata`：保存 `agent_run_id`、`delivery`。
+- `agent_run_events`：
+  - `run_started.payload.result_contract`
+  - `visible_message_sent.payload.message_id`
+  - `error.payload.failure_code`
+
+这复用现有 schema，迁移成本为零。历史消息没有 `agent_run_id`，历史 Run 也没有结果契约；它们只读兼容，不回填，不参与自动重派。
+
+自动重派阶段再增加最小必要字段：
+
+- Task 的当前尝试次数优先通过 `agent_run_task_links` 聚合，不新增计数列。
+- 是否可重试由本次终态事件的 `failure_code/retryable` 决定。
+- 只有确认旧 Run 已终态且本地 runtime 已停止，才创建下一 Run。
+
+## 6. API 与进程边界
+
+### Server -> Daemon
+
+现有流式请求继续保留 `task_id` 与 `run_id` 以兼容混合版本，但新 Server 对两者赋相同值。Daemon 内部任务管理、SSE 路由、取消和日志都以该值工作。
+
+### Daemon -> Agent
+
+新增环境变量：
+
+```text
+SOLO_RUN_ID=<agent_runs.id>
+```
+
+该值属于 runtime，Agent 自定义环境不能覆盖。
+
+### Agent CLI -> Daemon/Server
+
+`solo message send` 自动读取 `SOLO_RUN_ID`：
+
+- Daemon proxy body 携带 `run_id`。
+- direct API fallback body 也携带 `run_id`。
+
+用户手工运行 CLI 时通常没有该变量，行为保持不变；只有 Agent 身份提交带 `run_id` 的消息才参与运行交付确认。
+
+### Message API
+
+`CreateMessageRequest` 增加可选 `run_id`。当 sender 是 Agent 且提供 `run_id` 时：
+
+- Run 必须存在。
+- `run.agent_id == sender_id`。
+- `run.channel_id == channel_id`。
+- Run 的 Thread/Thinking node scope 与最终解析后的消息 scope 一致时，消息才计为本次 Run 的交付。
+- Run 必须尚未进入终态。
+
+Run 不存在、已结束或不属于当前 Agent 时返回 409。Agent 在一次运行中发往其他合法 scope 的协作消息仍可正常落库，但不写交付 metadata，也不满足本次 Run 的结果契约；这样不会破坏现有跨频道协作。
+
+## 7. 前端状态
+
+前端不维护独立真相：
+
+- 页面刷新后从 API 重取 Run 和消息。
+- WebSocket/SSE 只做增量更新。
+- `agent.run.finished=completed` 意味着结果契约已经满足。
+- `failed + missing_visible_result` 显示 Agent 未交付结果；当前阶段复用 `agent.error` 通知和 Run 失败状态。
+- 自动重派阶段显示系统消息：“本次尝试未成功交付，Solo 正在自动改派（第 N/3 次）”。
+- 三次尝试耗尽后显示持久化系统消息，并把 Task 退回 `todo`、清空 claimer。
+
+无需为 `run_id` 增加新的前端 store；消息 metadata 和运行面板可用于诊断，但普通消息渲染不变。
+
+## 8. 失败恢复
+
+### Daemon 或本地 runtime 异常
+
+Server 以 Run 持久化状态为准。单 Daemon 重连后：
+
+- Daemon 能证明本地 task 仍在运行：重新订阅同一 `run_id`。
+- Daemon 无该 task：旧 Run 进入 `failed/daemon_lost`。
+- 不把旧 Run 改回 active，也不复用 Run ID 创建第二次尝试。
+- Daemon 正常退出时先强制关闭并回收全部 provider runtime，停止发送正常的 cancelled/complete 终态；随后注销，由 Server 统一写入 `daemon_lost`，最后才释放机器锁，避免旧 runtime 在重派后继续修改 Task。
+
+### Server 重启
+
+启动后扫描 active Run：
+
+- 对照唯一 Daemon 的运行列表。
+- 一致则恢复流订阅和前端投影。
+- 不一致则收敛为 `daemon_lost`，再按自动重派策略处理。
+
+### 前端断线
+
+前端重连后重新拉取消息和 Run 列表。因为可见结果与终态都已入库，不依赖补齐丢失的实时事件。
+
+### 缺少可见结果
+
+backend complete 但结果契约未满足：
+
+- Run 终态为 `failed`。
+- failure code 为 `missing_visible_result`。
+- 不把模型纯文本补写为频道消息。
+- 普通消息触发只通知失败；Task 触发进入自动重派判断。
+
+### 自动重派
+
+仅以下失败自动重派：
+
+- `daemon_lost`
+- `timeout`
+- `provider_transient`
+- `missing_visible_result`
+
+以下失败不重派：
+
+- 用户取消
+- 权限拒绝
+- 无效输入
+- Task 已完成或已被用户改派
+
+策略：
+
+1. 最多 3 次总尝试。
+2. 旧 Run 必须先终态，且确认 runtime 已停止。
+3. 优先排除刚失败的 Agent；没有其他符合条件的 Agent 时可在下一次重新选择原 Agent。
+4. Task 在尝试期间保持 `in_progress`，每次尝试保留独立 Run。
+5. 每次改派写可见系统消息。
+6. 三次耗尽后 Task 回到 `todo` 并清空 claimer，等待用户处理。
+
+单用户、单 Daemon 下不需要并发租约；数据库事务内检查 Task 当前状态和最新主 Run 足以防止 watchdog 与回调重复重派。
+
+## 9. 兼容与迁移
+
+- 不做数据库 schema 迁移。
+- 旧 Daemon 不认识 `run_id` 时仍可使用 `task_id`；新 Server 发送相同值。
+- 旧 CLI 不携带 `run_id` 的 Agent 消息仍能发送，但不能满足新 Run 的 `visible_message` 契约，因此 Server 与 Daemon 应作为一个版本通过 `make rebuild` 升级。
+- 用户手工消息、用户手工 CLI、历史消息和历史 Run 行为不变。
+- Thinking protocol 第一阶段保持现状，后续只增加交接确认事件。
+
+## 10. 验证
+
+第一阶段成功标准：
+
+1. Daemon 收到的 `task_id == run_id == agent_runs.id`。
+2. Agent runtime 环境中存在不可覆盖的 `SOLO_RUN_ID`。
+3. Agent 消息入库后 `messages.metadata.agent_run_id` 正确。
+4. 同一 Run 的 `visible_message_sent` 事件只在入库成功后出现。
+5. 只有内部文本而没有消息入库时，Run 不能是 `completed`。
+6. 正常交付时 Run 为 `completed`，usage 写入 `agent_runs.usage_json`。
+7. 前端可见消息和数据库记录一致。
+
+验证顺序：
+
+- Go 单元/集成测试覆盖 scope 校验、消息确认、统一身份、缺失结果和 usage。
+- `make rebuild` 启动真实前端、API、Daemon、PostgreSQL。
+- Playwright 通过真实 Agent runtime 触发一次正常交付和一次无法交付。
+- 同时断言浏览器可见结果、`messages.metadata`、`agent_run_events`、`agent_runs.status` 和 `usage_json`。
+
+## 11. 第二阶段实现边界
+
+### 第 1 轮：单 Daemon 重启收敛
+
+不新增恢复表或租约。Daemon 注册请求直接携带其内存中已知任务的
+`task_id` 列表；由于 `task_id == run_id`，Server 可与 PostgreSQL 中的
+active Run 做集合对账：
+
+- Server 内存仍在跟踪的 Run 不重复订阅。
+- Daemon 仍保留的 active/terminal Run 重新订阅原 SSE；Daemon 的 replayable
+  事件恢复 backend/session/complete/error/done，沿用原 Run，不创建新 Run。
+- PostgreSQL active、但 Daemon 快照不存在的 Run 以
+  `failed/daemon_lost` 收敛，并追加带 `failure_code` 与 `retryable` 的 error
+  事件。
+- Daemon 主动注销时同样使用 `daemon_lost`，不再误记为 timeout。
+
+恢复只依赖 Run 行、首个 `run_started.result_contract`、主 Task link 和 Agent
+配置；前端继续以现有 Run API/WebSocket 投影状态，不增加 store。旧 Daemon
+不发送任务快照时，active Run 会按单 Daemon 前提收敛为 `daemon_lost`，因此
+Server 与 Daemon 仍要求通过 `make rebuild` 同版本升级。
+
+### 第 2 轮：自动重派
+
+自动重派只挂在统一的 Run 终态入口之后，并且只处理带 primary Task link 的
+Run。数据库事务锁定 Task 行后检查：
+
+1. Task 仍未结束，且当前 claimer 未被用户改成其他 Agent。
+2. 本 Run 是该 Task 最新一次 primary 尝试。
+3. primary 尝试总数未超过 3。
+4. error 事件明确标记 `retryable=true`，且 failure code 属于
+   `daemon_lost/timeout/provider_transient/missing_visible_result`。
+
+满足条件时优先选择同 Channel 内另一个 active Agent；没有其他 Agent 才回退
+原 Agent。事务内把 Task 保持为 `in_progress` 并更新 claimer，事务提交后写一条
+持久化 system 消息并触发下一 Run。三次耗尽时事务内把 Task 退回 `todo`、
+清空 claimer，再写最终 system 消息。系统消息复用 `messages` 表和现有
+WebSocket 投影，不建重试表；尝试次数由 `agent_run_task_links` 聚合。
+
+重派触发必须在旧 Run 已终态之后。`daemon_lost` 表示旧 Daemon 已注销、重启后
+快照中不存在该任务或进程已不可达；timeout 先请求取消；provider/missing-result
+只在 Daemon 已发出 terminal SSE 后进入重派。这样新 Run 不与旧 runtime 并行。
+重派 Run 的任务上下文必须以数据库中的当前 `claimer_id` 为准，明确告知新 Agent
+它已是当前执行者；原 Task 创建消息中的旧 @mention 只保留为历史内容，不能用于
+拒绝本次执行。
+
+### 每轮门禁
+
+每轮都执行：
+
+- 正确性 Review：检查 frontend/server/daemon/runtime/session/database 全链路和
+  与历史行为的兼容性。
+- Ponytail Review：只保留现有表、事件、任务快照和一个事务入口；若能删减则先
+  删减再复测。
+- 真实 E2E：使用 `make rebuild` 管理真实 frontend/API/Daemon/PostgreSQL 和本地
+  Agent runtime；断言浏览器可见结果及数据库 Run/Event/Task/Message 状态。
+- 全量 Go 测试、前端 build/lint 和 `git diff --check`。
+
+## 12. 实施顺序与工作量
+
+1. 统一运行身份、交付确认、usage：4–6 人日。
+2. Server/Daemon 重启恢复与 SSE 重连：3–5 人日。
+3. Task 自动重派和三次熔断：5–8 人日。
+4. Channel/Thread/Thinking session 精确恢复：3–5 人日。
+5. 本地权限 profile：5–8 人日。
+6. 兼容清理、指标和故障演练：2–4 人日。
+
+实施按上述顺序分轮推进：先建立后续功能依赖的唯一运行身份和可信终态，再补恢复、自动重派与 Session 连续性；权限 profile 不在本 MR 范围内。
+
+## 13. 普通 Channel Session 重启连续性修订
+
+### 边界
+
+现有 scope 设计保持不变：
+
+- 普通 Channel、DM 和其 Thread 共用 `Channel + Agent` provider Session。
+- Thread 的消息、Run 和交付证明继续由 `thread_id` 精确路由；不为每个 Thread
+  新建 provider 进程。
+- Thinking node 继续使用独立 node Session 和现有 `ResumeSessionID`。
+
+本轮只验证并补齐普通 Channel provider Session 在 Daemon 重启后的连续性，不改变
+消息路由、Task 重派、Thinking 生命周期或前端状态模型。
+
+### 所有权与生命周期
+
+Server 继续拥有 `agent_sessions` 与 `agent_runs.session_id` 映射；Daemon 继续拥有
+活跃 provider 进程。Daemon 内存中已有 Channel Session 时直接发送新 turn；内存
+Session 不存在时，Server 从 PostgreSQL 查找同一 Agent、provider、Channel 且非
+Thinking scope 的最近 active provider session ID，并通过现有
+`resume_session_id` 传给 Daemon；closed Session 不恢复。
+
+Thread 与 Task thread 复用同一 Channel scope，因此恢复查询允许最近 Run 带或不带
+`thread_id`，但必须匹配 Agent、provider、Channel 且 `thinking_node_id IS NULL`。
+
+### 数据流、持久化和 API
+
+1. Run 收到 Daemon 的 session 事件后，现有逻辑继续 upsert `agent_sessions` 并写入
+   `agent_runs.session_id`。
+2. 后续普通 Channel/Thread/Task Run 在公共调度入口读取最近
+   `agent_sessions.external_session_id`。
+3. Server 复用现有 `daemonTaskRequest.ResumeSessionID`；不新增 HTTP 字段。
+4. Daemon 复用现有 `GetOrCreateScopedSession(..., resumeSessionID, ...)`。
+
+不新增表、列、索引或前端 store。历史 Run 没有 session 映射时按现有冷启动行为
+执行；查询失败也只记录日志并冷启动，不阻断用户消息。
+
+### 失败恢复与兼容
+
+- provider 拒绝 resume 时，现有 backend 行为回退到创建新 Session。
+- 活跃 Daemon 内存 Session 优先，数据库 resume ID 不替换正在运行的进程。
+- Thinking node 不进入普通 Channel 恢复查询。
+- 默认行为对旧数据和当前 Channel/Thread 路由完全兼容。
+
+### 真实验证
+
+真实 E2E 使用 Claude 和 make 管理的 frontend/API/Daemon/PostgreSQL：
+
+1. 在 Channel 中让 Agent 记住一个随机值并交付确认。
+2. 记录 Run 绑定的 `external_session_id`。
+3. 执行 `make rebuild`。
+4. 在同一 Channel 再次触发 Agent，验证用户可见回复仍包含该随机值。
+5. 验证新 Run 仍绑定同一个 `external_session_id`，且消息 metadata 指向新 Run。

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -1,0 +1,558 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const credentials = { email: 'agent-result-delivery-e2e@solo.local', password: 'SoloE2E-2026!' };
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+interface Entity {
+  id: string;
+  name: string;
+}
+
+interface TaskEntity {
+  id: string;
+  task_number: number;
+  title: string;
+}
+
+interface DeliveryState {
+  run_id: string;
+  status: string;
+  contract: string;
+  message_id: string;
+  visible_event: boolean;
+  input_tokens: number;
+  output_tokens: number;
+  failure_code: string;
+}
+
+interface RecoveryState {
+  run_id: string;
+  status: string;
+  backend_started: boolean;
+  failure_code: string;
+  retryable: boolean;
+  message_id: string;
+}
+
+interface ChannelSessionState {
+  run_id: string;
+  status: string;
+  external_session_id: string;
+  message_id: string;
+  message_content: string;
+}
+
+interface TaskRetryState {
+  status: string;
+  claimer_id: string;
+  attempts: number;
+  failed_attempts: number;
+  latest_status: string;
+  latest_agent_id: string;
+  latest_message_id: string;
+  reassigned_events: number;
+  retry_messages: number;
+  exhausted_messages: number;
+}
+
+function databaseJSON<T>(query: string): T {
+  const output = execFileSync('docker', [
+    'exec',
+    process.env.SOLO_POSTGRES_CONTAINER ?? 'solo-postgres',
+    'psql',
+    '-U', process.env.POSTGRES_USER ?? 'solo',
+    '-d', process.env.POSTGRES_DB ?? 'solo',
+    '-tA',
+    '-c', query,
+  ], { encoding: 'utf8' }).trim();
+  return JSON.parse(output) as T;
+}
+
+function deliveryState(agentID: string): DeliveryState {
+  return databaseJSON<DeliveryState>(`
+    WITH latest AS (
+      SELECT *
+        FROM agent_runs
+       WHERE agent_id = '${agentID}'
+       ORDER BY started_at DESC
+       LIMIT 1
+    )
+    SELECT COALESCE((
+      SELECT json_build_object(
+        'run_id', r.id::text,
+        'status', r.status,
+        'contract', COALESCE((
+          SELECT e.payload->>'result_contract'
+            FROM agent_run_events e
+           WHERE e.run_id = r.id AND e.type = 'run_started'
+           ORDER BY e.seq
+           LIMIT 1
+        ), ''),
+        'message_id', COALESCE((
+          SELECT m.id::text
+            FROM messages m
+           WHERE m.metadata->>'agent_run_id' = r.id::text
+           ORDER BY m.created_at
+           LIMIT 1
+        ), ''),
+        'visible_event', EXISTS(
+          SELECT 1 FROM agent_run_events e
+           WHERE e.run_id = r.id AND e.type = 'visible_message_sent'
+        ),
+        'input_tokens', COALESCE((r.usage_json->>'input_tokens')::int, 0),
+        'output_tokens', COALESCE((r.usage_json->>'output_tokens')::int, 0),
+        'failure_code', COALESCE((
+          SELECT e.payload->>'failure_code'
+            FROM agent_run_events e
+           WHERE e.run_id = r.id AND e.type = 'error'
+           ORDER BY e.seq DESC
+           LIMIT 1
+        ), '')
+      )::text
+      FROM latest r
+    ), '{"run_id":"","status":"","contract":"","message_id":"","visible_event":false,"input_tokens":0,"output_tokens":0,"failure_code":""}')
+  `);
+}
+
+function recoveryState(agentID: string): RecoveryState {
+  return databaseJSON<RecoveryState>(`
+    WITH latest AS (
+      SELECT *
+        FROM agent_runs
+       WHERE agent_id = '${agentID}'
+       ORDER BY started_at DESC
+       LIMIT 1
+    )
+    SELECT COALESCE((
+      SELECT json_build_object(
+        'run_id', r.id::text,
+        'status', r.status,
+        'backend_started', r.backend_started_at IS NOT NULL,
+        'failure_code', COALESCE((
+          SELECT e.payload->>'failure_code'
+            FROM agent_run_events e
+           WHERE e.run_id = r.id AND e.type = 'error'
+           ORDER BY e.seq DESC
+           LIMIT 1
+        ), ''),
+        'retryable', COALESCE((
+          SELECT (e.payload->>'retryable')::boolean
+            FROM agent_run_events e
+           WHERE e.run_id = r.id AND e.type = 'error'
+           ORDER BY e.seq DESC
+           LIMIT 1
+        ), false),
+        'message_id', COALESCE((
+          SELECT m.id::text
+            FROM messages m
+           WHERE m.metadata->>'agent_run_id' = r.id::text
+           LIMIT 1
+        ), '')
+      )::text
+      FROM latest r
+    ), '{"run_id":"","status":"","backend_started":false,"failure_code":"","retryable":false,"message_id":""}')
+  `);
+}
+
+function channelSessionState(triggerMessageID: string): ChannelSessionState {
+  return databaseJSON<ChannelSessionState>(`
+    SELECT COALESCE((
+      SELECT json_build_object(
+        'run_id', r.id::text,
+        'status', r.status,
+        'external_session_id', COALESCE(s.external_session_id, ''),
+        'message_id', COALESCE(m.id::text, ''),
+        'message_content', COALESCE(m.content, '')
+      )::text
+        FROM agent_runs r
+        LEFT JOIN agent_sessions s ON s.id = r.session_id
+        LEFT JOIN LATERAL (
+          SELECT id, content
+            FROM messages
+           WHERE metadata->>'agent_run_id' = r.id::text
+           ORDER BY created_at
+           LIMIT 1
+        ) m ON true
+       WHERE r.trigger_message_id = '${triggerMessageID}'
+       ORDER BY r.started_at DESC
+       LIMIT 1
+    ), '{"run_id":"","status":"","external_session_id":"","message_id":"","message_content":""}')
+  `);
+}
+
+function taskRetryState(taskID: string): TaskRetryState {
+  return databaseJSON<TaskRetryState>(`
+    WITH linked AS (
+      SELECT r.*
+        FROM agent_runs r
+        JOIN agent_run_task_links link ON link.run_id = r.id AND link.role = 'primary'
+       WHERE link.task_id = '${taskID}'
+         AND (
+           SELECT e.payload->>'result_contract'
+             FROM agent_run_events e
+            WHERE e.run_id = r.id AND e.type = 'run_started'
+            ORDER BY e.seq
+            LIMIT 1
+         ) = 'visible_message'
+    ), latest AS (
+      SELECT * FROM linked ORDER BY started_at DESC, id DESC LIMIT 1
+    )
+    SELECT json_build_object(
+      'status', t.status,
+      'claimer_id', COALESCE(t.claimer_id::text, ''),
+      'attempts', (SELECT COUNT(*) FROM linked),
+      'failed_attempts', (SELECT COUNT(*) FROM linked WHERE status IN ('failed', 'timeout')),
+      'latest_status', COALESCE((SELECT status FROM latest), ''),
+      'latest_agent_id', COALESCE((SELECT agent_id::text FROM latest), ''),
+      'latest_message_id', COALESCE((
+        SELECT m.id::text
+          FROM messages m
+         WHERE m.metadata->>'agent_run_id' = (SELECT id::text FROM latest)
+         LIMIT 1
+      ), ''),
+      'reassigned_events', (
+        SELECT COUNT(*) FROM agent_run_events e
+         WHERE e.run_id IN (SELECT id FROM linked) AND e.type = 'task_reassigned'
+      ),
+      'retry_messages', (
+        SELECT COUNT(*) FROM messages m
+         WHERE m.metadata->>'task_id' = t.id::text
+           AND m.metadata->>'auto_reassign' = 'true'
+           AND m.metadata->>'exhausted' = 'false'
+      ),
+      'exhausted_messages', (
+        SELECT COUNT(*) FROM messages m
+         WHERE m.metadata->>'task_id' = t.id::text
+           AND m.metadata->>'exhausted' = 'true'
+      )
+    )::text
+    FROM tasks t
+    WHERE t.id = '${taskID}'
+  `);
+}
+
+async function authenticate(request: APIRequestContext): Promise<AuthResponse> {
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, { data: credentials });
+  if (login.ok()) return login.json();
+  const register = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: { ...credentials, display_name: 'Agent Result Delivery E2E' },
+  });
+  if (!register.ok()) throw new Error(`E2E authentication failed: ${register.status()} ${await register.text()}`);
+  return register.json();
+}
+
+async function api<T>(
+  request: APIRequestContext,
+  token: string,
+  method: 'post' | 'delete',
+  path: string,
+  data?: unknown,
+): Promise<T> {
+  const response = await request[method](`${apiBase}${path}`, {
+    headers: { authorization: `Bearer ${token}` },
+    data,
+  });
+  if (!response.ok()) throw new Error(`${method.toUpperCase()} ${path}: ${response.status()} ${await response.text()}`);
+  if (response.status() === 204) return undefined as T;
+  return response.json();
+}
+
+async function authenticatePage(page: Page, auth: AuthResponse) {
+  await page.addInitScript(({ accessToken, refreshToken }) => {
+    localStorage.setItem('access_token', accessToken);
+    localStorage.setItem('refresh_token', refreshToken);
+    localStorage.setItem('solo.locale', 'en');
+  }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+}
+
+test.describe('real Agent result delivery contract', () => {
+  test.skip(process.env.SOLO_E2E_REAL_AGENT_DELIVERY !== '1', 'requires the make-managed stack and authenticated local Claude runtime');
+  test.setTimeout(240000);
+
+  test('persists and renders a run-linked visible result before completing', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `delivery-e2e-${suffix}`,
+        description: 'Real Agent visible delivery contract E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Delivery E2E ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: 'When asked to introduce yourself, use solo message send to post the introduction to the current channel. Do not merely print it.',
+      });
+
+      await expect.poll(() => {
+        const state = deliveryState(agent!.id);
+        return `${state.status}/${state.contract}/${Boolean(state.message_id)}/${state.visible_event}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('completed/visible_message/true/true');
+
+      const state = deliveryState(agent.id);
+      expect(state.input_tokens + state.output_tokens).toBeGreaterThan(0);
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      const persistedMessage = page.locator(`[data-message-id="${state.message_id}"]`);
+      await expect(persistedMessage).toBeVisible();
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('fails a completed backend that did not persist a visible result', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `missing-delivery-e2e-${suffix}`,
+        description: 'Real Agent missing delivery contract E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Missing Delivery E2E ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        custom_args: ['--tools', ''],
+        system_prompt: 'Do not use tools. Respond with exactly INTERNAL_ONLY as plain text and stop.',
+      });
+
+      await expect.poll(() => {
+        const state = deliveryState(agent!.id);
+        return `${state.status}/${state.failure_code}/${Boolean(state.message_id)}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('failed/missing_visible_result/false');
+
+      await authenticatePage(page, auth);
+      await page.goto('/observability/live');
+      const card = page.locator('button').filter({ hasText: agent.name }).first();
+      await expect(card).toBeVisible();
+      await expect(card).toContainText('Failed');
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('converges an interrupted real Agent run after the make-managed stack restarts', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `daemon-recovery-e2e-${suffix}`,
+        description: 'Real daemon restart recovery E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Daemon Recovery E2E ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: 'Before introducing yourself, you must run the Bash command `sleep 60` and wait for it to finish. Only then use solo message send. Do not skip the wait.',
+      });
+
+      await expect.poll(() => {
+        const state = recoveryState(agent!.id);
+        return Boolean(state.run_id) && state.backend_started
+          && ['running', 'thinking', 'streaming', 'waiting_input', 'waiting_approval'].includes(state.status);
+      }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe(true);
+      const interruptedRunID = recoveryState(agent.id).run_id;
+
+      execFileSync('make', ['rebuild'], { cwd: '..', stdio: 'inherit' });
+
+      await expect.poll(() => {
+        const state = recoveryState(agent!.id);
+        return `${state.run_id}/${state.status}/${state.failure_code}/${state.retryable}/${Boolean(state.message_id)}`;
+      }, { timeout: 60000, intervals: [500, 1000, 2000] }).toBe(`${interruptedRunID}/failed/daemon_lost/true/false`);
+
+      await authenticatePage(page, auth);
+      await page.goto('/observability/live');
+      const card = page.locator('button').filter({ hasText: agent.name }).first();
+      await expect(card).toBeVisible();
+      await expect(card).toContainText('Stopped because the local daemon restarted');
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('resumes the same real Channel provider Session after the stack restarts', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    const secret = `CHANNEL_MEMORY_${suffix.toUpperCase()}`;
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `channel-session-resume-e2e-${suffix}`,
+        description: 'Real Channel provider Session restart continuity E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Channel Session Resume E2E ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: [
+          'The sender label @Agent Result Delivery E2E identifies the human test user, not another Agent; its messages are directed to you.',
+          'Always deliver replies with solo message send.',
+          'When introducing yourself, send exactly READY.',
+          'When a user says REMEMBER followed by a value, retain it only in the current conversation and send exactly STORED.',
+          'When a user says RECALL, send exactly RECALLED followed by the remembered value.',
+          'Never use message read, files, MEMORY.md, databases, or other storage for REMEMBER or RECALL.',
+        ].join(' '),
+      });
+
+      await expect.poll(() => deliveryState(agent!.id).status, {
+        timeout: 180000, intervals: [500, 1000, 2000],
+      }).toBe('completed');
+
+      const rememberMessage = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: `REMEMBER ${secret}` },
+      );
+      await expect.poll(() => {
+        const state = channelSessionState(rememberMessage.id);
+        return `${state.status}/${Boolean(state.external_session_id)}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('completed/true/STORED');
+      const first = channelSessionState(rememberMessage.id);
+
+      execFileSync('make', ['rebuild'], { cwd: '..', stdio: 'inherit' });
+
+      const recallMessage = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: 'RECALL' },
+      );
+      await expect.poll(() => {
+        const state = channelSessionState(recallMessage.id);
+        return `${state.status}/${state.external_session_id}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${first.external_session_id}/RECALLED ${secret}`,
+      );
+
+      const recalled = channelSessionState(recallMessage.id);
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.locator(`[data-message-id="${recalled.message_id}"]`)).toContainText(`RECALLED ${secret}`);
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('automatically reassigns a failed real Task run to another Agent', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let failingAgent: Entity | null = null;
+    let succeedingAgent: Entity | null = null;
+    let task: TaskEntity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `auto-reassign-e2e-${suffix}`,
+        description: 'Real Task automatic reassignment E2E',
+      });
+      failingAgent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `FailingWorker${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: 'For every Task, first run the Bash command `sleep 60` and wait for it to finish. Only then use solo message send once with the requested target. Do not skip the wait.',
+      });
+      succeedingAgent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `SuccessfulWorker${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: 'For a Task, do not submit or close it. Use solo message send exactly once with the target from the request to deliver a concise completed result.',
+      });
+      task = await api<TaskEntity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/tasks`, {
+        title: `@${failingAgent.name} Automatic reassignment ${suffix}`,
+        description: 'Deliver a short confirmation through solo message send.',
+      });
+
+      await expect.poll(() => {
+        const state = taskRetryState(task!.id);
+        const active = ['queued', 'running', 'thinking', 'streaming', 'waiting_input', 'waiting_approval'].includes(state.latest_status);
+        return `${state.attempts}/${state.latest_agent_id}/${active}`;
+      }, { timeout: 120000, intervals: [500, 1000, 2000] }).toBe(`1/${failingAgent.id}/true`);
+
+      execFileSync('make', ['rebuild'], { cwd: '..', stdio: 'inherit' });
+
+      await expect.poll(() => {
+        const state = taskRetryState(task!.id);
+        return `${state.status}/${state.claimer_id}/${state.attempts}/${state.failed_attempts}/${state.latest_status}/${state.latest_agent_id}/${Boolean(state.latest_message_id)}/${state.reassigned_events}/${state.retry_messages}`;
+      }, { timeout: 180000, intervals: [1000, 2000, 5000] }).toBe(
+        `in_progress/${succeedingAgent.id}/2/1/completed/${succeedingAgent.id}/true/1/1`,
+      );
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.getByText(/Solo 正在自动改派/).first()).toBeVisible();
+    } finally {
+      if (task && channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}/tasks/${task.id}`).catch(() => undefined);
+      if (succeedingAgent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${succeedingAgent.id}`).catch(() => undefined);
+      if (failingAgent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${failingAgent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('stops after three failed real Task attempts and returns it to TODO', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+    let task: TaskEntity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `retry-exhaustion-e2e-${suffix}`,
+        description: 'Real Task retry exhaustion E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Always Failing Worker ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        custom_env: {
+          SOLO_API_URL: 'http://127.0.0.1:1',
+          SOLO_DAEMON_URL: 'http://127.0.0.1:1',
+        },
+        system_prompt: 'For every request, run solo message send once with the requested target and append || true. Then stop without sending any other message.',
+      });
+      task = await api<TaskEntity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/tasks`, {
+        title: `Retry exhaustion ${suffix}`,
+        description: 'This real Task intentionally cannot deliver.',
+      });
+
+      await expect.poll(() => {
+        const state = taskRetryState(task!.id);
+        return `${state.status}/${Boolean(state.claimer_id)}/${state.attempts}/${state.failed_attempts}/${state.latest_status}/${state.reassigned_events}/${state.retry_messages}/${state.exhausted_messages}`;
+      }, { timeout: 220000, intervals: [1000, 2000, 5000] }).toBe('todo/false/3/3/failed/2/2/1');
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.getByText(/自动重派已尝试 3 次/).first()).toBeVisible();
+    } finally {
+      if (task && channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}/tasks/${task.id}`).catch(() => undefined);
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+});

--- a/frontend/lib/agent-activity.ts
+++ b/frontend/lib/agent-activity.ts
@@ -45,6 +45,7 @@ const ACTIVITY_TEXT_KEYS: Record<string, TranslationKey> = {
   'agent.activity.cancelled': 'agentActivityCancelled',
   'agent.activity.timeout': 'agentActivityTimeout',
   'agent.activity.failed': 'agentActivityFailed',
+  'agent.activity.daemon_lost': 'agentActivityDaemonLost',
   '已接收，正在处理': 'agentActivityAccepted',
   '仍在运行，暂无可见回复': 'agentActivityNoVisibleReply',
   '仍在运行，暂无新的进度': 'agentActivityNoProgress',
@@ -56,6 +57,7 @@ const ACTIVITY_TEXT_KEYS: Record<string, TranslationKey> = {
 
 const AGENT_ERROR_KEYS: Record<string, TranslationKey> = {
   'agent.error.no_available_daemon': 'agentErrorNoAvailableDaemon',
+  'agent.error.missing_visible_result': 'agentErrorMissingVisibleResult',
   'No available daemon to run this agent.': 'agentErrorNoAvailableDaemon',
 };
 

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -606,8 +606,10 @@ const en = {
   agentActivityCancelled: 'Cancelled',
   agentActivityTimeout: 'Timed out',
   agentActivityFailed: 'Failed',
+  agentActivityDaemonLost: 'Stopped because the local daemon restarted',
   agentRunFailedToast: '{name} failed: {reason}',
   agentErrorNoAvailableDaemon: 'No available runtime. Start a daemon and try again.',
+  agentErrorMissingVisibleResult: 'The agent finished without delivering a message. Please try again.',
 
   // ── Agent Run Status ──
   runQueued: 'Queued',
@@ -1496,8 +1498,10 @@ const zhCN = {
   agentActivityCancelled: '已取消',
   agentActivityTimeout: '执行超时',
   agentActivityFailed: '执行失败',
+  agentActivityDaemonLost: '本地 Daemon 重启，执行已中断',
   agentRunFailedToast: '{name} 运行失败：{reason}',
   agentErrorNoAvailableDaemon: '没有可用运行时。请先启动 daemon 后重试。',
+  agentErrorMissingVisibleResult: 'Agent 已结束，但没有交付消息，请重试。',
   runQueued: '排队中',
   runThinking: '思考中',
   runRunning: '运行中',

--- a/internal/server/handler/daemon.go
+++ b/internal/server/handler/daemon.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -64,6 +65,9 @@ func (h *DaemonHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.dm.Register(info)
+	if h.agent != nil {
+		go h.agent.ReconcileDaemonRuns(context.Background(), info, req.Tasks)
+	}
 
 	// Persist computer record via ComputerService
 	if h.computerSvc != nil {

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -92,6 +92,7 @@ type CreateMessageRequest struct {
 	AttachmentIDs  []string `json:"attachment_ids,omitempty"`
 	ThreadID       string   `json:"thread_id,omitempty"`
 	ThinkingNodeID string   `json:"thinking_node_id,omitempty"`
+	RunID          string   `json:"run_id,omitempty"`
 }
 
 // AttachmentMeta is the attachment metadata included in message responses.
@@ -168,6 +169,13 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "message content exceeds maximum length of 10000 characters")
 		return
 	}
+	runID := strings.TrimSpace(req.RunID)
+	if runID != "" {
+		if _, err := uuid.Parse(runID); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid run ID")
+			return
+		}
+	}
 	thinkingNodeID := strings.TrimSpace(req.ThinkingNodeID)
 	if thinkingNodeID != "" {
 		if req.ThreadID != "" || req.AsTask {
@@ -223,6 +231,10 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			writeThinkingScopeError(w, err)
 			return
 		}
+	}
+	if runID != "" && !isAgent {
+		writeError(w, http.StatusBadRequest, "run ID is only valid for agent messages")
+		return
 	}
 	if thinkingNodeID != "" && (req.ThreadID != "" || req.AsTask) {
 		writeError(w, http.StatusBadRequest, "thinking node messages cannot also be threads or tasks")
@@ -299,6 +311,17 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		if err != nil || ownedCount != len(attachmentIDs) {
 			writeError(w, http.StatusBadRequest, "one or more attachment IDs are invalid")
 			return
+		}
+	}
+	deliveryRunID := ""
+	if runID != "" {
+		scopeMatches, err := service.NewAgentRunService(h.pool).ValidateMessageDelivery(r.Context(), runID, userID, channelID, threadID, thinkingNodeID)
+		if err != nil {
+			writeError(w, http.StatusConflict, "invalid agent run")
+			return
+		}
+		if scopeMatches {
+			deliveryRunID = runID
 		}
 	}
 
@@ -405,15 +428,31 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if threadID != "" {
 		nullableThreadID = threadID
 	}
+	metadata := map[string]any{}
+	if deliveryRunID != "" {
+		metadata["agent_run_id"] = deliveryRunID
+		metadata["delivery"] = "visible"
+	}
+	metadataJSON, _ := json.Marshal(metadata)
 	_, err = h.pool.Exec(r.Context(),
-		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::uuid[], $9::uuid[], $10, $10)`,
-		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), now,
+		`INSERT INTO messages (id, channel_id, thread_id, thinking_node_id, sender_type, sender_id, content, mentioned_agent_ids, attachment_ids, metadata, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8::uuid[], $9::uuid[], $10::jsonb, $11, $11)`,
+		messageID, channelID, nullableThreadID, nullableUUIDString(thinkingNodeID), senderType, userID, content, formatUUIDArray(mentionedAgentIDs), formatUUIDArray(attachmentIDs), metadataJSON, now,
 	)
 	if err != nil {
 		slog.Error("failed to persist message", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to send message")
 		return
+	}
+	if deliveryRunID != "" {
+		if _, err := service.NewAgentRunService(h.pool).AppendEvent(r.Context(), service.AppendRunEventInput{
+			RunID:   deliveryRunID,
+			Type:    service.AgentRunEventVisibleMessageSent,
+			Message: "visible message persisted",
+			Payload: map[string]string{"message_id": messageID},
+		}); err != nil {
+			slog.Warn("failed to append visible message run event", "run_id", deliveryRunID, "message_id", messageID, "error", err)
+		}
 	}
 	if thinkingNodeID != "" {
 		thinkingSvc := service.NewThinkingService(h.pool)
@@ -494,6 +533,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 				SenderAvatar:  senderAvatar,
 				Content:       content,
 				ContentType:   "text",
+				Metadata:      metadata,
 				AttachmentIDs: attachmentIDs,
 				Attachments:   toWSAttachmentMeta(attachments),
 				CreatedAt:     now.UTC().Format(time.RFC3339),
@@ -566,6 +606,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			SenderAvatar:      senderAvatar,
 			Content:           content,
 			ContentType:       "text",
+			Metadata:          metadata,
 			ThreadID:          threadID,
 			ThinkingNodeID:    thinkingNodeID,
 			MentionedAgentIDs: mentionedAgentIDs,
@@ -620,12 +661,13 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	resp := MessageResponse{
 		ID:                messageID,
 		ChannelID:         channelID,
-		SenderType:        "user",
+		SenderType:        senderType,
 		SenderID:          userID,
 		SenderName:        displayName,
 		SenderAvatar:      senderAvatar,
 		Content:           content,
 		ContentType:       "text",
+		Metadata:          metadata,
 		MentionedAgentIDs: mentionedAgentIDs,
 		AttachmentIDs:     attachmentIDs,
 		Attachments:       attachments,

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/solo-ai/solo/internal/realtime"
 	"github.com/solo-ai/solo/pkg/agent"
@@ -42,8 +43,18 @@ const (
 	agentActivityCancelled      = "agent.activity.cancelled"
 	agentActivityTimeout        = "agent.activity.timeout"
 	agentActivityFailed         = "agent.activity.failed"
+	agentActivityDaemonLost     = "agent.activity.daemon_lost"
 
-	agentErrorNoAvailableDaemon = "agent.error.no_available_daemon"
+	agentErrorNoAvailableDaemon    = "agent.error.no_available_daemon"
+	agentErrorMissingVisibleResult = "agent.error.missing_visible_result"
+
+	agentResultContractVisibleMessage = "visible_message"
+	agentResultContractHandoff        = "handoff"
+	agentResultContractNone           = "none"
+	agentFailureMissingVisibleResult  = "missing_visible_result"
+	agentFailureDaemonLost            = "daemon_lost"
+	agentFailureTimeout               = "timeout"
+	agentFailureProviderTransient     = "provider_transient"
 )
 
 // maxAgentChainDepth limits the depth of agent-to-agent trigger chains
@@ -225,7 +236,6 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 
 		// Build the task request
 		taskReq := daemonTaskRequest{
-			TaskID:           uuid.New().String(),
 			AgentID:          ag.ID,
 			ChannelID:        channelID,
 			TriggerMessageID: messageID,
@@ -238,6 +248,7 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 			TaskContext:    taskContext,
 			AgentChain:     newChain,
 			MentionedNames: mentionedNames,
+			ResultContract: agentResultContractVisibleMessage,
 		}
 
 		// Dispatch via streaming SSE and handle events
@@ -370,7 +381,6 @@ func (s *AgentService) triggerAgentResponseInNode(ctx context.Context, channelID
 			continue
 		}
 		taskReq := daemonTaskRequest{
-			TaskID:                uuid.NewString(),
 			AgentID:               ag.ID,
 			ChannelID:             channelID,
 			NodeID:                nodeID,
@@ -384,6 +394,10 @@ func (s *AgentService) triggerAgentResponseInNode(ctx context.Context, channelID
 			MentionedNames:        mentionedNames,
 			ResumeSessionID:       nodeCtx.ResumeSessionID,
 			ReturnHandoff:         returnHandoff,
+			ResultContract:        agentResultContractVisibleMessage,
+		}
+		if handoffRun {
+			taskReq.ResultContract = agentResultContractHandoff
 		}
 		go s.handleStreamingAgentTask(context.Background(), daemon, taskReq, ag)
 		dispatched = true
@@ -593,6 +607,14 @@ func (s *AgentService) broadcastAgentError(threadID, channelID, agentID, agentNa
 // handleStreamingAgentTask dispatches a task to a daemon via SSE streaming
 // and forwards events to WebSocket subscribers.
 func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *DaemonInfo, taskReq daemonTaskRequest, ag agentChannelInfo) {
+	s.runStreamingAgentTask(ctx, daemon, taskReq, ag, nil)
+}
+
+func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *DaemonInfo, taskReq daemonTaskRequest, ag agentChannelInfo, existingRun *AgentRun) {
+	resultContract := taskReq.ResultContract
+	if resultContract == "" {
+		resultContract = agentResultContractVisibleMessage
+	}
 	if taskReq.ReturnHandoff {
 		defer func() {
 			cleared, err := NewThinkingService(s.pool).CancelReturn(context.Background(), taskReq.NodeID)
@@ -616,41 +638,62 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 		agentName = "Agent"
 	}
 
-	// Track this task for daemon offline cleanup (cleanup on return)
-	s.dm.TrackTask(taskReq.TaskID, daemon.ID, ag.ID)
-	defer s.dm.RemoveTask(taskReq.TaskID)
-
 	// Queue and backend execution are timed independently by DaemonManager.
 	// This context is cancelled when either phase exceeds its own deadline.
 	streamCtx, streamCancel := context.WithCancel(ctx)
 	defer streamCancel()
 
-	// Pre-generate a message ID for the streaming message
-	streamMessageID := uuid.New().String()
 	runSvc := NewAgentRunService(s.pool)
 	triggerType := AgentRunTriggerMessage
 	if taskReq.OriginTaskID != "" {
 		triggerType = AgentRunTriggerTask
 	}
-	run, err := runSvc.StartRun(ctx, StartRunInput{
-		AgentID:          ag.ID,
-		TriggerType:      triggerType,
-		TriggerMessageID: taskReq.TriggerMessageID,
-		ChannelID:        taskReq.ChannelID,
-		ThreadID:         taskReq.ThreadID,
-		ThinkingNodeID:   taskReq.NodeID,
-		Status:           AgentRunStatusQueued,
-		ActivityText:     "等待执行",
-		Source:           taskReq.ModelConfig.Provider,
-	})
-	if err != nil {
-		slog.Warn("failed to start agent run", "task_id", taskReq.TaskID, "agent_id", ag.ID, "error", err)
+	newRun := existingRun == nil
+	run := existingRun
+	if newRun && taskReq.NodeID == "" && taskReq.ResumeSessionID == "" {
+		err := s.pool.QueryRow(ctx, `
+			SELECT sess.external_session_id
+			  FROM agent_runs r
+			  JOIN agent_sessions sess ON sess.id = r.session_id
+			 WHERE r.agent_id = $1
+			   AND r.channel_id = $2
+			   AND r.thinking_node_id IS NULL
+			   AND sess.provider = $3
+			   AND sess.status = 'active'
+			   AND COALESCE(sess.external_session_id, '') <> ''
+			 ORDER BY sess.last_active_at DESC, r.updated_at DESC
+			 LIMIT 1`,
+			ag.ID, taskReq.ChannelID, taskReq.ModelConfig.Provider,
+		).Scan(&taskReq.ResumeSessionID)
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn("failed to load channel session for resume", "agent_id", ag.ID, "channel_id", taskReq.ChannelID, "error", err)
+		}
 	}
-	if run != nil {
-		s.dm.AttachTaskRun(taskReq.TaskID, run.ID)
-		taskReq.RunID = run.ID
+	if newRun {
+		var err error
+		run, err = runSvc.StartRun(ctx, StartRunInput{
+			AgentID:          ag.ID,
+			TriggerType:      triggerType,
+			TriggerMessageID: taskReq.TriggerMessageID,
+			ChannelID:        taskReq.ChannelID,
+			ThreadID:         taskReq.ThreadID,
+			ThinkingNodeID:   taskReq.NodeID,
+			Status:           AgentRunStatusQueued,
+			ActivityText:     "等待执行",
+			Source:           taskReq.ModelConfig.Provider,
+		})
+		if err != nil {
+			slog.Warn("failed to start agent run", "agent_id", ag.ID, "error", err)
+			s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, err.Error())
+			return
+		}
 	}
-	if run != nil && taskReq.OriginTaskID != "" {
+	taskReq.TaskID = run.ID
+	taskReq.RunID = run.ID
+	s.dm.TrackTask(run.ID, daemon.ID, ag.ID)
+	s.dm.AttachTaskRun(run.ID, run.ID)
+	defer s.dm.RemoveTask(run.ID)
+	if newRun && taskReq.OriginTaskID != "" {
 		if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: run.ID, TaskID: taskReq.OriginTaskID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
 			slog.Warn("failed to link agent run task", "run_id", run.ID, "task_id", taskReq.OriginTaskID, "error", err)
 		} else {
@@ -661,7 +704,7 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 			})
 		}
 	}
-	if run != nil {
+	if newRun {
 		s.broadcastAgentRun(taskReq.ChannelID, "agent.run.started", runPayload(run, ag.ID, agentName, taskReq.OriginTaskID))
 		if taskReq.TriggerMessageID != "" {
 			s.appendAndBroadcastRunEvent(ctx, runSvc, run, ag.ID, agentName, AgentRunEventUserMessageReceived, "用户消息触发 run", "", map[string]any{
@@ -674,6 +717,7 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 			"trigger_type":       triggerType,
 			"trigger_message_id": taskReq.TriggerMessageID,
 			"task_id":            taskReq.OriginTaskID,
+			"result_contract":    resultContract,
 		})
 	}
 
@@ -700,6 +744,9 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 		s.broadcastAgentChunk(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, "context", lastMsg.Content, nil)
 	}
 
+	var inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens int
+	failureCode := ""
+	retryable := false
 	finishRun := func(status AgentRunStatus) {
 		if run == nil {
 			return
@@ -709,10 +756,56 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 			run = current
 			return
 		}
+		if run.TranscriptPath != "" {
+			entries, transcriptErr := ReadAgentTranscriptWindow(run.TranscriptPath, run.StartedAt.Add(-time.Second), time.Now().UTC().Add(time.Second), 10000)
+			if transcriptErr != nil {
+				slog.Warn("failed to read agent usage from transcript", "run_id", run.ID, "error", transcriptErr)
+			} else {
+				var transcriptInput, transcriptOutput, transcriptCacheRead, transcriptCacheWrite int
+				for _, entry := range entries {
+					if entry.Usage == nil {
+						continue
+					}
+					transcriptInput += int(entry.Usage.InputTokens)
+					transcriptOutput += int(entry.Usage.OutputTokens)
+					transcriptCacheRead += int(entry.Usage.CacheReadInputTokens)
+					transcriptCacheWrite += int(entry.Usage.CacheCreationInputTokens)
+				}
+				if transcriptInput > 0 || transcriptOutput > 0 || transcriptCacheRead > 0 || transcriptCacheWrite > 0 {
+					inputTokens = transcriptInput
+					outputTokens = transcriptOutput
+					cacheReadTokens = transcriptCacheRead
+					cacheWriteTokens = transcriptCacheWrite
+				}
+			}
+		}
+		if status == AgentRunStatusCompleted && resultContract == agentResultContractVisibleMessage {
+			visible, visibleErr := runSvc.HasVisibleMessage(ctx, run.ID)
+			if visibleErr != nil {
+				slog.Warn("failed to verify visible agent result", "run_id", run.ID, "error", visibleErr)
+			}
+			if visibleErr != nil || !visible {
+				status = AgentRunStatusFailed
+				failureCode = agentFailureMissingVisibleResult
+				retryable = true
+				s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, agentErrorMissingVisibleResult)
+			}
+		}
+		activityText := finalStateActivityText(status)
+		if failureCode == agentFailureDaemonLost {
+			activityText = agentActivityDaemonLost
+		}
+		usage := map[string]int{
+			"input_tokens":       inputTokens,
+			"output_tokens":      outputTokens,
+			"cache_read_tokens":  cacheReadTokens,
+			"cache_write_tokens": cacheWriteTokens,
+		}
 		finished, err := runSvc.FinishRun(ctx, FinishRunInput{
 			RunID:        run.ID,
 			Status:       status,
-			ActivityText: finalStateActivityText(status),
+			ActivityText: activityText,
+			Usage:        usage,
 		})
 		if errors.Is(err, ErrAgentRunAlreadyFinished) {
 			run = finished
@@ -722,20 +815,32 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 			slog.Warn("failed to finish agent run", "run_id", run.ID, "status", status, "error", err)
 			finished = run
 			finished.Status = status
-			finished.ActivityText = finalStateActivityText(status)
+			finished.ActivityText = activityText
+		}
+		if inputTokens > 0 || outputTokens > 0 || cacheReadTokens > 0 || cacheWriteTokens > 0 {
+			s.appendAndBroadcastRunEvent(ctx, runSvc, finished, ag.ID, agentName, AgentRunEventUsage, "usage", "", usage)
 		}
 		eventType := AgentRunEventDone
 		if status != AgentRunStatusCompleted {
 			eventType = AgentRunEventError
 		}
-		s.appendAndBroadcastRunEvent(ctx, runSvc, finished, ag.ID, agentName, eventType, finalStateActivityText(status), "", map[string]any{
-			"status": status,
-		})
+		eventPayload := map[string]any{"status": status}
+		if failureCode != "" {
+			eventPayload["failure_code"] = failureCode
+			eventPayload["retryable"] = retryable
+		}
+		s.appendAndBroadcastRunEvent(ctx, runSvc, finished, ag.ID, agentName, eventType, activityText, "", eventPayload)
 		s.broadcastAgentRun(taskReq.ChannelID, "agent.run.finished", runPayload(finished, ag.ID, agentName, taskReq.OriginTaskID))
 	}
 
 	// Send via SSE streaming
-	eventCh, err := s.dm.StreamTask(streamCtx, daemon, taskReq)
+	var eventCh <-chan SSEDaemonEvent
+	var err error
+	if newRun {
+		eventCh, err = s.dm.StreamTask(streamCtx, daemon, taskReq)
+	} else {
+		eventCh, err = s.dm.SubscribeTask(streamCtx, daemon, taskReq.TaskID)
+	}
 	if err != nil {
 		slog.Error("failed to stream agent task",
 			"task_id", taskReq.TaskID,
@@ -744,12 +849,16 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 			"error", err,
 		)
 		s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, err.Error())
+		retryable = true
+		if newRun {
+			failureCode = agentFailureProviderTransient
+		} else {
+			failureCode = agentFailureDaemonLost
+		}
 		finishRun(AgentRunStatusFailed)
 		return
 	}
 
-	// Track usage for logging
-	var inputTokens, outputTokens int
 	taskCompleted := false
 	// Track final state for the run finished broadcast. Updated by event handlers
 	// and read by the deferred broadcaster. Defaults to "aborted" if the stream
@@ -920,23 +1029,28 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 				ExternalSessionID string `json:"external_session_id"`
 				TranscriptPath    string `json:"transcript_path"`
 				Usage             struct {
-					InputTokens  int `json:"input_tokens"`
-					OutputTokens int `json:"output_tokens"`
+					InputTokens      int `json:"input_tokens"`
+					OutputTokens     int `json:"output_tokens"`
+					CacheReadTokens  int `json:"cache_read_tokens"`
+					CacheWriteTokens int `json:"cache_write_tokens"`
 				} `json:"usage"`
 			}
 			if err := json.Unmarshal([]byte(event.Data), &data); err == nil {
 				bindRunSession(data.ExternalSessionID, data.TranscriptPath)
 				inputTokens = data.Usage.InputTokens
 				outputTokens = data.Usage.OutputTokens
+				cacheReadTokens = data.Usage.CacheReadTokens
+				cacheWriteTokens = data.Usage.CacheWriteTokens
 				taskCompleted = true
 				finalState = "completed"
 			}
 
 		case "error":
 			var data struct {
-				AgentID string `json:"agent_id"`
-				Error   string `json:"error"`
-				Status  string `json:"status"`
+				AgentID   string `json:"agent_id"`
+				Error     string `json:"error"`
+				Status    string `json:"status"`
+				Retryable bool   `json:"retryable"`
 			}
 			if err := json.Unmarshal([]byte(event.Data), &data); err == nil {
 				slog.Error("agent task stream error",
@@ -946,6 +1060,14 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 				)
 				s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, data.Error)
 				finalState = finalStateFromErrorEventStatus(data.Status)
+				retryable = data.Retryable
+				if data.Retryable {
+					if finalState == "timeout" {
+						failureCode = agentFailureTimeout
+					} else {
+						failureCode = agentFailureProviderTransient
+					}
+				}
 			} else {
 				finalState = "failed"
 			}
@@ -1032,7 +1154,7 @@ func (s *AgentService) handleStreamingAgentTask(ctx context.Context, daemon *Dae
 	slog.Info("agent streaming task completed",
 		"agent_id", ag.ID,
 		"channel_id", taskReq.ChannelID,
-		"message_id", streamMessageID,
+		"run_id", run.ID,
 		"input_tokens", inputTokens,
 		"output_tokens", outputTokens,
 	)
@@ -1125,6 +1247,117 @@ func (s *AgentService) StartAgentRunWatchdogLoop(ctx context.Context) {
 	}
 }
 
+// ReconcileDaemonRuns converges PostgreSQL Run state with the one local
+// daemon's in-memory task list after either process restarts.
+func (s *AgentService) ReconcileDaemonRuns(ctx context.Context, daemon *DaemonInfo, taskIDs []string) {
+	if daemon == nil {
+		return
+	}
+	runs, err := NewAgentRunService(s.pool).ListActiveRuns(ctx)
+	if err != nil {
+		slog.Warn("failed to list active runs for daemon reconciliation", "daemon_id", daemon.ID, "error", err)
+		return
+	}
+	known := make(map[string]bool, len(taskIDs))
+	for _, taskID := range taskIDs {
+		known[taskID] = true
+	}
+	for i := range runs {
+		run := &runs[i]
+		if !known[run.ID] {
+			s.dm.RemoveTask(run.ID)
+			if err := s.finishDaemonLostRun(ctx, run); err != nil {
+				slog.Warn("failed to converge lost daemon run", "run_id", run.ID, "error", err)
+			}
+			continue
+		}
+		if s.dm.IsTaskTracked(run.ID) {
+			continue
+		}
+		taskReq, ag, err := s.loadRecoveredRun(ctx, run)
+		if err != nil {
+			slog.Warn("failed to load daemon run recovery context", "run_id", run.ID, "error", err)
+			continue
+		}
+		s.dm.TrackTask(run.ID, daemon.ID, run.AgentID)
+		s.dm.AttachTaskRun(run.ID, run.ID)
+		go s.runStreamingAgentTask(context.Background(), daemon, taskReq, ag, run)
+	}
+}
+
+func (s *AgentService) loadRecoveredRun(ctx context.Context, run *AgentRun) (daemonTaskRequest, agentChannelInfo, error) {
+	var ag agentChannelInfo
+	if err := s.pool.QueryRow(ctx, `
+		SELECT id::text, name, model_provider, model_name, system_prompt
+		  FROM agents
+		 WHERE id = $1 AND is_active = true`, run.AgentID,
+	).Scan(&ag.ID, &ag.Name, &ag.ModelProvider, &ag.ModelName, &ag.SystemPrompt); err != nil {
+		return daemonTaskRequest{}, ag, err
+	}
+
+	var resultContract, taskID string
+	if err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE((
+		         SELECT payload->>'result_contract'
+		           FROM agent_run_events
+		          WHERE run_id = $1 AND type = $2
+		          ORDER BY seq ASC
+		          LIMIT 1
+		       ), $3),
+		       COALESCE((
+		         SELECT task_id::text
+		           FROM agent_run_task_links
+		          WHERE run_id = $1 AND role = $4
+		          ORDER BY created_at DESC
+		          LIMIT 1
+		       ), '')`,
+		run.ID, AgentRunEventRunStarted, agentResultContractVisibleMessage, AgentRunTaskRolePrimary,
+	).Scan(&resultContract, &taskID); err != nil {
+		return daemonTaskRequest{}, ag, err
+	}
+
+	return daemonTaskRequest{
+		TaskID:           run.ID,
+		RunID:            run.ID,
+		AgentID:          run.AgentID,
+		ChannelID:        run.ChannelID,
+		ThreadID:         run.ThreadID,
+		NodeID:           run.ThinkingNodeID,
+		TriggerMessageID: run.TriggerMessageID,
+		SystemPrompt:     ag.SystemPrompt,
+		ModelConfig: agent.ModelConfig{
+			Provider: ag.ModelProvider,
+			Model:    ag.ModelName,
+		},
+		OriginTaskID:   taskID,
+		ReturnHandoff:  resultContract == agentResultContractHandoff,
+		ResultContract: resultContract,
+	}, ag, nil
+}
+
+func (s *AgentService) finishDaemonLostRun(ctx context.Context, run *AgentRun) error {
+	runSvc := NewAgentRunService(s.pool)
+	finished, err := runSvc.FinishRun(ctx, FinishRunInput{
+		RunID:        run.ID,
+		Status:       AgentRunStatusFailed,
+		ActivityText: agentActivityDaemonLost,
+	})
+	if errors.Is(err, ErrAgentRunAlreadyFinished) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	s.appendAndBroadcastRunEvent(ctx, runSvc, finished, finished.AgentID, finished.AgentName, AgentRunEventError, agentActivityDaemonLost, "", map[string]any{
+		"status":       AgentRunStatusFailed,
+		"failure_code": agentFailureDaemonLost,
+		"retryable":    true,
+	})
+	s.broadcastAgentError(finished.ThreadID, finished.ChannelID, finished.AgentID, finished.AgentName, agentActivityDaemonLost)
+	s.broadcastAgentRun(finished.ChannelID, "agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, ""))
+	return nil
+}
+
 func (s *AgentService) CheckAgentRunWatchdogs(ctx context.Context, now time.Time) error {
 	runSvc := NewAgentRunService(s.pool)
 	staleQueuedRuns, err := s.listStaleQueuedRuns(ctx, now.Add(-agentRunQueueTimeout))
@@ -1166,7 +1399,7 @@ func (s *AgentService) CheckAgentRunWatchdogs(ctx context.Context, now time.Time
 			return err
 		}
 	}
-	return nil
+	return s.retryFailedTaskRuns(ctx)
 }
 
 func (s *AgentService) listStaleQueuedRuns(ctx context.Context, before time.Time) ([]AgentRun, error) {
@@ -1196,19 +1429,27 @@ func (s *AgentService) listRunsWithoutVisibleReply(ctx context.Context, before t
 	return scanAgentRuns(s.pool.Query(ctx, baseAgentRunSelect()+`
 		 WHERE r.status = ANY($1)
 		   AND r.backend_started_at <= $2
-		   AND NOT EXISTS (
-		         SELECT 1 FROM agent_run_events e
+		   AND COALESCE((
+		         SELECT e.payload->>'result_contract'
+		           FROM agent_run_events e
 		          WHERE e.run_id = r.id AND e.type = $3
+		          ORDER BY e.seq ASC
+		          LIMIT 1
+		       ), $4) = $4
+		   AND NOT EXISTS (
+		         SELECT 1 FROM messages m
+		          WHERE m.metadata->>'agent_run_id' = r.id::text
 		       )
 		   AND NOT EXISTS (
 		         SELECT 1 FROM agent_run_events e
-		          WHERE e.run_id = r.id AND e.type = $4
+		          WHERE e.run_id = r.id AND e.type = $5
 		       )
 		 ORDER BY r.started_at ASC
 		 LIMIT 100`,
 		executingAgentRunStatuses(),
 		before,
-		AgentRunEventAssistantMessage,
+		AgentRunEventRunStarted,
+		agentResultContractVisibleMessage,
 		agentRunEventNoVisibleReplyWatchdog,
 	))
 }
@@ -1269,6 +1510,14 @@ func (s *AgentService) timeoutStaleQueuedAgentRun(ctx context.Context, runSvc *A
 }
 
 func (s *AgentService) finishTimedOutAgentRun(ctx context.Context, runSvc *AgentRunService, run *AgentRun, activity string) error {
+	retryable := false
+	if daemon := s.dm.SelectDaemon("llm"); daemon != nil {
+		if err := s.dm.CancelTask(ctx, daemon, run.ID); err != nil {
+			slog.Warn("failed to stop timed out daemon task", "run_id", run.ID, "error", err)
+		} else {
+			retryable = true
+		}
+	}
 	finished, err := runSvc.FinishRun(ctx, FinishRunInput{
 		RunID:        run.ID,
 		Status:       AgentRunStatusTimeout,
@@ -1281,7 +1530,9 @@ func (s *AgentService) finishTimedOutAgentRun(ctx context.Context, runSvc *Agent
 		return err
 	}
 	s.appendAndBroadcastRunEvent(ctx, runSvc, finished, finished.AgentID, finished.AgentName, AgentRunEventError, activity, "", map[string]any{
-		"status": AgentRunStatusTimeout,
+		"status":       AgentRunStatusTimeout,
+		"failure_code": agentFailureTimeout,
+		"retryable":    retryable,
 	})
 	s.broadcastAgentRun(finished.ChannelID, "agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, ""))
 	return nil
@@ -1787,7 +2038,6 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 		}
 
 		taskReq := daemonTaskRequest{
-			TaskID:           uuid.New().String(),
 			AgentID:          ag.ID,
 			ChannelID:        channelID,
 			ThreadID:         threadID,
@@ -1801,6 +2051,7 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 			TaskContext:    taskContext,
 			AgentChain:     newChain,
 			MentionedNames: threadMentionedNames,
+			ResultContract: agentResultContractVisibleMessage,
 		}
 
 		// Use streaming for thread as well
@@ -1873,7 +2124,7 @@ func (s *AgentService) TriggerAllAgentsForTask(ctx context.Context, channelID, t
 	}
 }
 
-func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskID, agentID string, taskNumber int, taskTitle, taskDescription string, agentChain, mentionedAgentIDs []string) {
+func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskID, agentID string, taskNumber int, taskTitle, taskDescription string, agentChain, mentionedAgentIDs []string) bool {
 	// Get agent info
 	var ag agentChannelInfo
 	err := s.pool.QueryRow(ctx,
@@ -1886,22 +2137,25 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 		slog.Error("failed to get agent info for task trigger",
 			"agent_id", agentID, "task_id", taskID, "error", err,
 		)
-		return
+		return false
 	}
 
 	// Look up the task's message_id so we can route the agent response to the
 	// task's thread rather than the main channel.
 	var messageID string
 	var taskMsgChannelID string
+	var taskStatus string
+	var taskClaimerID string
 	err = s.pool.QueryRow(ctx,
-		`SELECT COALESCE(message_id::text, ''), channel_id FROM tasks WHERE id = $1`,
+		`SELECT COALESCE(message_id::text, ''), channel_id, status, COALESCE(claimer_id::text, '')
+		 FROM tasks WHERE id = $1`,
 		taskID,
-	).Scan(&messageID, &taskMsgChannelID)
+	).Scan(&messageID, &taskMsgChannelID, &taskStatus, &taskClaimerID)
 	if err != nil {
 		slog.Error("failed to look up task for thread routing",
 			"task_id", taskID, "error", err,
 		)
-		return
+		return false
 	}
 
 	// Resolve thread ID from the task's message. If the task was created from
@@ -1940,7 +2194,7 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 			slog.Error("TriggerAgentForTask: failed to create system message for task",
 				"task_id", taskID, "error", dbErr,
 			)
-			return
+			return false
 		}
 		_, _ = s.pool.Exec(ctx,
 			`UPDATE tasks SET message_id = $1 WHERE id = $2`,
@@ -1952,7 +2206,7 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 			slog.Error("TriggerAgentForTask: failed to create thread for task",
 				"task_id", taskID, "error", tErr,
 			)
-			return
+			return false
 		}
 		threadID = tid
 		messageID = msgID
@@ -1966,7 +2220,7 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 	if daemon == nil {
 		slog.Warn("no available daemon for task agent trigger", "agent_id", ag.ID, "task_id", taskID)
 		s.broadcastAgentError(threadID, channelID, ag.ID, ag.Name, agentErrorNoAvailableDaemon)
-		return
+		return false
 
 	}
 
@@ -1974,11 +2228,11 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 	if agentChain != nil {
 		if len(agentChain) >= maxAgentChainDepth {
 			slog.Debug("agent chain depth limit reached (task)", "agent_id", agentID, "channel_id", channelID, "depth", len(agentChain))
-			return
+			return false
 		}
 		if containsStr(agentChain, agentID) {
 			slog.Debug("agent already in trigger chain (task), skipping", "agent_id", agentID, "channel_id", channelID)
-			return
+			return false
 		}
 	}
 	newChain := append([]string(nil), agentChain...)
@@ -2023,17 +2277,19 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 
 	taskContent := fmt.Sprintf("New message received:\n\n[target=%s msg=%s time=%s type=%s] @%s: %s",
 		target, shortMsgID, msgCreatedAt, senderType, senderName, msgContent)
-	taskContent += fmt.Sprintf(" [task #%d status=todo channel=%s]", taskNumber, channelID)
+	taskContent += fmt.Sprintf(" [task #%d status=%s channel=%s]", taskNumber, taskStatus, channelID)
 	taskContent += "\n\nRespond as appropriate. Complete all your work before stopping."
 	taskContent += "\n- To reply to this message, use the `target` and `msg` fields above."
 	taskContent += "\n- To claim or update this task, use the `channel` field above (e.g. `solo task claim -n N -c <channel>`)."
+	if taskClaimerID == agentID {
+		taskContent += fmt.Sprintf("\n- This Task is currently assigned to you (@%s). Execute it now even if the original message names a previous assignee; do not claim it again.", ag.Name)
+	}
 
 	contextMsgs := []agent.Message{
 		{Role: agent.RoleUser, Content: taskContent, SenderID: ""},
 	}
 
 	taskReq := daemonTaskRequest{
-		TaskID:           uuid.New().String(),
 		AgentID:          ag.ID,
 		ChannelID:        channelID,
 		ThreadID:         threadID,
@@ -2044,7 +2300,8 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 			Provider: ag.ModelProvider,
 			Model:    ag.ModelName,
 		},
-		OriginTaskID: taskID,
+		OriginTaskID:   taskID,
+		ResultContract: agentResultContractVisibleMessage,
 	}
 
 	slog.Info("triggering agent for task",
@@ -2058,6 +2315,7 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 	// The daemon task request includes task context. The agent evaluates the task,
 	// and if it decides to claim, outputs /claim #N which is parsed by
 	go s.handleStreamingAgentTask(context.Background(), daemon, taskReq, ag)
+	return true
 }
 
 func (s *AgentService) TriggerAgentForArtifact(ctx context.Context, task *Task, data artifactRenderData, requestedBy, mode string) error {
@@ -2085,11 +2343,11 @@ func (s *AgentService) TriggerAgentForArtifact(ctx context.Context, task *Task, 
 	}
 
 	taskReq := daemonTaskRequest{
-		TaskID:       uuid.New().String(),
-		AgentID:      ag.ID,
-		ChannelID:    task.ChannelID,
-		ThreadID:     threadID,
-		OriginTaskID: task.ID,
+		AgentID:        ag.ID,
+		ChannelID:      task.ChannelID,
+		ThreadID:       threadID,
+		OriginTaskID:   task.ID,
+		ResultContract: agentResultContractNone,
 		Messages: []agent.Message{
 			{Role: agent.RoleUser, Content: renderArtifactAgentPrompt(data, mode)},
 		},
@@ -2447,6 +2705,7 @@ type daemonTaskRequest struct {
 	MentionedNames        []string          `json:"mentioned_names,omitempty"`  // v1.3: names of @mentioned agents for context awareness
 	InitialGreeting       string            `json:"initial_greeting,omitempty"` // greeting message to prepend as system context
 	ReturnHandoff         bool              `json:"return_handoff,omitempty"`
+	ResultContract        string            `json:"-"`
 }
 
 // containsStr returns true if the slice s contains value v.

--- a/internal/server/service/agent_helpers.go
+++ b/internal/server/service/agent_helpers.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/google/uuid"
 	"github.com/solo-ai/solo/internal/realtime"
 	"github.com/solo-ai/solo/pkg/agent"
 )
@@ -76,13 +75,13 @@ func (s *AgentService) TriggerAgentGreeting(ctx context.Context, channelID, agen
 	}
 
 	taskReq := daemonTaskRequest{
-		TaskID:    uuid.New().String(),
 		AgentID:   ag.ID,
 		ChannelID: channelID,
 		Messages: []agent.Message{
 			{Role: agent.RoleUser, Content: greetingContent, SenderID: ""},
 		},
-		SystemPrompt: ag.SystemPrompt,
+		SystemPrompt:   ag.SystemPrompt,
+		ResultContract: agentResultContractVisibleMessage,
 		ModelConfig: agent.ModelConfig{
 			Provider: ag.ModelProvider,
 			Model:    ag.ModelName,

--- a/internal/server/service/agent_p0_test.go
+++ b/internal/server/service/agent_p0_test.go
@@ -197,13 +197,13 @@ func TestAgentRunProgressWatchdogWarnsOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartRun: %v", err)
 	}
-	_, err = runSvc.AppendEvent(ctx, AppendRunEventInput{
-		RunID:   run.ID,
-		Type:    AgentRunEventAssistantMessage,
-		Message: "visible reply already happened",
-	})
+	_, err = pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, metadata)
+		VALUES ($1, $2, 'agent', $3, 'visible reply already happened', jsonb_build_object('agent_run_id', $4::text))`,
+		uuid.NewString(), channelID, agentID, run.ID,
+	)
 	if err != nil {
-		t.Fatalf("AppendEvent assistant: %v", err)
+		t.Fatalf("insert visible message: %v", err)
 	}
 	old := time.Now().Add(-agentNoProgressAfter - time.Second)
 	_, err = pool.Exec(ctx, `UPDATE agent_runs SET backend_started_at = $2, updated_at = $2 WHERE id = $1`, run.ID, old)
@@ -278,7 +278,7 @@ func TestAgentRunWatchdogTimesOutStaleActiveRun(t *testing.T) {
 	}
 }
 
-func TestDaemonOfflineTimesOutTrackedAgentRun(t *testing.T) {
+func TestDaemonOfflineFailsTrackedAgentRunAsLost(t *testing.T) {
 	pool := agentRunTestPool(t)
 	ctx := context.Background()
 	ownerID := agentRunUser(t, pool)
@@ -323,18 +323,19 @@ func TestDaemonOfflineTimesOutTrackedAgentRun(t *testing.T) {
 	if err := pool.QueryRow(ctx, `SELECT status, finished_at FROM agent_runs WHERE id = $1`, run.ID).Scan(&status, &finishedAt); err != nil {
 		t.Fatalf("query run: %v", err)
 	}
-	if status != string(AgentRunStatusTimeout) {
-		t.Fatalf("status = %q, want timeout", status)
+	if status != string(AgentRunStatusFailed) {
+		t.Fatalf("status = %q, want failed", status)
 	}
 	if finishedAt == nil {
 		t.Fatal("finished_at is nil")
 	}
-	if !rec.hasBroadcastEvent("agent.run.finished", agentActivityTimeout) {
-		t.Fatalf("offline timeout finish not broadcast: %q", rec.broadcastMessages)
+	if !rec.hasBroadcastEvent("agent.run.finished", agentActivityDaemonLost) {
+		t.Fatalf("offline daemon-lost finish not broadcast: %q", rec.broadcastMessages)
 	}
+	assertRunFailure(t, pool, run.ID, agentFailureDaemonLost, true)
 }
 
-func TestDaemonUnregisterTimesOutTrackedAgentRun(t *testing.T) {
+func TestDaemonReconcileFailsTrackedRunMissingFromNewProcess(t *testing.T) {
 	pool := agentRunTestPool(t)
 	ctx := context.Background()
 	ownerID := agentRunUser(t, pool)
@@ -362,22 +363,42 @@ func TestDaemonUnregisterTimesOutTrackedAgentRun(t *testing.T) {
 	rec := newRecordingBroadcaster()
 	dm := NewDaemonManager(pool, rec)
 	daemonID := "daemon-" + agentID[:8]
-	dm.Register(&DaemonInfo{ID: daemonID, Host: "127.0.0.1", Port: 1, Capabilities: []string{"agent"}})
-	taskID := uuid.NewString()
-	dm.TrackTask(taskID, daemonID, agentID)
-	dm.AttachTaskRun(taskID, run.ID)
+	daemon := &DaemonInfo{ID: daemonID, Host: "127.0.0.1", Port: 1, Capabilities: []string{"agent"}}
+	dm.Register(daemon)
+	dm.TrackTask(run.ID, daemonID, agentID)
+	dm.AttachTaskRun(run.ID, run.ID)
 
-	dm.Unregister(daemonID)
+	svc := NewAgentService(pool, dm, rec, NewMentionService(pool))
+	svc.ReconcileDaemonRuns(ctx, daemon, nil)
 
 	var status string
 	if err := pool.QueryRow(ctx, `SELECT status FROM agent_runs WHERE id = $1`, run.ID).Scan(&status); err != nil {
 		t.Fatalf("query run: %v", err)
 	}
-	if status != string(AgentRunStatusTimeout) {
-		t.Fatalf("status = %q, want timeout", status)
+	if status != string(AgentRunStatusFailed) {
+		t.Fatalf("status = %q, want failed", status)
 	}
-	if !rec.hasBroadcastEvent("agent.run.finished", agentActivityTimeout) {
-		t.Fatalf("unregister timeout finish not broadcast: %q", rec.broadcastMessages)
+	if !rec.hasBroadcastEvent("agent.run.finished", agentActivityDaemonLost) {
+		t.Fatalf("reconcile daemon-lost finish not broadcast: %q", rec.broadcastMessages)
+	}
+	assertRunFailure(t, pool, run.ID, agentFailureDaemonLost, true)
+}
+
+func assertRunFailure(t *testing.T, pool *pgxpool.Pool, runID, wantCode string, wantRetryable bool) {
+	t.Helper()
+	var code string
+	var retryable bool
+	if err := pool.QueryRow(context.Background(), `
+		SELECT payload->>'failure_code', COALESCE((payload->>'retryable')::boolean, false)
+		  FROM agent_run_events
+		 WHERE run_id = $1 AND type = $2
+		 ORDER BY seq DESC
+		 LIMIT 1`, runID, AgentRunEventError,
+	).Scan(&code, &retryable); err != nil {
+		t.Fatalf("query run failure: %v", err)
+	}
+	if code != wantCode || retryable != wantRetryable {
+		t.Fatalf("failure = (%q, %t), want (%q, %t)", code, retryable, wantCode, wantRetryable)
 	}
 }
 

--- a/internal/server/service/agent_retry.go
+++ b/internal/server/service/agent_retry.go
@@ -1,0 +1,311 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/solo-ai/solo/internal/realtime"
+)
+
+const maxTaskRunAttempts = 3
+
+type retryableTaskRun struct {
+	RunID      string
+	AgentID    string
+	TaskID     string
+	FinishedAt time.Time
+}
+
+func (s *AgentService) retryFailedTaskRuns(ctx context.Context) error {
+	rows, err := s.pool.Query(ctx, `
+		SELECT r.id::text, r.agent_id::text, link.task_id::text, r.finished_at
+		  FROM agent_runs r
+		  JOIN agent_run_task_links link ON link.run_id = r.id AND link.role = $1
+		  JOIN tasks t ON t.id = link.task_id
+		  JOIN LATERAL (
+		    SELECT payload
+		      FROM agent_run_events
+		     WHERE run_id = r.id AND type = $2
+		     ORDER BY seq DESC
+		     LIMIT 1
+		  ) failure ON true
+		 WHERE r.status = ANY($3)
+		   AND t.status = ANY($4)
+		   AND (t.claimer_id IS NULL OR t.claimer_id = r.agent_id)
+		   AND t.updated_at <= r.finished_at
+		   AND failure.payload->>'failure_code' = ANY($5)
+		   AND COALESCE((failure.payload->>'retryable')::boolean, false)
+		   AND (
+		     SELECT payload->>'result_contract'
+		       FROM agent_run_events
+		      WHERE run_id = r.id AND type = $6
+		      ORDER BY seq
+		      LIMIT 1
+		   ) = $7
+		   AND NOT EXISTS (
+		     SELECT 1
+		       FROM agent_run_events
+		      WHERE run_id = r.id AND type = ANY($8)
+		   )
+		   AND r.id = (
+		     SELECT r2.id
+		       FROM agent_runs r2
+		       JOIN agent_run_task_links link2 ON link2.run_id = r2.id AND link2.role = $1
+		      WHERE link2.task_id = link.task_id
+		      ORDER BY r2.started_at DESC, r2.id DESC
+		      LIMIT 1
+		   )
+		 ORDER BY r.finished_at ASC
+		 LIMIT 100`,
+		AgentRunTaskRolePrimary,
+		AgentRunEventError,
+		[]string{string(AgentRunStatusFailed), string(AgentRunStatusTimeout)},
+		[]string{TaskStatusTodo, TaskStatusInProgress},
+		[]string{agentFailureDaemonLost, agentFailureTimeout, agentFailureProviderTransient, agentFailureMissingVisibleResult},
+		AgentRunEventRunStarted,
+		agentResultContractVisibleMessage,
+		[]string{AgentRunEventTaskReassigned, AgentRunEventTaskRetryExhausted},
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var runs []retryableTaskRun
+	for rows.Next() {
+		var run retryableTaskRun
+		if err := rows.Scan(&run.RunID, &run.AgentID, &run.TaskID, &run.FinishedAt); err != nil {
+			return err
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, run := range runs {
+		if err := s.retryTaskRun(ctx, run); err != nil {
+			slog.Warn("automatic task reassignment failed", "run_id", run.RunID, "task_id", run.TaskID, "error", err)
+		}
+	}
+	return nil
+}
+
+func (s *AgentService) retryTaskRun(ctx context.Context, failed retryableTaskRun) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var task Task
+	var currentClaimer string
+	if err := tx.QueryRow(ctx, `
+		SELECT id::text, task_number, channel_id::text, title, COALESCE(description, ''),
+		       status, COALESCE(claimer_id::text, ''), priority, due_date,
+		       COALESCE(message_id::text, ''), updated_at
+		  FROM tasks
+		 WHERE id = $1
+		 FOR UPDATE`, failed.TaskID,
+	).Scan(
+		&task.ID, &task.TaskNumber, &task.ChannelID, &task.Title, &task.Description,
+		&task.Status, &currentClaimer, &task.Priority, &task.DueDate,
+		&task.MessageID, &task.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	if (task.Status != TaskStatusTodo && task.Status != TaskStatusInProgress) ||
+		(currentClaimer != "" && currentClaimer != failed.AgentID) ||
+		task.UpdatedAt.After(failed.FinishedAt) {
+		return nil
+	}
+
+	var latestRunID string
+	if err := tx.QueryRow(ctx, `
+		SELECT r.id::text
+		  FROM agent_runs r
+		  JOIN agent_run_task_links link ON link.run_id = r.id AND link.role = $2
+		 WHERE link.task_id = $1
+		 ORDER BY r.started_at DESC, r.id DESC
+		 LIMIT 1`, failed.TaskID, AgentRunTaskRolePrimary,
+	).Scan(&latestRunID); err != nil || latestRunID != failed.RunID {
+		return err
+	}
+	var handled bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM agent_run_events
+		   WHERE run_id = $1 AND type = ANY($2)
+		)`, failed.RunID, []string{AgentRunEventTaskReassigned, AgentRunEventTaskRetryExhausted},
+	).Scan(&handled); err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
+	var attempts int
+	if err := tx.QueryRow(ctx, `
+		SELECT COUNT(*)
+		  FROM agent_runs r
+		  JOIN agent_run_task_links link ON link.run_id = r.id AND link.role = $2
+		 WHERE link.task_id = $1
+		   AND (
+		     SELECT payload->>'result_contract'
+		       FROM agent_run_events
+		      WHERE run_id = r.id AND type = $3
+		      ORDER BY seq
+		      LIMIT 1
+		   ) = $4`,
+		failed.TaskID, AgentRunTaskRolePrimary, AgentRunEventRunStarted, agentResultContractVisibleMessage,
+	).Scan(&attempts); err != nil {
+		return err
+	}
+
+	if attempts >= maxTaskRunAttempts {
+		task.Status = TaskStatusTodo
+		task.ClaimerID = ""
+		task.ClaimerName = ""
+		if err := tx.QueryRow(ctx, `
+			UPDATE tasks
+			   SET status = $2, claimer_id = NULL, updated_at = now()
+			 WHERE id = $1
+			 RETURNING updated_at`, task.ID, TaskStatusTodo,
+		).Scan(&task.UpdatedAt); err != nil {
+			return err
+		}
+		if err := appendTaskRetryEvent(ctx, tx, failed.RunID, AgentRunEventTaskRetryExhausted, map[string]any{
+			"attempts": maxTaskRunAttempts,
+		}); err != nil {
+			return err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return err
+		}
+		s.broadcastTaskClaimed(&task, task.ChannelID)
+		return s.persistTaskRetryMessage(ctx, &task,
+			fmt.Sprintf("Task #%d 自动重派已尝试 %d 次，已退回 TODO 等待处理。", task.TaskNumber, maxTaskRunAttempts),
+			maxTaskRunAttempts, true)
+	}
+
+	var nextAgentID, nextAgentName string
+	if err := tx.QueryRow(ctx, `
+		SELECT a.id::text, a.name
+		  FROM channel_members cm
+		  JOIN agents a ON a.id = cm.member_id
+		 WHERE cm.channel_id = $1
+		   AND cm.member_type = 'agent'
+		   AND a.is_active = true
+		 ORDER BY (a.id = $2), cm.joined_at, a.created_at, a.id
+		 LIMIT 1`, task.ChannelID, failed.AgentID,
+	).Scan(&nextAgentID, &nextAgentName); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	if s.dm.SelectDaemon("llm") == nil {
+		return nil
+	}
+
+	previousStatus := task.Status
+	previousClaimer := currentClaimer
+	task.Status = TaskStatusInProgress
+	task.ClaimerID = nextAgentID
+	task.ClaimerName = nextAgentName
+	if err := tx.QueryRow(ctx, `
+		UPDATE tasks
+		   SET status = $2, claimer_id = $3, updated_at = now()
+		 WHERE id = $1
+		 RETURNING updated_at`, task.ID, TaskStatusInProgress, nextAgentID,
+	).Scan(&task.UpdatedAt); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	if !s.TriggerAgentForTask(ctx, task.ChannelID, task.ID, nextAgentID, task.TaskNumber, task.Title, task.Description, nil, nil) {
+		_, _ = s.pool.Exec(ctx, `
+			UPDATE tasks
+			   SET status = $2, claimer_id = $3, updated_at = now()
+			 WHERE id = $1 AND claimer_id = $4`,
+			task.ID, previousStatus, nullableStr(previousClaimer), nextAgentID,
+		)
+		return nil
+	}
+
+	nextAttempt := attempts + 1
+	runSvc := NewAgentRunService(s.pool)
+	_, err = runSvc.AppendEvent(ctx, AppendRunEventInput{
+		RunID:   failed.RunID,
+		Type:    AgentRunEventTaskReassigned,
+		Message: "task automatically reassigned",
+		Payload: map[string]any{
+			"attempt":       nextAttempt,
+			"max_attempts":  maxTaskRunAttempts,
+			"next_agent_id": nextAgentID,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	s.broadcastTaskClaimed(&task, task.ChannelID)
+	return s.persistTaskRetryMessage(ctx, &task,
+		fmt.Sprintf("本次尝试未成功交付，Solo 正在自动改派（第 %d/%d 次）：@%s", nextAttempt, maxTaskRunAttempts, nextAgentName),
+		nextAttempt, false)
+}
+
+func appendTaskRetryEvent(ctx context.Context, tx pgx.Tx, runID, eventType string, payload any) error {
+	raw, err := marshalJSON(payload)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO agent_run_events (id, run_id, seq, type, message, payload)
+		SELECT $1, $2, COALESCE(MAX(seq), 0) + 1, $3, $4, $5
+		  FROM agent_run_events
+		 WHERE run_id = $2`,
+		uuid.NewString(), runID, eventType, eventType, raw,
+	)
+	return err
+}
+
+func (s *AgentService) persistTaskRetryMessage(ctx context.Context, task *Task, content string, attempt int, exhausted bool) error {
+	messageID := uuid.NewString()
+	now := time.Now()
+	metadata := map[string]any{
+		"task_id":       task.ID,
+		"auto_reassign": true,
+		"attempt":       attempt,
+		"exhausted":     exhausted,
+	}
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, content_type, metadata, created_at, updated_at)
+		VALUES ($1, $2, 'system', '00000000-0000-0000-0000-000000000000', $3, 'system', $4, $5, $5)`,
+		messageID, task.ChannelID, content, metadata, now,
+	); err != nil {
+		return err
+	}
+	if s.hub != nil {
+		s.hub.BroadcastToChannel(task.ChannelID, realtime.Envelope("message.new", map[string]any{
+			"id":           messageID,
+			"channel_id":   task.ChannelID,
+			"sender_type":  "system",
+			"sender_id":    "system",
+			"sender_name":  "Solo",
+			"content":      content,
+			"content_type": "system",
+			"metadata":     metadata,
+			"created_at":   now.UTC().Format(time.RFC3339),
+		}))
+	}
+	return nil
+}

--- a/internal/server/service/agent_retry_test.go
+++ b/internal/server/service/agent_retry_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestAutomaticTaskRetryExhaustionReturnsTaskToTodoOnce(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	taskID := uuid.NewString()
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tasks WHERE id = $1`, taskID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	_, err := pool.Exec(ctx, `
+		INSERT INTO tasks (id, task_number, channel_id, creator_id, title, status, claimer_id)
+		VALUES ($1, 1, $2, $3, 'retry exhaustion', $4, $5)`,
+		taskID, channelID, ownerID, TaskStatusInProgress, agentID,
+	)
+	if err != nil {
+		t.Fatalf("insert task: %v", err)
+	}
+
+	runSvc := NewAgentRunService(pool)
+	var lastRunID string
+	for range maxTaskRunAttempts {
+		run, err := runSvc.StartRun(ctx, StartRunInput{
+			AgentID:      agentID,
+			TriggerType:  AgentRunTriggerTask,
+			ChannelID:    channelID,
+			Status:       AgentRunStatusRunning,
+			ActivityText: agentActivityAccepted,
+		})
+		if err != nil {
+			t.Fatalf("StartRun: %v", err)
+		}
+		lastRunID = run.ID
+		if err := runSvc.LinkTask(ctx, LinkRunTaskInput{
+			RunID: run.ID, TaskID: taskID, Role: AgentRunTaskRolePrimary, Confidence: 1,
+		}); err != nil {
+			t.Fatalf("LinkTask: %v", err)
+		}
+		if _, err := runSvc.AppendEvent(ctx, AppendRunEventInput{
+			RunID: run.ID,
+			Type:  AgentRunEventRunStarted,
+			Payload: map[string]any{
+				"result_contract": agentResultContractVisibleMessage,
+			},
+		}); err != nil {
+			t.Fatalf("append run_started: %v", err)
+		}
+		if _, err := runSvc.FinishRun(ctx, FinishRunInput{
+			RunID: run.ID, Status: AgentRunStatusFailed, ActivityText: agentActivityFailed,
+		}); err != nil {
+			t.Fatalf("FinishRun: %v", err)
+		}
+		if _, err := runSvc.AppendEvent(ctx, AppendRunEventInput{
+			RunID: run.ID,
+			Type:  AgentRunEventError,
+			Payload: map[string]any{
+				"failure_code": agentFailureMissingVisibleResult,
+				"retryable":    true,
+			},
+		}); err != nil {
+			t.Fatalf("append error: %v", err)
+		}
+	}
+
+	rec := newRecordingBroadcaster()
+	svc := NewAgentService(pool, NewDaemonManager(pool, rec), rec, nil)
+	if err := svc.retryFailedTaskRuns(ctx); err != nil {
+		t.Fatalf("retryFailedTaskRuns: %v", err)
+	}
+	if err := svc.retryFailedTaskRuns(ctx); err != nil {
+		t.Fatalf("second retryFailedTaskRuns: %v", err)
+	}
+
+	var status, claimerID string
+	if err := pool.QueryRow(ctx, `
+		SELECT status, COALESCE(claimer_id::text, '') FROM tasks WHERE id = $1`,
+		taskID,
+	).Scan(&status, &claimerID); err != nil {
+		t.Fatalf("query task: %v", err)
+	}
+	if status != TaskStatusTodo || claimerID != "" {
+		t.Fatalf("task = status %q claimer %q, want todo/unclaimed", status, claimerID)
+	}
+
+	var messageCount, eventCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM messages
+		 WHERE metadata->>'task_id' = $1 AND metadata->>'exhausted' = 'true'`,
+		taskID,
+	).Scan(&messageCount); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM agent_run_events
+		 WHERE run_id = $1 AND type = $2`,
+		lastRunID, AgentRunEventTaskRetryExhausted,
+	).Scan(&eventCount); err != nil {
+		t.Fatalf("count events: %v", err)
+	}
+	if messageCount != 1 || eventCount != 1 {
+		t.Fatalf("exhaustion artifacts = messages %d events %d, want 1/1", messageCount, eventCount)
+	}
+}

--- a/internal/server/service/agent_run.go
+++ b/internal/server/service/agent_run.go
@@ -55,7 +55,10 @@ const (
 	AgentRunEventToolStarted         = "tool_started"
 	AgentRunEventToolFinished        = "tool_finished"
 	AgentRunEventAssistantMessage    = "assistant_message"
+	AgentRunEventVisibleMessageSent  = "visible_message_sent"
 	AgentRunEventTaskLinked          = "task_linked"
+	AgentRunEventTaskReassigned      = "task_reassigned"
+	AgentRunEventTaskRetryExhausted  = "task_retry_exhausted"
 	AgentRunEventUsage               = "usage"
 	AgentRunEventDone                = "done"
 	AgentRunEventError               = "error"
@@ -688,6 +691,46 @@ func (s *AgentRunService) ListEvents(ctx context.Context, runID string) ([]Agent
 		events = append(events, *event)
 	}
 	return events, rows.Err()
+}
+
+func (s *AgentRunService) ValidateMessageDelivery(ctx context.Context, runID, agentID, channelID, threadID, thinkingNodeID string) (bool, error) {
+	var runChannelID, runThreadID, runThinkingNodeID string
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE(channel_id::text, ''),
+		       COALESCE(thread_id::text, ''),
+		       COALESCE(thinking_node_id::text, '')
+		  FROM agent_runs
+		 WHERE id = $1
+		   AND agent_id = $2
+		   AND finished_at IS NULL`,
+		runID, agentID,
+	).Scan(&runChannelID, &runThreadID, &runThinkingNodeID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, fmt.Errorf("agent run is missing, finished, or owned by another agent")
+		}
+		return false, err
+	}
+	return runChannelID == channelID && runThreadID == threadID && runThinkingNodeID == thinkingNodeID, nil
+}
+
+func (s *AgentRunService) HasVisibleMessage(ctx context.Context, runID string) (bool, error) {
+	var visible bool
+	err := s.pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			  FROM agent_runs r
+			  JOIN messages m
+			    ON m.sender_type = 'agent'
+			   AND m.sender_id = r.agent_id
+			   AND m.channel_id = r.channel_id
+			   AND COALESCE(m.thread_id::text, '') = COALESCE(r.thread_id::text, '')
+			   AND COALESCE(m.thinking_node_id::text, '') = COALESCE(r.thinking_node_id::text, '')
+			   AND m.metadata->>'agent_run_id' = r.id::text
+			 WHERE r.id = $1
+		)`, runID,
+	).Scan(&visible)
+	return visible, err
 }
 
 func (s *AgentRunService) GetRunTranscript(ctx context.Context, runID string, limit int) ([]AgentTranscriptEntry, error) {

--- a/internal/server/service/agent_run_test.go
+++ b/internal/server/service/agent_run_test.go
@@ -633,6 +633,62 @@ INSERT INTO messages (session_id, role, content, timestamp) VALUES ('hermes-live
 	}
 }
 
+func TestAgentRunVisibleMessageDelivery(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE created_by = $1`, ownerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	runSvc := NewAgentRunService(pool)
+	run, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentID,
+		TriggerType:  AgentRunTriggerMessage,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusRunning,
+		ActivityText: "执行中",
+	})
+	if err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+
+	matches, err := runSvc.ValidateMessageDelivery(ctx, run.ID, agentID, channelID, "", "")
+	if err != nil || !matches {
+		t.Fatalf("ValidateMessageDelivery correct scope = %v, %v", matches, err)
+	}
+	matches, err = runSvc.ValidateMessageDelivery(ctx, run.ID, agentID, uuid.NewString(), "", "")
+	if err != nil || matches {
+		t.Fatalf("ValidateMessageDelivery other scope = %v, %v", matches, err)
+	}
+	if _, err := runSvc.ValidateMessageDelivery(ctx, run.ID, uuid.NewString(), channelID, "", ""); err == nil {
+		t.Fatal("ValidateMessageDelivery accepted another agent")
+	}
+
+	visible, err := runSvc.HasVisibleMessage(ctx, run.ID)
+	if err != nil || visible {
+		t.Fatalf("HasVisibleMessage before insert = %v, %v", visible, err)
+	}
+	_, err = pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, metadata)
+		VALUES ($1, $2, 'agent', $3, 'delivered', jsonb_build_object('agent_run_id', $4::text, 'delivery', 'visible'))`,
+		uuid.NewString(), channelID, agentID, run.ID,
+	)
+	if err != nil {
+		t.Fatalf("insert visible message: %v", err)
+	}
+	visible, err = runSvc.HasVisibleMessage(ctx, run.ID)
+	if err != nil || !visible {
+		t.Fatalf("HasVisibleMessage after insert = %v, %v", visible, err)
+	}
+}
+
 func agentRunListContains(runs []AgentRun, id string) bool {
 	for _, run := range runs {
 		if run.ID == id {
@@ -756,6 +812,19 @@ func agentRunTranscriptFileWithText(t *testing.T, text string) string {
 	t.Helper()
 	path := t.TempDir() + "/session.jsonl"
 	raw := fmt.Sprintf(`{"type":"user","timestamp":%q,"message":{"content":%q}}`+"\n", time.Now().UTC().Format(time.RFC3339), text)
+	if err := os.WriteFile(path, []byte(raw), 0600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func agentRunTranscriptFileWithUsage(t *testing.T, text string, inputTokens, outputTokens int) string {
+	t.Helper()
+	path := t.TempDir() + "/session.jsonl"
+	raw := fmt.Sprintf(
+		`{"type":"user","timestamp":%q,"message":{"content":%q,"usage":{"input_tokens":%d,"output_tokens":%d}}}`+"\n",
+		time.Now().UTC().Format(time.RFC3339), text, inputTokens, outputTokens,
+	)
 	if err := os.WriteFile(path, []byte(raw), 0600); err != nil {
 		t.Fatalf("write transcript: %v", err)
 	}

--- a/internal/server/service/agent_stream_test.go
+++ b/internal/server/service/agent_stream_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -32,7 +33,7 @@ func TestStreamingAgentTaskBindsSessionAndTranscript(t *testing.T) {
 	agentID := agentRunAgent(t, pool, ownerID)
 	channelID := agentRunChannel(t, pool, ownerID)
 	messageID := agentRunMessage(t, pool, channelID, ownerID)
-	transcriptPath := agentRunTranscriptFileWithText(t, "stream transcript")
+	transcriptPath := agentRunTranscriptFileWithUsage(t, "stream transcript", 3, 4)
 	t.Cleanup(func() {
 		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
 		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_sessions WHERE agent_id = $1`, agentID)
@@ -43,17 +44,22 @@ func TestStreamingAgentTaskBindsSessionAndTranscript(t *testing.T) {
 	})
 
 	daemonID := uuid.NewString()
-	taskID := uuid.NewString()
+	var gotTaskID, gotRunID string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/internal/daemon/run":
+		switch {
+		case r.URL.Path == "/internal/daemon/run":
+			var req daemonTaskRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode daemon request: %v", err)
+			}
+			gotTaskID, gotRunID = req.TaskID, req.RunID
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			_, _ = fmt.Fprintf(w, `{"task_id":%q,"status":"accepted"}`, taskID)
-		case "/internal/daemon/tasks/" + taskID + "/events":
+			_, _ = fmt.Fprintf(w, `{"task_id":%q,"status":"accepted"}`, req.TaskID)
+		case r.URL.Path == "/internal/daemon/tasks/"+gotTaskID+"/events":
 			w.Header().Set("Content-Type", "text/event-stream")
 			_, _ = fmt.Fprintf(w, "event: session\ndata: {\"external_session_id\":\"provider-session-1\"}\n\n")
-			_, _ = fmt.Fprintf(w, "event: complete\ndata: {\"external_session_id\":\"provider-session-1\",\"transcript_path\":%q,\"usage\":{\"input_tokens\":3,\"output_tokens\":4}}\n\n", transcriptPath)
+			_, _ = fmt.Fprintf(w, "event: complete\ndata: {\"external_session_id\":\"provider-session-1\",\"transcript_path\":%q,\"usage\":{\"input_tokens\":0,\"output_tokens\":0}}\n\n", transcriptPath)
 			_, _ = fmt.Fprint(w, "event: done\ndata: {}\n\n")
 		default:
 			http.NotFound(w, r)
@@ -66,22 +72,25 @@ func TestStreamingAgentTaskBindsSessionAndTranscript(t *testing.T) {
 	dm.Register(daemon)
 	svc := NewAgentService(pool, dm, noopBroadcaster{}, nil)
 	svc.handleStreamingAgentTask(ctx, daemon, daemonTaskRequest{
-		TaskID:           taskID,
 		AgentID:          agentID,
 		ChannelID:        channelID,
 		TriggerMessageID: messageID,
 		Messages:         []agent.Message{{Role: agent.RoleUser, Content: "hello"}},
 		ModelConfig:      agent.ModelConfig{Provider: "claude", Model: "test"},
+		ResultContract:   agentResultContractNone,
 	}, agentChannelInfo{ID: agentID, Name: "Test Agent"})
 
 	var runID, sessionID, runStatus, runTranscript string
+	var inputUsage, outputUsage int
 	err := pool.QueryRow(ctx,
-		`SELECT id::text, COALESCE(session_id::text, ''), status, COALESCE(transcript_path, '')
+		`SELECT id::text, COALESCE(session_id::text, ''), status, COALESCE(transcript_path, ''),
+		        COALESCE((usage_json->>'input_tokens')::int, 0),
+		        COALESCE((usage_json->>'output_tokens')::int, 0)
 		   FROM agent_runs
 		  WHERE agent_id = $1
 		  ORDER BY started_at DESC
 		  LIMIT 1`, agentID,
-	).Scan(&runID, &sessionID, &runStatus, &runTranscript)
+	).Scan(&runID, &sessionID, &runStatus, &runTranscript, &inputUsage, &outputUsage)
 	if err != nil {
 		t.Fatalf("query run: %v", err)
 	}
@@ -93,6 +102,12 @@ func TestStreamingAgentTaskBindsSessionAndTranscript(t *testing.T) {
 	}
 	if runTranscript != transcriptPath {
 		t.Fatalf("run transcript path = %q, want %q", runTranscript, transcriptPath)
+	}
+	if gotTaskID != runID || gotRunID != runID {
+		t.Fatalf("daemon identity = task %q run %q, want agent run %q", gotTaskID, gotRunID, runID)
+	}
+	if inputUsage != 3 || outputUsage != 4 {
+		t.Fatalf("usage = (%d, %d), want (3, 4)", inputUsage, outputUsage)
 	}
 
 	var externalID, sessionTranscript string
@@ -114,6 +129,62 @@ func TestStreamingAgentTaskBindsSessionAndTranscript(t *testing.T) {
 	}
 	if len(timeline.Entries) != 1 || timeline.Entries[0].Text != "stream transcript" {
 		t.Fatalf("timeline entries = %+v", timeline.Entries)
+	}
+}
+
+func TestStreamingAgentTaskFailsWithoutVisibleMessage(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageID := agentRunMessage(t, pool, channelID, ownerID)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE created_by = $1`, ownerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	taskID, server := streamingTestDaemon(t)
+	defer server.Close()
+	rec := newRecordingBroadcaster()
+	dm := NewDaemonManager(pool, rec)
+	daemon := daemonInfoForTest(t, server.URL, uuid.NewString())
+	dm.Register(daemon)
+	svc := NewAgentService(pool, dm, rec, nil)
+	svc.handleStreamingAgentTask(ctx, daemon, daemonTaskRequest{
+		TaskID:           taskID,
+		AgentID:          agentID,
+		ChannelID:        channelID,
+		TriggerMessageID: messageID,
+		ModelConfig:      agent.ModelConfig{Provider: "claude", Model: "test"},
+	}, agentChannelInfo{ID: agentID, Name: "Test Agent"})
+
+	var runID, status, failureCode string
+	err := pool.QueryRow(ctx, `
+		SELECT r.id::text, r.status, COALESCE((
+			SELECT e.payload->>'failure_code'
+			  FROM agent_run_events e
+			 WHERE e.run_id = r.id AND e.type = $2
+			 ORDER BY e.seq DESC
+			 LIMIT 1
+		), '')
+		  FROM agent_runs r
+		 WHERE r.agent_id = $1
+		 ORDER BY r.started_at DESC
+		 LIMIT 1`,
+		agentID, AgentRunEventError,
+	).Scan(&runID, &status, &failureCode)
+	if err != nil {
+		t.Fatalf("query failed run: %v", err)
+	}
+	if status != string(AgentRunStatusFailed) || failureCode != agentFailureMissingVisibleResult {
+		t.Fatalf("run %s = status %q failure %q", runID, status, failureCode)
+	}
+	if !rec.hasChannelEvent(channelID, "agent.error", agentErrorMissingVisibleResult) {
+		t.Fatalf("missing visible-result error not broadcast: %q", rec.channelMessages[channelID])
 	}
 }
 

--- a/internal/server/service/daemon.go
+++ b/internal/server/service/daemon.go
@@ -183,7 +183,7 @@ func (dm *DaemonManager) Unregister(daemonID string) {
 	dm.mu.Unlock()
 
 	for _, task := range timedOutTasks {
-		dm.timeoutPendingTaskRun(task)
+		dm.daemonLostPendingTaskRun(task)
 	}
 
 	slog.Info("daemon unregistered",
@@ -272,6 +272,13 @@ func (dm *DaemonManager) GetDaemonPendingTasks(daemonID string) []PendingTaskInf
 		}
 	}
 	return result
+}
+
+func (dm *DaemonManager) IsTaskTracked(taskID string) bool {
+	dm.mu.RLock()
+	defer dm.mu.RUnlock()
+	_, ok := dm.pendingTasks[taskID]
+	return ok
 }
 
 // SelectDaemon picks the daemon with the lowest current load.
@@ -446,6 +453,12 @@ func (dm *DaemonManager) StreamTask(ctx context.Context, daemon *DaemonInfo, req
 		return nil, fmt.Errorf("daemon returned empty task_id")
 	}
 
+	return dm.SubscribeTask(ctx, daemon, taskID)
+}
+
+// SubscribeTask reconnects to an already-dispatched daemon task. The daemon
+// replays lifecycle events, so a restarted server can converge the same Run.
+func (dm *DaemonManager) SubscribeTask(ctx context.Context, daemon *DaemonInfo, taskID string) (<-chan SSEDaemonEvent, error) {
 	// Connect to SSE endpoint
 	eventsURL := fmt.Sprintf("http://%s:%d/internal/daemon/tasks/%s/events", daemon.Host, daemon.Port, taskID)
 
@@ -462,6 +475,12 @@ func (dm *DaemonManager) StreamTask(ctx context.Context, daemon *DaemonInfo, req
 	if err != nil {
 		cancel()
 		return nil, fmt.Errorf("connect to SSE stream: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		resp.Body.Close()
+		cancel()
+		return nil, fmt.Errorf("daemon returned status %d for task events: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
 	eventCh := make(chan SSEDaemonEvent, 64)
@@ -651,7 +670,7 @@ func (dm *DaemonManager) healthCheckLoop() {
 }
 
 func (dm *DaemonManager) checkHealth() {
-	var timedOutTasks []PendingTaskInfo
+	var lostTasks []PendingTaskInfo
 
 	dm.mu.Lock()
 	now := time.Now()
@@ -684,7 +703,7 @@ func (dm *DaemonManager) checkHealth() {
 		cleanedCount := 0
 		for taskID, task := range dm.pendingTasks {
 			if task.DaemonID == id {
-				timedOutTasks = append(timedOutTasks, task)
+				lostTasks = append(lostTasks, task)
 				delete(dm.pendingTasks, taskID)
 				cleanedCount++
 			}
@@ -698,9 +717,12 @@ func (dm *DaemonManager) checkHealth() {
 	}
 
 	// Remove tasks that have exceeded their phase-specific timeout threshold.
-	timedOutTasks = append(timedOutTasks, dm.removeStaleTasks(now)...)
+	timedOutTasks := dm.removeStaleTasks(now)
 	dm.mu.Unlock()
 
+	for _, task := range lostTasks {
+		dm.daemonLostPendingTaskRun(task)
+	}
 	for _, task := range timedOutTasks {
 		dm.timeoutPendingTaskRun(task)
 	}
@@ -738,44 +760,82 @@ func (dm *DaemonManager) removeStaleTasks(now time.Time) []PendingTaskInfo {
 }
 
 func (dm *DaemonManager) timeoutPendingTaskRun(task PendingTaskInfo) {
+	activity := agentActivityTimeout
+	if task.TimeoutPhase == "queue" {
+		activity = agentActivityQueueTimeout
+	}
+	dm.finishPendingTaskRun(task, AgentRunStatusTimeout, activity, agentFailureTimeout, true)
+}
+
+func (dm *DaemonManager) daemonLostPendingTaskRun(task PendingTaskInfo) {
+	dm.finishPendingTaskRun(task, AgentRunStatusFailed, agentActivityDaemonLost, agentFailureDaemonLost, true)
+}
+
+func (dm *DaemonManager) finishPendingTaskRun(task PendingTaskInfo, status AgentRunStatus, activity, failureCode string, retryable bool) {
 	if task.RunID == "" || dm.pool == nil {
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	if daemon, ok := dm.GetDaemon(task.DaemonID); ok && daemon.Status == DaemonStatusOnline {
+		if err := dm.CancelTask(ctx, daemon, task.TaskID); err != nil {
+			retryable = false
+			slog.Warn("failed to stop daemon task before terminal transition", "task_id", task.TaskID, "daemon_id", task.DaemonID, "error", err)
+		}
+	}
+
 	runSvc := NewAgentRunService(dm.pool)
 	run, err := runSvc.GetRun(ctx, task.RunID)
 	if err != nil {
-		slog.Warn("failed to load pending task run for timeout", "task_id", task.TaskID, "run_id", task.RunID, "error", err)
+		slog.Warn("failed to load pending task run", "task_id", task.TaskID, "run_id", task.RunID, "error", err)
 		return
 	}
 	if !isActiveAgentRunStatus(run.Status) {
 		return
 	}
-	activity := agentActivityTimeout
-	if task.TimeoutPhase == "queue" {
-		activity = agentActivityQueueTimeout
-	}
 	finished, err := runSvc.FinishRun(ctx, FinishRunInput{
 		RunID:        run.ID,
-		Status:       AgentRunStatusTimeout,
+		Status:       status,
 		ActivityText: activity,
 	})
 	if errors.Is(err, ErrAgentRunAlreadyFinished) {
 		return
 	}
 	if err != nil {
-		slog.Warn("failed to timeout pending task run", "task_id", task.TaskID, "run_id", task.RunID, "error", err)
+		slog.Warn("failed to finish pending task run", "task_id", task.TaskID, "run_id", task.RunID, "error", err)
 		return
 	}
-	if dm.hub != nil {
-		dm.hub.Broadcast(realtime.Envelope("agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, "")))
+	event, eventErr := runSvc.AppendEvent(ctx, AppendRunEventInput{
+		RunID:   finished.ID,
+		Type:    AgentRunEventError,
+		Message: activity,
+		Payload: map[string]any{
+			"status":       status,
+			"failure_code": failureCode,
+			"retryable":    retryable,
+		},
+	})
+	if eventErr != nil {
+		slog.Warn("failed to append pending task failure event", "task_id", task.TaskID, "run_id", task.RunID, "error", eventErr)
 	}
-	if daemon, ok := dm.GetDaemon(task.DaemonID); ok {
-		if err := dm.CancelTask(ctx, daemon, task.TaskID); err != nil {
-			slog.Warn("failed to cancel timed out daemon task", "task_id", task.TaskID, "daemon_id", task.DaemonID, "error", err)
+	if dm.hub != nil {
+		if event != nil {
+			dm.hub.Broadcast(realtime.Envelope("agent.run.event", map[string]any{
+				"id":         event.ID,
+				"run_id":     finished.ID,
+				"agent_id":   finished.AgentID,
+				"agent_name": finished.AgentName,
+				"channel_id": finished.ChannelID,
+				"thread_id":  finished.ThreadID,
+				"seq":        event.Seq,
+				"event_type": event.Type,
+				"message":    event.Message,
+				"payload":    json.RawMessage(event.Payload),
+				"timestamp":  event.CreatedAt.UTC().Format(time.RFC3339),
+			}))
 		}
+		dm.hub.Broadcast(realtime.Envelope("agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, "")))
 	}
 }
 
@@ -807,6 +867,7 @@ type DaemonRegisterRequest struct {
 	CurrentLoad   int32            `json:"current_load"`
 	AgentTypes    []string         `json:"agent_types"`
 	SystemInfo    DaemonSystemInfo `json:"system_info"`
+	Tasks         []string         `json:"tasks,omitempty"`
 }
 
 type DaemonRegisterResponse struct {

--- a/internal/server/ws/message.go
+++ b/internal/server/ws/message.go
@@ -156,6 +156,7 @@ type MessageNewPayload struct {
 	SenderAvatar       string           `json:"sender_avatar,omitempty"`
 	Content            string           `json:"content"`
 	ContentType        string           `json:"content_type"`
+	Metadata           map[string]any   `json:"metadata,omitempty"`
 	ThreadID           string           `json:"thread_id,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
 	MentionedAgentIDs  []string         `json:"mentioned_agent_ids,omitempty"`
@@ -255,6 +256,7 @@ type ThreadMessageItem struct {
 	SenderAvatar  string           `json:"sender_avatar,omitempty"`
 	Content       string           `json:"content"`
 	ContentType   string           `json:"content_type"`
+	Metadata      map[string]any   `json:"metadata,omitempty"`
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`

--- a/pkg/agent/claude.go
+++ b/pkg/agent/claude.go
@@ -958,9 +958,9 @@ func (b *ClaudeBackend) handleUser(msg claudeSDKMessage, ch chan<- OutputChunk) 
 
 // ── CLI argument construction ──
 
-// claudeBlockedArgs are flags hardcoded by the Backend that must not be
-// overridden by user-configured CustomArgs. Overriding these would break
-// the daemon-to-claude communication protocol.
+// claudeBlockedArgs are flags owned by the Backend that must not be overridden
+// by user-configured CustomArgs. Overriding these would break the protocol or
+// route a Channel turn into the wrong provider session.
 //
 // Note: "-p" is intentionally NOT blocked. We run Claude Code in interactive
 // mode (without -p) so agents can autonomously execute shell commands
@@ -972,6 +972,12 @@ var claudeBlockedArgs = map[string]blockedArgMode{
 	"--permission-mode": blockedWithValue,
 	"--disallowedTools": blockedWithValue,
 	"--max-turns":       blockedWithValue,
+	"--resume":          blockedWithValue,
+	"-r":                blockedWithValue,
+	"--continue":        blockedStandalone,
+	"-c":                blockedStandalone,
+	"--session-id":      blockedWithValue,
+	"--fork-session":    blockedStandalone,
 }
 
 // buildClaudeArgs constructs the CLI arguments for spawning Claude Code.
@@ -996,6 +1002,9 @@ func buildClaudeArgs(req *ExecuteRequest, opts *ExecuteOptions) []string {
 	}
 	if opts.MaxTurns > 0 {
 		args = append(args, "--max-turns", strconv.Itoa(opts.MaxTurns))
+	}
+	if opts.ResumeSessionID != "" {
+		args = append(args, "--resume", opts.ResumeSessionID)
 	}
 	if opts.SystemPrompt != "" {
 		// Write system prompt to .solo/system-prompt.md.

--- a/pkg/agent/claude_test.go
+++ b/pkg/agent/claude_test.go
@@ -34,6 +34,21 @@ func TestBuildClaudeArgs(t *testing.T) {
 		assertContains(t, args, "sonnet")
 	})
 
+	t.Run("with runtime-owned resume session", func(t *testing.T) {
+		req := &ExecuteRequest{}
+		opts := &ExecuteOptions{
+			ResumeSessionID: "provider-session",
+			CustomArgs:      []string{"--resume", "wrong-session", "--continue", "--fork-session"},
+		}
+		args := buildClaudeArgs(req, opts)
+
+		assertContains(t, args, "--resume")
+		assertContains(t, args, "provider-session")
+		assertNotContains(t, args, "wrong-session")
+		assertNotContains(t, args, "--continue")
+		assertNotContains(t, args, "--fork-session")
+	})
+
 	t.Run("with system prompt", func(t *testing.T) {
 		req := &ExecuteRequest{}
 		opts := &ExecuteOptions{SystemPrompt: "Be helpful.", WorkspaceDir: t.TempDir()}

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -399,7 +399,7 @@ func (m *AgentSessionManager) ForceCloseSession(agentID string) error {
 	return firstErr
 }
 
-// CloseAll terminates all sessions.
+// CloseAll immediately terminates all sessions for daemon shutdown.
 func (m *AgentSessionManager) CloseAll() {
 	m.mu.Lock()
 	entries := make([]*agentSessionEntry, 0, len(m.sessions))
@@ -412,8 +412,8 @@ func (m *AgentSessionManager) CloseAll() {
 	for _, entry := range entries {
 		ps, asleep, _ := entry.snapshot()
 		if !asleep && ps != nil {
-			m.logger.Info("session: closing (shutdown)", "agent_id", entry.AgentID)
-			_ = m.backend.Close(ps)
+			m.logger.Warn("session: force-closing (shutdown)", "agent_id", entry.AgentID)
+			_ = m.backend.ForceClose(ps)
 		}
 	}
 }

--- a/pkg/agent/session_test.go
+++ b/pkg/agent/session_test.go
@@ -125,6 +125,30 @@ func TestSessionManagerClosesReturnedThinkingSession(t *testing.T) {
 	}
 }
 
+func TestSessionManagerCloseAllForceCloses(t *testing.T) {
+	backend := &scopedRecordingBackend{}
+	mgr := NewAgentSessionManager(backend, NewWorkspaceManager(t.TempDir()), nil, slog.Default())
+	ps, err := mgr.GetOrCreateSession(context.Background(), "agent-1", AgentConfig{
+		AgentID: "agent-1", Name: "Agent", Provider: "claude",
+	}, ChannelContext{}, []Message{{Role: RoleUser, Content: "work"}}, nil)
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	<-ps.Result
+
+	mgr.CloseAll()
+
+	backend.mu.Lock()
+	forced, closed := backend.forceCloseCount, backend.closeCount
+	backend.mu.Unlock()
+	if forced != 1 || closed != 0 {
+		t.Fatalf("shutdown closes = force %d graceful %d, want 1/0", forced, closed)
+	}
+	if mgr.IsActive("agent-1") {
+		t.Fatal("session remains active after CloseAll")
+	}
+}
+
 func TestSessionManagerSleepsOnlyIdleThinkingSessionsAndResumes(t *testing.T) {
 	backend := &scopedRecordingBackend{}
 	mgr := NewAgentSessionManager(backend, NewWorkspaceManager(t.TempDir()), nil, slog.Default())


### PR DESCRIPTION
## What changed

- Use one canonical Agent Run ID across Server, Daemon, CLI delivery metadata, events, usage, and task links.
- Require persisted `visible_message` delivery before a normal message or Task Run can complete.
- Reconcile active Runs against the single Daemon snapshot and converge missing work to `daemon_lost`.
- Close provider runtimes before Daemon unregister/lock release so stale processes cannot race a reassigned Task.
- Automatically reassign retryable Task failures, cap attempts at three, then return exhausted Tasks to TODO.
- Tell a reassigned Agent that it is the current database-backed assignee even when the original Task message names an older Agent.
- Resume the latest Channel provider Session after a Daemon restart without changing Channel/Thread routing scope.
- Add localized activity states, architecture documentation, regression coverage, and a six-scenario real E2E suite.

## Why

The previous paths could disagree about Run identity, report backend completion without a visible persisted result, strand Runs after a Daemon restart, or let a stale provider process race automatic reassignment. Reassigned Agents also received the original Task creation text and could reasonably refuse work because it still named the previous assignee.

The persisted Run, message delivery metadata, Daemon snapshot, and Task `claimer_id` are now the authoritative boundaries.

## Impact and compatibility

This is scoped to Solo's current single-user, single-Daemon model. It adds no database migration and preserves existing Channel/Thread message routing. Server, Daemon, and CLI should be upgraded together through `make rebuild`; historical messages remain readable but messages without a current `agent_run_id` do not satisfy a new Run's delivery contract.

## Validation

- `make test-e2e-agent-delivery` — 6/6 passed against the real frontend, API server, PostgreSQL, Daemon, and local Claude runtime (4.1m)
- Verified the user-visible result and persisted PostgreSQL Run/message/event/usage state
- `go test ./...`
- `npm run build`
- `npm run lint` — 0 errors (51 pre-existing warnings)
- `git diff --check`
- Correctness review and Ponytail review: no blocking findings
