### PR TITLE
Clarify incoming message sender labels

### DIFF
--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -406,7 +406,6 @@ test.describe('real Agent result delivery contract', () => {
         model_provider: 'claude',
         model_name: 'sonnet',
         system_prompt: [
-          'The sender label @Agent Result Delivery E2E identifies the human test user, not another Agent; its messages are directed to you.',
           'Always deliver replies with solo message send.',
           'When introducing yourself, send exactly READY.',
           'When a user says REMEMBER followed by a value, retain it only in the current conversation and send exactly STORED.',

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -97,6 +97,7 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 	b.WriteString("[target=dm:@richard msg=c9d0e1f2 time=2026-03-15T01:00:02 type=human] @richard: hey, can you help?\n")
 	b.WriteString("[target=#general:a1b2c3d4 msg=f3a4b5c6 time=2026-03-15T01:00:03 type=human] @richard: thread reply\n")
 	b.WriteString("```\n\n")
+	b.WriteString("Parse this line structurally: the `@name:` immediately after `]` is the **sender label**, never a recipient or @mention. Only `@name` tokens inside the content after that sender label are @mentions. For example, `] @lili: hello` means lili sent `hello`; it does not address or @mention lili.\n\n")
 	b.WriteString("Header fields:\n")
 	b.WriteString("- `target=` — where the message came from. Reuse as the `--target` parameter when replying.\n")
 	b.WriteString("- `msg=` — message short ID (first 8 chars of UUID). Use as thread suffix to start/reply in a thread.\n")

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -235,6 +235,8 @@ func TestBuildSystemPrompt_MessageFormat(t *testing.T) {
 	assertHas(t, p, "time=")
 	assertHas(t, p, "msg=")
 	assertHas(t, p, "type=")
+	assertHas(t, p, "is the **sender label**, never a recipient or @mention")
+	assertHas(t, p, "] @lili: hello")
 }
 
 func TestBuildSystemPrompt_MessageNotifications(t *testing.T) {


### PR DESCRIPTION
## What changed

- Clarify that the `@name:` immediately after the incoming message header is the sender label, not an addressee or mention.
- Define only `@name` tokens inside the message body as mentions.
- Remove the E2E-only sender-label workaround so the shared System Prompt owns this behavior.

## Root cause

Solo renders incoming messages as `] @sender: content`, while `@name` is also the mention syntax. The existing prompt described the overall format but did not explicitly disambiguate the sender prefix, so Claude could treat the human sender as the intended recipient and decline to respond.

## Impact

Agents now parse the envelope sender separately from mentions in the message content, avoiding false “this message is for someone else” decisions.

## Validation

- `env GOCACHE=/private/tmp/solo-go-cache go test ./pkg/agent`
- `make test-e2e-agent-session-resume` — real frontend, API server, PostgreSQL, and Claude runtime; 1 passed
- `make rebuild` with ports 3000, 8080, and 8081 verified listening
