### PR TITLE
Add reliable message delivery

### DIFF
--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -376,16 +376,17 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		AgentID    string `json:"agent_id"`
-		Action     string `json:"action"`
-		ChannelID  string `json:"channel_id"`
-		Content    string `json:"content,omitempty"`
-		ThreadID   string `json:"thread_id,omitempty"`
-		NodeID     string `json:"thinking_node_id,omitempty"`
-		RunID      string `json:"run_id,omitempty"`
-		TaskNumber int    `json:"task_number,omitempty"`
-		TaskID     string `json:"task_id,omitempty"`
-		Status     string `json:"status,omitempty"`
+		AgentID     string `json:"agent_id"`
+		Action      string `json:"action"`
+		ChannelID   string `json:"channel_id"`
+		Content     string `json:"content,omitempty"`
+		ThreadID    string `json:"thread_id,omitempty"`
+		NodeID      string `json:"thinking_node_id,omitempty"`
+		RunID       string `json:"run_id,omitempty"`
+		TaskNumber  int    `json:"task_number,omitempty"`
+		TaskID      string `json:"task_id,omitempty"`
+		Status      string `json:"status,omitempty"`
+		ClientMsgID string `json:"client_msg_id,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
@@ -433,6 +434,9 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.RunID != "" {
 			bodyMap["run_id"] = req.RunID
+		}
+		if req.ClientMsgID != "" {
+			bodyMap["client_msg_id"] = req.ClientMsgID
 		}
 		serverBody, _ = json.Marshal(bodyMap)
 	case "task_claim":

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -42,6 +42,8 @@ import (
 
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // Exit codes matching the v1.3 CLI spec.
@@ -294,7 +296,7 @@ func handleTeamForm(args []string, baseURL, token string) {
 }
 
 func requestTeamFormation(baseURL, token, channelID string, reqBody []byte) (int, []byte, error) {
-	statusCode, body, err := proxyRequest("team_form", channelID, string(reqBody), "", token, 0, "")
+	statusCode, body, err := proxyRequest("team_form", channelID, string(reqBody), "", token, 0, "", "")
 	if err != nil || statusCode == http.StatusBadGateway || statusCode == http.StatusGatewayTimeout {
 		statusCode, body, err = doHTTPWithTimeout(http.MethodPost, baseURL+"/api/v1/team-formations", token, reqBody, teamFormationRequestTimeout)
 	}
@@ -386,7 +388,7 @@ func handleArtifactPublish(args []string, baseURL, token string) {
 
 // proxyRequest calls the daemon proxy instead of the server API directly.
 // This keeps local thinking separate from channel communication.
-func proxyRequest(action, channelID, content, threadID, token string, taskNumber int, status string) (int, []byte, error) {
+func proxyRequest(action, channelID, content, threadID, token string, taskNumber int, status, clientMsgID string) (int, []byte, error) {
 	daemonURL := os.Getenv("SOLO_DAEMON_URL")
 	if daemonURL == "" {
 		daemonURL = "http://127.0.0.1:8081"
@@ -415,6 +417,9 @@ func proxyRequest(action, channelID, content, threadID, token string, taskNumber
 	}
 	if status != "" {
 		body["status"] = status
+	}
+	if clientMsgID != "" {
+		body["client_msg_id"] = clientMsgID
 	}
 	// For task_claim with -m, the message_id is passed in the content field.
 	// Forward it as task_id so the proxy can construct the correct URL path.
@@ -566,7 +571,7 @@ func handleTaskClaim(args []string, baseURL, token string) {
 
 	// Try daemon proxy first (uses fresh JWT).
 	// Pass messageID via taskID parameter so the proxy uses it in the URL path.
-	statusCode, body, err := proxyRequest("task_claim", channelID, taskID, "", token, number, "")
+	statusCode, body, err := proxyRequest("task_claim", channelID, taskID, "", token, number, "", "")
 	if err != nil {
 		// Fallback to direct API
 		apiURL := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%s/claim", baseURL, channelID, taskID)
@@ -730,7 +735,7 @@ func handleTaskUnclaim(args []string, baseURL, token string) {
 	}
 
 	// Try daemon proxy first (uses fresh JWT)
-	statusCode, body, err := proxyRequest("task_unclaim", channelID, "", "", token, number, "")
+	statusCode, body, err := proxyRequest("task_unclaim", channelID, "", "", token, number, "", "")
 	if err != nil {
 		// Fallback to direct API
 		url := fmt.Sprintf("%s/api/v1/channels/%s/tasks/%d/claim", baseURL, channelID, number)
@@ -852,7 +857,8 @@ func handleMessageSend(args []string, baseURL, token string) {
 		doExit(exitUsage)
 	}
 
-	reqBody := map[string]string{"content": content}
+	clientMsgID := uuid.NewString()
+	reqBody := map[string]string{"content": content, "client_msg_id": clientMsgID}
 	if threadID != "" {
 		reqBody["thread_id"] = threadID
 	}
@@ -865,8 +871,8 @@ func handleMessageSend(args []string, baseURL, token string) {
 
 	body, _ := json.Marshal(reqBody)
 	// Try daemon proxy first
-	statusCode, respBody, err := proxyRequest("message_send", channelID, content, threadID, token, 0, "")
-	if err != nil {
+	statusCode, respBody, err := proxyRequest("message_send", channelID, content, threadID, token, 0, "", clientMsgID)
+	if err != nil || statusCode == http.StatusBadGateway || statusCode == http.StatusGatewayTimeout {
 		// Fallback to direct API
 		url := fmt.Sprintf("%s/api/v1/channels/%s/messages", baseURL, channelID)
 		statusCode, respBody, err = doHTTP(http.MethodPost, url, token, body)
@@ -910,7 +916,7 @@ func handleChannel(args []string, baseURL, token string) {
 // proxyOrDirect tries the daemon proxy first, then falls back to direct API.
 // Used for read-only commands that need fresh auth tokens in persistent sessions.
 func proxyOrDirect(action, channelID, content string, token string) (int, []byte, error) {
-	statusCode, body, err := proxyRequest(action, channelID, content, "", token, 0, "")
+	statusCode, body, err := proxyRequest(action, channelID, content, "", token, 0, "", "")
 	if err != nil {
 		// Fallback handled by caller
 		return 0, nil, err
@@ -1001,7 +1007,7 @@ func handleMessageCheck(args []string, baseURL, token string) {
 		}
 	}
 
-	statusCode, body, err := proxyRequest("message_check", channelID, "", "", token, 0, "")
+	statusCode, body, err := proxyRequest("message_check", channelID, "", "", token, 0, "", "")
 	if err != nil {
 		statusCode, body, err = doHTTP(http.MethodGet, requestURL, token, nil)
 	}

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -686,6 +686,9 @@ func TestHandleMessageSend(t *testing.T) {
 	if body["content"] != "hello" {
 		t.Errorf("expected content=hello, got %s", body["content"])
 	}
+	if body["client_msg_id"] == "" {
+		t.Error("expected client_msg_id")
+	}
 	if _, ok := body["thread_id"]; ok {
 		t.Errorf("expected no thread_id when -t not provided, got %v", body["thread_id"])
 	}
@@ -1277,7 +1280,7 @@ func TestProxyRequestCarriesAgentRunID(t *testing.T) {
 	t.Setenv("SOLO_DAEMON_URL", server.URL)
 	t.Setenv("SOLO_AGENT_ID", "agent-1")
 	t.Setenv("SOLO_RUN_ID", "run-1")
-	status, _, err := proxyRequest("message_send", "channel-1", "done", "", "token", 0, "")
+	status, _, err := proxyRequest("message_send", "channel-1", "done", "", "token", 0, "", "client-1")
 	if err != nil {
 		t.Fatalf("proxyRequest: %v", err)
 	}
@@ -1286,6 +1289,9 @@ func TestProxyRequestCarriesAgentRunID(t *testing.T) {
 	}
 	if got["run_id"] != "run-1" {
 		t.Fatalf("run_id = %#v, want run-1", got["run_id"])
+	}
+	if got["client_msg_id"] != "client-1" {
+		t.Fatalf("client_msg_id = %#v, want client-1", got["client_msg_id"])
 	}
 }
 

--- a/frontend/components/dashboard/message-input.tsx
+++ b/frontend/components/dashboard/message-input.tsx
@@ -367,36 +367,25 @@ export function MessageInput({
   const hasUploading = uploads.some((u) => u.status === 'uploading');
   const canSend = (trimmed.length > 0 || (!asTask && doneUploads.length > 0)) && !isSending && !hasUploading && !disabled;
 
-  const handleSend = useCallback(async () => {
+  const handleSend = useCallback(() => {
     if (!canSend || isSendingRef.current) return;
 
     isSendingRef.current = true;
     setIsSending(true);
-    try {
-      const attachmentIds =
-        doneUploads.length > 0
-          ? doneUploads.map((u) => u.id)
-          : undefined;
-
-      await onSend(
-        trimmed,
-        mentionedAgentIds,
-        asTask,
-        undefined,
-        attachmentIds,
-      );
-      setContent('');
-      setAsTask(false);
-      setUploads([]);
-      resetMention();
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto';
-      }
-    } finally {
-      isSendingRef.current = false;
-      setIsSending(false);
-      textareaRef.current?.focus();
+    const attachmentIds = doneUploads.length > 0
+      ? doneUploads.map((u) => u.id)
+      : undefined;
+    void onSend(trimmed, mentionedAgentIds, asTask, undefined, attachmentIds);
+    setContent('');
+    setAsTask(false);
+    setUploads([]);
+    resetMention();
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
     }
+    isSendingRef.current = false;
+    setIsSending(false);
+    textareaRef.current?.focus();
   }, [canSend, trimmed, onSend, mentionedAgentIds, asTask, doneUploads, resetMention]);
 
   // ---- Keyboard handling ----

--- a/frontend/components/dashboard/thread-panel.tsx
+++ b/frontend/components/dashboard/thread-panel.tsx
@@ -503,22 +503,19 @@ function ThreadReplyInput({
   const trimmed = content.trim();
   const canSend = trimmed.length > 0 && !isSending && !disabled;
 
-  const handleSend = useCallback(async () => {
+  const handleSend = useCallback(() => {
     if (!canSend || isSendingRef.current) return;
     isSendingRef.current = true;
     setIsSending(true);
-    try {
-      await onSend(trimmed, mentionedAgentIds);
-      setContent('');
-      resetMention();
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto';
-      }
-    } finally {
-      isSendingRef.current = false;
-      setIsSending(false);
-      textareaRef.current?.focus();
+    void onSend(trimmed, mentionedAgentIds);
+    setContent('');
+    resetMention();
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
     }
+    isSendingRef.current = false;
+    setIsSending(false);
+    textareaRef.current?.focus();
   }, [canSend, trimmed, onSend, mentionedAgentIds, resetMention]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/frontend/e2e/message-reliability.spec.ts
+++ b/frontend/e2e/message-reliability.spec.ts
@@ -1,0 +1,261 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const wsBase = apiBase.replace(/^http/, 'ws');
+const credentials = { email: 'message-reliability-e2e@solo.local', password: 'SoloE2E-2026!' };
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+interface SendResponse {
+  id: string;
+  message_id?: string;
+  thread_id?: string;
+  client_msg_id: string;
+  deduplicated?: boolean;
+}
+
+function databaseJSON<T>(query: string): T {
+  const output = execFileSync('docker', [
+    'exec', process.env.SOLO_POSTGRES_CONTAINER ?? 'solo-postgres',
+    'psql', '-U', process.env.POSTGRES_USER ?? 'solo', '-d', process.env.POSTGRES_DB ?? 'solo',
+    '-tA', '-c', query,
+  ], { encoding: 'utf8' }).trim();
+  return JSON.parse(output) as T;
+}
+
+async function authenticate(request: APIRequestContext): Promise<AuthResponse> {
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, { data: credentials });
+  if (login.ok()) return login.json();
+  const register = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: { ...credentials, display_name: 'Message Reliability E2E' },
+  });
+  if (!register.ok()) throw new Error(`E2E authentication failed: ${register.status()} ${await register.text()}`);
+  return register.json();
+}
+
+async function openEventProbe(page: Page, token: string, channelID: string): Promise<void> {
+  await page.evaluate(
+    ({ url, accessToken, channel }) => new Promise<void>((resolve, reject) => {
+      const state = window as typeof window & { reliabilityEvents?: Array<Record<string, unknown>>; reliabilitySocket?: WebSocket };
+      state.reliabilityEvents = [];
+      const socket = new WebSocket(`${url}/api/v1/ws?token=${encodeURIComponent(accessToken)}`);
+      state.reliabilitySocket = socket;
+      socket.onerror = () => reject(new Error('reliability probe failed to connect'));
+      socket.onmessage = (event) => {
+        const envelope = JSON.parse(String(event.data)) as { type: string; payload: Record<string, unknown> };
+        if (envelope.type === 'message.new' || envelope.type === 'thread.message.new') {
+          state.reliabilityEvents!.push({ type: envelope.type, ...envelope.payload });
+        }
+      };
+      socket.onopen = () => {
+        socket.send(JSON.stringify({ type: 'subscribe', payload: { channel_id: channel } }));
+        resolve();
+      };
+    }),
+    { url: wsBase, accessToken: token, channel: channelID },
+  );
+}
+
+test('client message ID deduplicates message, task, and first thread reply', async ({ page, request }) => {
+  const auth = await authenticate(request);
+  const headers = { authorization: `Bearer ${auth.access_token}` };
+  const suffix = Date.now().toString(36);
+  const created = await request.post(`${apiBase}/api/v1/channels`, {
+    headers,
+    data: { name: `reliability-e2e-${suffix}`, description: 'Message reliability E2E' },
+  });
+  expect(created.ok()).toBe(true);
+  const channel = await created.json() as { id: string };
+  let dmID = '';
+  let dmMessageID = '';
+
+  try {
+    await page.addInitScript(({ accessToken, refreshToken }) => {
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('refresh_token', refreshToken);
+      localStorage.setItem('solo.locale', 'en');
+    }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+    await page.goto(`/dashboard?channel=${channel.id}`);
+    await expect(page.locator('#channel-conversation-panel')).toBeVisible();
+    await openEventProbe(page, auth.access_token, channel.id);
+
+    const messageContent = `RELIABLE_MESSAGE_${suffix}`;
+    const messageClientID = crypto.randomUUID();
+    const messageRequests = [1, 2].map(() => request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages`,
+      { headers, data: { content: messageContent, client_msg_id: messageClientID } },
+    ));
+    const messageResponses = await Promise.all(messageRequests);
+    expect(messageResponses.every((response) => response.status() === 201)).toBe(true);
+    const messageBodies = await Promise.all(messageResponses.map((response) => response.json() as Promise<SendResponse>));
+    expect(new Set(messageBodies.map((body) => body.id)).size).toBe(1);
+    expect(messageBodies.some((body) => body.deduplicated)).toBe(true);
+    expect(messageBodies.every((body) => body.client_msg_id === messageClientID)).toBe(true);
+    await expect(page.getByLabel('Message list').getByText(messageContent, { exact: true })).toHaveCount(1);
+
+    const taskContent = `RELIABLE_TASK_${suffix}`;
+    const taskClientID = crypto.randomUUID();
+    const taskResponses = await Promise.all([1, 2].map(() => request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages`,
+      { headers, data: { content: taskContent, as_task: true, client_msg_id: taskClientID } },
+    )));
+    const taskBodies = await Promise.all(taskResponses.map((response) => response.json() as Promise<SendResponse>));
+    expect(new Set(taskBodies.map((body) => body.id)).size).toBe(1);
+    expect(taskBodies.some((body) => body.deduplicated)).toBe(true);
+
+    const threadContent = `RELIABLE_THREAD_${suffix}`;
+    const threadClientID = crypto.randomUUID();
+    const messageID = messageBodies[0].id;
+    const threadResponses = await Promise.all([1, 2].map(() => request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages/${messageID}/thread`,
+      { headers, data: { content: threadContent, client_msg_id: threadClientID } },
+    )));
+    const threadBodies = await Promise.all(threadResponses.map((response) => response.json() as Promise<SendResponse>));
+    expect(new Set(threadBodies.map((body) => body.id)).size).toBe(1);
+    expect(threadBodies.some((body) => body.deduplicated)).toBe(true);
+
+    await expect.poll(() => page.evaluate(({ messageID, threadID }) => {
+      const events = (window as typeof window & { reliabilityEvents?: Array<Record<string, unknown>> }).reliabilityEvents ?? [];
+      return {
+        messages: events.filter((event) => event.client_msg_id === messageID).length,
+        threads: events.filter((event) => {
+          const message = event.message as Record<string, unknown> | undefined;
+          return message?.client_msg_id === threadID;
+        }).length,
+      };
+    }, { messageID: messageClientID, threadID: threadClientID })).toEqual({ messages: 1, threads: 1 });
+
+    const state = databaseJSON<{ messages: number; tasks: number; replies: number; reply_count: number }>(`
+      SELECT json_build_object(
+        'messages', COUNT(*) FILTER (WHERE m.content = '${messageContent}'),
+        'tasks', (SELECT COUNT(*) FROM tasks WHERE channel_id = '${channel.id}' AND title = '${taskContent}'),
+        'replies', COUNT(*) FILTER (WHERE m.content = '${threadContent}'),
+        'reply_count', COALESCE((SELECT reply_count FROM threads WHERE root_message_id = '${messageID}'), 0)
+      )::text
+      FROM messages m
+      WHERE m.channel_id = '${channel.id}'
+    `);
+    expect(state).toEqual({ messages: 1, tasks: 1, replies: 1, reply_count: 1 });
+
+    const secondary = await request.post(`${apiBase}/api/v1/auth/register`, {
+      data: {
+        email: `message-reliability-peer-${suffix}@solo.local`,
+        password: credentials.password,
+        display_name: 'Reliability Peer',
+      },
+    });
+    expect(secondary.ok()).toBe(true);
+    const secondaryAuth = await secondary.json() as AuthResponse;
+    const secondaryUserResponse = await request.get(`${apiBase}/api/v1/users/me`, {
+      headers: { authorization: `Bearer ${secondaryAuth.access_token}` },
+    });
+    const secondaryUser = await secondaryUserResponse.json() as { id: string };
+    const dmResponse = await request.post(`${apiBase}/api/v1/dm`, {
+      headers,
+      data: { member_type: 'user', member_id: secondaryUser.id },
+    });
+    expect(dmResponse.ok()).toBe(true);
+    dmID = (await dmResponse.json() as { id: string }).id;
+    const dmContent = `RELIABLE_DM_${suffix}`;
+    const dmClientID = crypto.randomUUID();
+    const dmResponses = await Promise.all([1, 2].map(() => request.post(
+      `${apiBase}/api/v1/dm/${dmID}/messages`,
+      { headers, data: { content: dmContent, client_msg_id: dmClientID } },
+    )));
+    const dmBodies = await Promise.all(dmResponses.map((response) => response.json() as Promise<SendResponse>));
+    dmMessageID = dmBodies[0].id;
+    expect(new Set(dmBodies.map((body) => body.id)).size).toBe(1);
+    expect(dmBodies.some((body) => body.deduplicated)).toBe(true);
+    expect(databaseJSON<number>(`
+      SELECT COUNT(*)::int::text FROM messages WHERE channel_id = '${dmID}' AND content = '${dmContent}'
+    `)).toBe(1);
+
+    const uiContent = `RELIABLE_UI_${suffix}`;
+    const composer = page.getByPlaceholder('Type a message...');
+    await composer.fill(uiContent);
+    await composer.press('Enter');
+    await expect(composer).toHaveValue('');
+    await expect(page.getByLabel('Message list').getByText(uiContent, { exact: true })).toHaveCount(1);
+    await expect.poll(() => databaseJSON<number>(`
+      SELECT COUNT(*)::int::text FROM messages WHERE channel_id = '${channel.id}' AND content = '${uiContent}'
+    `)).toBe(1);
+    await expect.poll(() => page.evaluate((content) => {
+      const events = (window as typeof window & { reliabilityEvents?: Array<Record<string, unknown>> }).reliabilityEvents ?? [];
+      return events.find((event) => event.content === content)?.client_msg_id ?? '';
+    }, uiContent)).not.toBe('');
+  } finally {
+    await page.evaluate(() => (window as typeof window & { reliabilitySocket?: WebSocket }).reliabilitySocket?.close()).catch(() => undefined);
+    if (dmID && dmMessageID) {
+      await request.delete(`${apiBase}/api/v1/dm/${dmID}/messages/${dmMessageID}`, { headers }).catch(() => undefined);
+    }
+    await request.delete(`${apiBase}/api/v1/channels/${channel.id}`, { headers });
+  }
+});
+
+test('duplicate delivery triggers one real Agent run and one visible CLI reply', async ({ page, request }) => {
+  test.skip(process.env.SOLO_E2E_REAL_AGENT_DELIVERY !== '1', 'requires the make-managed stack and authenticated local Claude runtime');
+  test.setTimeout(240_000);
+
+  const auth = await authenticate(request);
+  const headers = { authorization: `Bearer ${auth.access_token}` };
+  const suffix = Date.now().toString(36);
+  let channelID = '';
+  let agentID = '';
+
+  try {
+    const channelResponse = await request.post(`${apiBase}/api/v1/channels`, {
+      headers,
+      data: { name: `reliability-agent-${suffix}`, description: 'Real Agent reliability E2E' },
+    });
+    channelID = (await channelResponse.json() as { id: string }).id;
+    const acknowledgement = `RELIABLE_AGENT_ACK_${suffix.toUpperCase()}`;
+    const agentResponse = await request.post(`${apiBase}/api/v1/channels/${channelID}/agents`, {
+      headers,
+      data: {
+        name: `Reliability Agent ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: `For every human message, use solo message send to reply with exactly ${acknowledgement}. Do not merely print the reply.`,
+      },
+    });
+    expect(agentResponse.ok()).toBe(true);
+    agentID = (await agentResponse.json() as { id: string }).id;
+
+    await expect.poll(() => databaseJSON<boolean>(`
+      SELECT (COUNT(*) > 0 AND COUNT(*) FILTER (WHERE status IN ('queued','thinking','running','streaming','waiting_input','waiting_approval')) = 0)::text
+      FROM agent_runs WHERE agent_id = '${agentID}'
+    `), { timeout: 180_000, intervals: [500, 1000, 2000] }).toBe(true);
+
+    const content = `HUMAN_RELIABLE_TRIGGER_${suffix}`;
+    const clientMsgID = crypto.randomUUID();
+    const duplicateResponses = await Promise.all([1, 2].map(() => request.post(
+      `${apiBase}/api/v1/channels/${channelID}/messages`,
+      { headers, data: { content, client_msg_id: clientMsgID } },
+    )));
+    const duplicateBodies = await Promise.all(duplicateResponses.map((response) => response.json() as Promise<SendResponse>));
+    const triggerMessageID = duplicateBodies[0].id;
+    expect(new Set(duplicateBodies.map((body) => body.id)).size).toBe(1);
+
+    await expect.poll(() => databaseJSON<{ runs: number; visible_replies: number }>(`
+      SELECT json_build_object(
+        'runs', (SELECT COUNT(*) FROM agent_runs WHERE trigger_message_id = '${triggerMessageID}'),
+        'visible_replies', (SELECT COUNT(*) FROM messages WHERE channel_id = '${channelID}' AND sender_id = '${agentID}' AND content = '${acknowledgement}')
+      )::text
+    `), { timeout: 180_000, intervals: [500, 1000, 2000] }).toEqual({ runs: 1, visible_replies: 1 });
+
+    await page.addInitScript(({ accessToken, refreshToken }) => {
+      localStorage.setItem('access_token', accessToken);
+      localStorage.setItem('refresh_token', refreshToken);
+      localStorage.setItem('solo.locale', 'en');
+    }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+    await page.goto(`/dashboard?channel=${channelID}`);
+    await expect(page.getByLabel('Message list').getByText(acknowledgement, { exact: true })).toHaveCount(1);
+  } finally {
+    if (agentID) await request.delete(`${apiBase}/api/v1/agents/${agentID}`, { headers }).catch(() => undefined);
+    if (channelID) await request.delete(`${apiBase}/api/v1/channels/${channelID}`, { headers }).catch(() => undefined);
+  }
+});

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -117,10 +117,11 @@ export class ApiClient {
     return this.requestText(url, { method: 'GET' });
   }
 
-  async post<T>(path: string, body?: unknown): Promise<T> {
+  async post<T>(path: string, body?: unknown, options?: Pick<RequestInit, 'signal'>): Promise<T> {
     return this.request<T>(path, {
       method: 'POST',
       body: body !== undefined ? JSON.stringify(body) : undefined,
+      ...options,
     });
   }
 

--- a/frontend/lib/auth-context.tsx
+++ b/frontend/lib/auth-context.tsx
@@ -20,6 +20,7 @@ import {
   type ReactNode,
 } from 'react';
 import { ApiError, apiClient, defaultTokenStorage, setAuthTokens, clearAuthTokens } from './api-client';
+import { cancelAllReliableSends } from './reliable-send';
 
 // ---- 类型定义 ----
 
@@ -208,6 +209,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     } catch {
       // 即使登出 API 失败，也清除本地 token
     }
+    cancelAllReliableSends();
     clearAuthTokens();
     dispatch({ type: 'LOGOUT' });
   }, []);

--- a/frontend/lib/hooks/use-dm.ts
+++ b/frontend/lib/hooks/use-dm.ts
@@ -14,6 +14,14 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { apiClient, ApiError } from '@/lib/api-client';
 import { useAuth } from '@/lib/auth-context';
 import { useWebSocket } from '@/lib/ws-context';
+import {
+  acknowledgeReliableSend,
+  cancelReliableSend,
+  createClientMessageID,
+  postMessageWithTimeout,
+  retryReliableSend,
+  sendReliably,
+} from '@/lib/reliable-send';
 import type { Attachment, DMChannel, Message, CreateDMInput } from '@/lib/types';
 
 // ---- Constants ----
@@ -38,6 +46,7 @@ interface DMChannelResponse {
 
 interface DMMessageResponse {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   sender_type: string;
   sender_id: string;
@@ -92,6 +101,7 @@ function mapDMChannel(resp: DMChannelResponse): DMChannel {
 function mapDMMessageResponse(resp: DMMessageResponse): Message {
   return {
     id: resp.id,
+    client_msg_id: resp.client_msg_id,
     channel_id: resp.channel_id,
     user_id: resp.sender_id,
     display_name: resp.sender_name || resp.sender_id,
@@ -114,6 +124,7 @@ function mapDMMessageResponse(resp: DMMessageResponse): Message {
 /** Convert a flattened WS DM message event to a Message */
 function flatDMToMessage(event: {
   id: string;
+  client_msg_id?: string;
   dm_id: string;
   sender_type: string;
   sender_id: string;
@@ -130,6 +141,7 @@ function flatDMToMessage(event: {
 }): Message {
   return {
     id: event.id,
+    client_msg_id: event.client_msg_id,
     channel_id: event.dm_id,
     user_id: event.sender_id,
     display_name: event.sender_name || event.sender_id,
@@ -150,6 +162,7 @@ function flatDMToMessage(event: {
 /** Convert a message.new WS event to a Message (channel_id IS the DM ID) */
 function flatToMessage(event: {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   sender_type: string;
   sender_id: string;
@@ -167,6 +180,7 @@ function flatToMessage(event: {
 }): Message {
   return {
     id: event.id,
+    client_msg_id: event.client_msg_id,
     channel_id: event.channel_id,
     user_id: event.sender_id,
     display_name: event.sender_name || event.sender_id,
@@ -226,8 +240,8 @@ export function useDM(dmId: string | null = null) {
       const currentMsgs = messagesRef.current;
       if (currentMsgs.length === 0) return;
 
-      const lastMsg = currentMsgs[currentMsgs.length - 1];
-      if (lastMsg.id && !lastMsg.id.startsWith('dm-temp-')) {
+      const lastMsg = [...currentMsgs].reverse().find((message) => message.status === 'sent');
+      if (lastMsg?.id) {
         apiClient
           .get<DMMessageListResponse>(`/api/v1/dm/${did}/messages`, {
             limit: '50',
@@ -348,10 +362,16 @@ export function useDM(dmId: string | null = null) {
       if (event.type === 'message.new') {
         if (event.channel_id !== did) return;
         if (event.thread_id) return; // thread messages handled by thread hook
+        const wsMessage = flatToMessage(event);
+        if (event.client_msg_id && acknowledgeReliableSend(event.client_msg_id, {
+          message: wsMessage,
+          id: event.id,
+          task_number: event.task_number,
+        })) return;
 
         setMessages((prev) => {
           const existing = prev.find((m) => m.id === event.id);
-          const newMsg = flatToMessage(event);
+          const newMsg = wsMessage;
 
           if (existing) {
             if (existing.status === 'streaming') {
@@ -369,7 +389,7 @@ export function useDM(dmId: string | null = null) {
           }
 
           // Clean up orphaned temp/sending messages
-          const cleaned = prev.filter(
+          const cleaned = event.client_msg_id ? prev : prev.filter(
             (m) =>
               !(
                 (m.id.startsWith('dm-temp-') || m.status === 'sending') &&
@@ -386,12 +406,18 @@ export function useDM(dmId: string | null = null) {
       if (event.type === 'dm.message.new') {
         if (event.dm_id !== did) return;
         if (event.thread_id) return; // thread replies handled by thread hook
+        const wsMessage = flatDMToMessage(event);
+        if (event.client_msg_id && acknowledgeReliableSend(event.client_msg_id, {
+          message: wsMessage,
+          id: event.id,
+          task_number: event.task_number,
+        })) return;
 
         setMessages((prev) => {
           const existing = prev.find((m) => m.id === event.id);
           if (existing) {
             if (existing.status === 'streaming') {
-              const newMsg = flatDMToMessage(event);
+              const newMsg = wsMessage;
               return prev.map((m) =>
                 m.id === event.id
                   ? { ...m, ...newMsg, status: 'sent' as const }
@@ -400,7 +426,7 @@ export function useDM(dmId: string | null = null) {
             }
             return prev;
           }
-          return [...prev, flatDMToMessage(event)];
+          return [...prev, wsMessage];
         });
       }
 
@@ -624,9 +650,10 @@ export function useDM(dmId: string | null = null) {
       const hasAttachments = Boolean(attachmentIds && attachmentIds.length > 0);
       if (!id || (!trimmedContent && !hasAttachments) || (asTask && !trimmedContent)) return null;
 
-      const tempId = `dm-temp-${Date.now()}`;
+      const clientMsgID = createClientMessageID();
       const optimisticMessage: Message = {
-        id: tempId,
+        id: clientMsgID,
+        client_msg_id: clientMsgID,
         channel_id: id,
         user_id: user?.id ?? '',
         display_name: user?.display_name ?? 'You',
@@ -638,89 +665,74 @@ export function useDM(dmId: string | null = null) {
 
       setMessages((prev) => [...prev, optimisticMessage]);
 
-      try {
-        const body: Record<string, unknown> = { content: trimmedContent };
-        if (_mentionedAgentIds && _mentionedAgentIds.length > 0) {
-          body.mentioned_agent_ids = _mentionedAgentIds;
-        }
-        if (asTask) {
-          body.as_task = true;
-        }
-        if (attachmentIds && attachmentIds.length > 0) {
-          body.attachment_ids = attachmentIds;
-        }
-        const confirmed = await apiClient.post<DMMessageResponse & { task_number?: number; message_id?: string }>(
-          `/api/v1/dm/${id}/messages`,
-          body,
-        );
-
-        const isTaskResponse = asTask && (confirmed as unknown as Record<string, unknown>).message_id !== undefined;
-        const realMessageId = isTaskResponse
-          ? (confirmed as unknown as Record<string, unknown>).message_id as string
-          : confirmed.id;
-
-        setMessages((prev) => {
-          if (isTaskResponse) {
-            const taskResp = confirmed as unknown as Record<string, unknown>;
-            const creatorName = (taskResp.creator_name as string) || undefined;
-            return prev.map((m) => {
-              if (m.id === tempId) {
-                return {
-                  ...m,
-                  id: realMessageId,
-                  status: 'sent' as const,
-                  ...(creatorName && { display_name: creatorName }),
-                  task_number: taskResp.task_number as number | undefined,
-                  task_status: taskResp.status as string | undefined,
-                  task_claimer_name: taskResp.claimer_name as string | undefined,
-                  task_claimer_deleted: taskResp.claimer_deleted as boolean | undefined,
-                };
-              }
-              if (m.id === realMessageId) {
-                return {
-                  ...m,
-                  task_number: taskResp.task_number as number | undefined,
-                  task_status: taskResp.status as string | undefined,
-                  task_claimer_name: taskResp.claimer_name as string | undefined,
-                  task_claimer_deleted: taskResp.claimer_deleted as boolean | undefined,
-                };
-              }
-              return m;
-            });
-          }
-          // Non-asTask: replace temp message and any WS duplicate
-          const confirmedMessage: Message = { ...mapDMMessageResponse(confirmed), status: 'sent' as const };
-          const skipIds = new Set([tempId, confirmed.id]);
-          let hasConfirmed = false;
-          const result: Message[] = [];
-          for (const m of prev) {
-            if (skipIds.has(m.id)) {
-              if (!hasConfirmed) {
-                result.push(confirmedMessage);
-                hasConfirmed = true;
-              }
-            } else {
-              result.push(m);
-            }
-          }
-          if (!hasConfirmed) {
-            result.push(confirmedMessage);
-          }
-          return result;
-        });
-
-        return {
-          id: realMessageId,
-          task_number: (confirmed as unknown as Record<string, unknown>).task_number as number | undefined,
-        };
-      } catch {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === tempId ? { ...m, status: 'failed' as const } : m,
-          ),
-        );
-        return null;
+      const body: Record<string, unknown> = {
+        content: trimmedContent,
+        client_msg_id: clientMsgID,
+      };
+      if (_mentionedAgentIds && _mentionedAgentIds.length > 0) {
+        body.mentioned_agent_ids = _mentionedAgentIds;
       }
+      if (asTask) body.as_task = true;
+      if (attachmentIds && attachmentIds.length > 0) {
+        body.attachment_ids = attachmentIds;
+      }
+
+      const confirmation = await sendReliably(clientMsgID, {
+        request: async () => {
+          const confirmed = await postMessageWithTimeout<DMMessageResponse & { task_number?: number; message_id?: string }>(
+            `/api/v1/dm/${id}/messages`,
+            body,
+          );
+          const task = confirmed as unknown as Record<string, unknown>;
+          const isTaskResponse = asTask && task.message_id !== undefined;
+          const messageID = isTaskResponse ? task.message_id as string : confirmed.id;
+          const message = isTaskResponse
+            ? {
+                ...optimisticMessage,
+                id: messageID,
+                status: 'sent' as const,
+                display_name: task.creator_name as string || optimisticMessage.display_name,
+                task_number: task.task_number as number | undefined,
+                task_status: task.status as string | undefined,
+                task_claimer_name: task.claimer_name as string | undefined,
+                task_claimer_deleted: task.claimer_deleted as boolean | undefined,
+              }
+            : mapDMMessageResponse(confirmed);
+          return { message, id: messageID, task_number: task.task_number as number | undefined };
+        },
+        onConfirmed: (confirmed) => {
+          if (dmIdRef.current !== id) return;
+          setMessages((prev) => {
+            const result: Message[] = [];
+            let replaced = false;
+            for (const message of prev) {
+              if (message.id === clientMsgID || message.id === confirmed.id) {
+                if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+                replaced = true;
+              } else {
+                result.push(message);
+              }
+            }
+            if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+            return result;
+          });
+        },
+        onFailed: () => {
+          if (dmIdRef.current !== id) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'failed' as const } : message,
+          ));
+        },
+        onRetrying: () => {
+          if (dmIdRef.current !== id) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'sending' as const } : message,
+          ));
+        },
+      });
+      return confirmation
+        ? { id: confirmation.id, task_number: confirmation.task_number }
+        : null;
     },
     [user],
   );
@@ -729,32 +741,8 @@ export function useDM(dmId: string | null = null) {
 
   const retryMessage = useCallback(
     async (messageId: string, content: string) => {
-      const id = dmIdRef.current;
-      if (!id) return;
-
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === messageId ? { ...m, status: 'sending' as const } : m,
-        ),
-      );
-
-      try {
-        const confirmed = await apiClient.post<DMMessageResponse>(
-          `/api/v1/dm/${id}/messages`,
-          { content },
-        );
-
-        setMessages((prev) => {
-          const filtered = prev.filter((m) => m.id !== messageId && m.id !== confirmed.id);
-          return [...filtered, { ...mapDMMessageResponse(confirmed), status: 'sent' as const }];
-        });
-      } catch {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === messageId ? { ...m, status: 'failed' as const } : m,
-          ),
-        );
-      }
+      void content;
+      retryReliableSend(messageId);
     },
     [],
   );
@@ -767,6 +755,7 @@ export function useDM(dmId: string | null = null) {
 
   /** Cancel (remove from list) a failed or sending message */
   const cancelMessage = useCallback((messageId: string) => {
+    cancelReliableSend(messageId);
     setMessages((prev) => prev.filter((m) => m.id !== messageId));
   }, []);
 

--- a/frontend/lib/hooks/use-messages.ts
+++ b/frontend/lib/hooks/use-messages.ts
@@ -13,6 +13,14 @@ import { apiClient, ApiError } from '@/lib/api-client';
 import { useWebSocket } from '@/lib/ws-context';
 import { useAuth } from '@/lib/auth-context';
 import { t } from '@/lib/i18n';
+import {
+  acknowledgeReliableSend,
+  cancelReliableSend,
+  createClientMessageID,
+  postMessageWithTimeout,
+  retryReliableSend,
+  sendReliably,
+} from '@/lib/reliable-send';
 import type { Attachment, Message } from '@/lib/types';
 
 // ---- Constants ----
@@ -23,6 +31,7 @@ const PAGE_SIZE = 50;
 
 interface MessageResponse {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   sender_type: string;
   sender_id: string;
@@ -56,6 +65,7 @@ interface MessageListResponse {
 function mapMessageResponse(resp: MessageResponse): Message {
   return {
     id: resp.id,
+    client_msg_id: resp.client_msg_id,
     channel_id: resp.channel_id,
     user_id: resp.sender_id,
     display_name: resp.sender_name || resp.sender_id,
@@ -83,6 +93,7 @@ function mapMessageResponse(resp: MessageResponse): Message {
 /** Convert a flattened WS message event to a Message */
 function flatToMessage(event: {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   sender_type: string;
   sender_id: string;
@@ -105,6 +116,7 @@ function flatToMessage(event: {
 }): Message {
   return {
     id: event.id,
+    client_msg_id: event.client_msg_id,
     channel_id: event.channel_id,
     user_id: event.sender_id,
     display_name: event.sender_name || event.sender_id,
@@ -181,8 +193,8 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
 
       // Use the most recent message ID as the "after" cursor
       // to fetch messages that arrived during disconnection
-      const lastMsg = currentMsgs[currentMsgs.length - 1];
-      if (lastMsg.id && !lastMsg.id.startsWith('temp-')) {
+      const lastMsg = [...currentMsgs].reverse().find((message) => message.status === 'sent');
+      if (lastMsg?.id) {
         apiClient
           .get<MessageListResponse>(`/api/v1/channels/${cid}/messages`, {
             limit: '50',
@@ -235,10 +247,16 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
         if (event.channel_id !== cid) return;
         if (event.thread_id) return;
         if ((event.thinking_node_id ?? null) !== thinkingNodeIdRef.current) return;
+        const wsMessage = flatToMessage(event);
+        if (event.client_msg_id && acknowledgeReliableSend(event.client_msg_id, {
+          message: wsMessage,
+          id: event.id,
+          task_number: event.task_number,
+        })) return;
 
         setMessages((prev) => {
           const existing = prev.find((m) => m.id === event.id);
-          const newMsg = flatToMessage(event);
+          const newMsg = wsMessage;
 
           if (existing) {
             // Merge WS data into existing message. WS is authoritative
@@ -263,7 +281,7 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
           // New message — clean up any orphaned temp/sending messages
           // that might be optimistic duplicates of this real message.
           // Only remove temp messages whose content matches (best-effort dedup).
-          const cleaned = prev.filter(
+          const cleaned = event.client_msg_id ? prev : prev.filter(
             (m) =>
               !(
                 (m.id.startsWith('temp-') || m.status === 'sending') &&
@@ -513,9 +531,10 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
       const hasAttachments = Boolean(attachmentIds && attachmentIds.length > 0);
       if (!id || (!trimmedContent && !hasAttachments) || (asTask && !trimmedContent)) return null;
 
-      const tempId = `temp-${Date.now()}`;
+      const clientMsgID = createClientMessageID();
       const optimisticMessage: Message = {
-        id: tempId,
+        id: clientMsgID,
+        client_msg_id: clientMsgID,
         channel_id: id,
         user_id: user?.id || 'local-user',
         display_name: user?.display_name || 'You',
@@ -529,110 +548,74 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
 
       setMessages((prev) => [...prev, optimisticMessage]);
 
-      try {
-        const body: Record<string, unknown> = { content: trimmedContent };
-        if (nodeID) {
-          body.thinking_node_id = nodeID;
-        }
-        if (mentionedAgentIds && mentionedAgentIds.length > 0) {
-          body.mentioned_agent_ids = mentionedAgentIds;
-        }
-        if (asTask) {
-          body.as_task = true;
-        }
-        if (attachmentIds && attachmentIds.length > 0) {
-          body.attachment_ids = attachmentIds;
-        }
-        const confirmed = await apiClient.post<MessageResponse & { task_number?: number; message_id?: string }>(
-          `/api/v1/channels/${id}/messages`,
-          body,
-        );
-
-        // asTask responses return a TaskResponse shape (id=task UUID, message_id=message UUID)
-        // instead of MessageResponse (id=message UUID, sender_name, content, etc.).
-        // Detect by checking for the message_id field.
-        const isTaskResponse = asTask && (confirmed as unknown as Record<string, unknown>).message_id !== undefined;
-        const realMessageId = isTaskResponse
-          ? (confirmed as unknown as Record<string, unknown>).message_id as string
-          : confirmed.id;
-
-        if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) {
-          return {
-            id: realMessageId,
-            task_number: (confirmed as unknown as Record<string, unknown>).task_number as number | undefined,
-          };
-        }
-
-        setMessages((prev) => {
-          if (isTaskResponse) {
-            // Map the optimistic temp message to the real message ID from the TaskResponse.
-            // Preserve the optimistic fields (display_name, content) — the WS message.new
-            // broadcast will handle final dedup and enrichment.
-            const taskResp = confirmed as unknown as Record<string, unknown>;
-            return prev.map((m) => {
-              if (m.id === tempId) {
-                return {
-                  ...m,
-                  id: realMessageId,
-                  status: 'sent' as const,
-                  task_number: taskResp.task_number as number | undefined,
-                  task_status: taskResp.status as string | undefined,
-                  task_claimer_name: taskResp.claimer_name as string | undefined,
-                  task_claimer_deleted: taskResp.claimer_deleted as boolean | undefined,
-                };
-              }
-              // If WS message.new already arrived with the real message ID,
-              // update its task fields in place.
-              if (m.id === realMessageId) {
-                return {
-                  ...m,
-                  task_number: taskResp.task_number as number | undefined,
-                  task_status: taskResp.status as string | undefined,
-                  task_claimer_name: taskResp.claimer_name as string | undefined,
-                  task_claimer_deleted: taskResp.claimer_deleted as boolean | undefined,
-                };
-              }
-              return m;
-            });
-          }
-          // Non-asTask: replace temp message (and any WS duplicate) with the confirmed response.
-          // Use reduce to guarantee exactly one confirmed message in the output,
-          // regardless of whether 0, 1, or 2 matching messages existed in prev.
-          const confirmedMessage: Message = { ...mapMessageResponse(confirmed), status: 'sent' as const };
-          const skipIds = new Set([tempId, confirmed.id]);
-          let hasConfirmed = false;
-          const result: Message[] = [];
-          for (const m of prev) {
-            if (skipIds.has(m.id)) {
-              if (!hasConfirmed) {
-                result.push(confirmedMessage);
-                hasConfirmed = true;
-              }
-              // else: duplicate — skip it
-            } else {
-              result.push(m);
-            }
-          }
-          // Edge case: neither temp nor WS-dup was in prev (shouldn't happen but safe)
-          if (!hasConfirmed) {
-            result.push(confirmedMessage);
-          }
-          return result;
-        });
-
-        return {
-          id: realMessageId,
-          task_number: (confirmed as unknown as Record<string, unknown>).task_number as number | undefined,
-        };
-      } catch {
-        if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return null;
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === tempId ? { ...m, status: 'failed' as const } : m,
-          ),
-        );
-        return null;
+      const body: Record<string, unknown> = {
+        content: trimmedContent,
+        client_msg_id: clientMsgID,
+      };
+      if (nodeID) body.thinking_node_id = nodeID;
+      if (mentionedAgentIds && mentionedAgentIds.length > 0) {
+        body.mentioned_agent_ids = mentionedAgentIds;
       }
+      if (asTask) body.as_task = true;
+      if (attachmentIds && attachmentIds.length > 0) {
+        body.attachment_ids = attachmentIds;
+      }
+
+      const confirmation = await sendReliably(clientMsgID, {
+        request: async () => {
+          const confirmed = await postMessageWithTimeout<MessageResponse & { task_number?: number; message_id?: string }>(
+            `/api/v1/channels/${id}/messages`,
+            body,
+          );
+          const task = confirmed as unknown as Record<string, unknown>;
+          const isTaskResponse = asTask && task.message_id !== undefined;
+          const messageID = isTaskResponse ? task.message_id as string : confirmed.id;
+          const message = isTaskResponse
+            ? {
+                ...optimisticMessage,
+                id: messageID,
+                status: 'sent' as const,
+                task_number: task.task_number as number | undefined,
+                task_status: task.status as string | undefined,
+                task_claimer_name: task.claimer_name as string | undefined,
+                task_claimer_deleted: task.claimer_deleted as boolean | undefined,
+              }
+            : mapMessageResponse(confirmed);
+          return { message, id: messageID, task_number: task.task_number as number | undefined };
+        },
+        onConfirmed: (confirmed) => {
+          if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return;
+          setMessages((prev) => {
+            const result: Message[] = [];
+            let replaced = false;
+            for (const message of prev) {
+              if (message.id === clientMsgID || message.id === confirmed.id) {
+                if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+                replaced = true;
+              } else {
+                result.push(message);
+              }
+            }
+            if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+            return result;
+          });
+        },
+        onFailed: () => {
+          if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'failed' as const } : message,
+          ));
+        },
+        onRetrying: () => {
+          if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'sending' as const } : message,
+          ));
+        },
+      });
+      return confirmation
+        ? { id: confirmation.id, task_number: confirmation.task_number }
+        : null;
     },
     [user],
   );
@@ -641,39 +624,8 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
 
   const retryMessage = useCallback(
     async (messageId: string, content: string) => {
-      const id = channelRef.current;
-      const nodeID = thinkingNodeIdRef.current;
-      if (!id) return;
-
-      setMessages((prev) =>
-        prev.map((m) =>
-          m.id === messageId ? { ...m, status: 'sending' as const } : m,
-        ),
-      );
-
-      try {
-        const confirmed = await apiClient.post<MessageResponse>(
-          `/api/v1/channels/${id}/messages`,
-          {
-            content,
-            ...(nodeID ? { thinking_node_id: nodeID } : {}),
-          },
-        );
-
-        if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return;
-
-        setMessages((prev) => {
-          const filtered = prev.filter((m) => m.id !== messageId && m.id !== confirmed.id);
-          return [...filtered, { ...mapMessageResponse(confirmed), status: 'sent' as const }];
-        });
-      } catch {
-        if (channelRef.current !== id || thinkingNodeIdRef.current !== nodeID) return;
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === messageId ? { ...m, status: 'failed' as const } : m,
-          ),
-        );
-      }
+      void content;
+      retryReliableSend(messageId);
     },
     [],
   );
@@ -686,6 +638,7 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
 
   /** Cancel (remove from list) a failed or sending message */
   const cancelMessage = useCallback((messageId: string) => {
+    cancelReliableSend(messageId);
     setMessages((prev) => prev.filter((m) => m.id !== messageId));
   }, []);
 

--- a/frontend/lib/hooks/use-thread.ts
+++ b/frontend/lib/hooks/use-thread.ts
@@ -13,6 +13,12 @@ import { apiClient } from '@/lib/api-client';
 import { useWebSocket } from '@/lib/ws-context';
 import { useAuth } from '@/lib/auth-context';
 import { t } from '@/lib/i18n';
+import {
+  acknowledgeReliableSend,
+  createClientMessageID,
+  postMessageWithTimeout,
+  sendReliably,
+} from '@/lib/reliable-send';
 import type { Attachment } from '@/lib/types';
 import type { WSMessage, WSMessageSource } from '@/lib/ws-types';
 
@@ -20,6 +26,7 @@ import type { WSMessage, WSMessageSource } from '@/lib/ws-types';
 
 interface ThreadReplyResponse {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   thread_id: string;
   sender_type: string;
@@ -44,6 +51,7 @@ interface ThreadMessageListResponse {
 function toWSMessage(r: ThreadReplyResponse): WSMessage {
   return {
     id: r.id,
+    client_msg_id: r.client_msg_id,
     channel_id: r.channel_id,
     sender_type: r.sender_type as WSMessageSource,
     sender_id: r.sender_id,
@@ -148,10 +156,9 @@ export function useThread(): UseThreadReturn {
   useEffect(() => {
     const unsub = onEvent((event) => {
       const tid = threadIdRef.current;
-      if (!tid) return;
 
       // Streaming tokens from agent in thread (P25-10-F)
-      if (event.type === 'message.agent_typing' && event.thread_id === tid) {
+      if (tid && event.type === 'message.agent_typing' && event.thread_id === tid) {
         setMessages((prev) => {
           const existing = prev.find((m) => m.id === event.id);
           if (existing) {
@@ -182,30 +189,31 @@ export function useThread(): UseThreadReturn {
         return;
       }
 
-      if (event.type === 'thread.message.new' && event.thread.thread_id === tid) {
+      if (event.type === 'thread.message.new') {
+        const newMsg: WSMessage = {
+          id: event.message.id,
+          client_msg_id: event.message.client_msg_id,
+          channel_id: event.message.channel_id,
+          sender_type: event.message.sender_type as WSMessageSource,
+          sender_id: event.message.sender_id,
+          sender_name: event.message.sender_name,
+          sender_avatar: event.message.sender_avatar,
+          display_name: event.message.sender_name,
+          content: event.message.content,
+          content_type: event.message.content_type,
+          thread_parent_id: event.message.thread_id,
+          attachments: event.message.attachments,
+          created_at: event.message.created_at,
+        };
+        if (event.message.client_msg_id && acknowledgeReliableSend(event.message.client_msg_id, {
+          message: newMsg,
+          thread_id: event.message.thread_id,
+        })) return;
+        if (!tid || event.thread.thread_id !== tid) return;
         // Replace streaming placeholder if one exists, otherwise append
         setMessages((prev) => {
-          // Skip WS if the user has a pending send — API response will handle it.
-          // Otherwise WS and API race and the same message appears twice.
-          if (event.message.sender_type === 'user' && prev.some((m) => m.status === 'sending' && m.sender_type === 'user')) {
-            return prev;
-          }
           const hasStreaming = prev.some((m) => m.id === event.message.id && m.status === 'streaming');
           const exists = prev.some((m) => m.id === event.message.id);
-          const newMsg = {
-            id: event.message.id,
-            channel_id: event.message.channel_id,
-            sender_type: event.message.sender_type as WSMessageSource,
-            sender_id: event.message.sender_id,
-            sender_name: event.message.sender_name,
-            sender_avatar: event.message.sender_avatar,
-            display_name: event.message.sender_name,
-            content: event.message.content,
-            content_type: event.message.content_type,
-            thread_parent_id: event.message.thread_id,
-            attachments: event.message.attachments,
-            created_at: event.message.created_at,
-          };
           const result = prev.map((m) =>
             m.id === event.message.id ? newMsg : m,
           );
@@ -227,9 +235,10 @@ export function useThread(): UseThreadReturn {
       const mid = messageIdRef.current;
       if (!cid || !mid || !content.trim()) return;
 
-      const tempId = `thread-temp-${Date.now()}`;
+      const clientMsgID = createClientMessageID();
       const optimistic: WSMessage = {
-        id: tempId,
+        id: clientMsgID,
+        client_msg_id: clientMsgID,
         channel_id: cid,
         sender_type: 'user',
         sender_id: user?.id || 'local-user',
@@ -243,28 +252,49 @@ export function useThread(): UseThreadReturn {
 
       setMessages((prev) => [...prev, optimistic]);
 
-      try {
-        const res = await apiClient.post<ThreadReplyResponse>(
-          `/api/v1/channels/${cid}/messages/${mid}/thread`,
-          { content: content.trim(), mentioned_agent_ids: mentionedAgentIds || [] },
-        );
-
-        const confirmed = { ...toWSMessage(res), status: 'sent' as const };
-        setMessages((prev) =>
-          prev.map((m) => (m.id === tempId ? confirmed : m)),
-        );
-
-        // 如果这是第一条回复，thread_id 刚刚创建，更新并订阅
-        if (res.thread_id && !threadIdRef.current) {
-          setThreadId(res.thread_id);
-        }
-      } catch {
-        setMessages((prev) =>
-          prev.map((m) =>
-            m.id === tempId ? { ...m, status: 'failed' as const } : m,
-          ),
-        );
-      }
+      await sendReliably(clientMsgID, {
+        request: async () => {
+          const response = await postMessageWithTimeout<ThreadReplyResponse>(
+            `/api/v1/channels/${cid}/messages/${mid}/thread`,
+            {
+              content: content.trim(),
+              mentioned_agent_ids: mentionedAgentIds || [],
+              client_msg_id: clientMsgID,
+            },
+          );
+          return { message: toWSMessage(response), thread_id: response.thread_id };
+        },
+        onConfirmed: (confirmed) => {
+          if (channelIdRef.current !== cid || messageIdRef.current !== mid) return;
+          setMessages((prev) => {
+            const result: WSMessage[] = [];
+            let replaced = false;
+            for (const message of prev) {
+              if (message.id === clientMsgID || message.id === confirmed.message.id) {
+                if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+                replaced = true;
+              } else {
+                result.push(message);
+              }
+            }
+            if (!replaced) result.push({ ...confirmed.message, status: 'sent' as const });
+            return result;
+          });
+          if (confirmed.thread_id && !threadIdRef.current) setThreadId(confirmed.thread_id);
+        },
+        onFailed: () => {
+          if (channelIdRef.current !== cid || messageIdRef.current !== mid) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'failed' as const } : message,
+          ));
+        },
+        onRetrying: () => {
+          if (channelIdRef.current !== cid || messageIdRef.current !== mid) return;
+          setMessages((prev) => prev.map((message) =>
+            message.id === clientMsgID ? { ...message, status: 'sending' as const } : message,
+          ));
+        },
+      });
     },
     [user],
   );

--- a/frontend/lib/reliable-send.ts
+++ b/frontend/lib/reliable-send.ts
@@ -1,0 +1,116 @@
+import { apiClient } from '@/lib/api-client';
+
+type PendingSend<T> = {
+  attempts: number;
+  inFlight: boolean;
+  status: 'pending' | 'failed';
+  timer: ReturnType<typeof setTimeout> | null;
+  request: () => Promise<T>;
+  onConfirmed: (result: T) => void;
+  onFailed: () => void;
+  onRetrying: () => void;
+  resolve: (result: T | null) => void;
+};
+
+const pendingSends = new Map<string, PendingSend<unknown>>();
+
+export function createClientMessageID(): string {
+  return typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `cm-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export async function postMessageWithTimeout<T>(path: string, body: unknown): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    return await apiClient.post<T>(path, body, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function sendReliably<T>(
+  clientMessageID: string,
+  handlers: Omit<PendingSend<T>, 'attempts' | 'inFlight' | 'status' | 'timer' | 'resolve'>,
+): Promise<T | null> {
+  return new Promise((resolve) => {
+    pendingSends.set(clientMessageID, {
+      ...handlers,
+      attempts: 0,
+      inFlight: false,
+      status: 'pending',
+      timer: null,
+      resolve,
+    } as PendingSend<unknown>);
+    void runSend(clientMessageID);
+  });
+}
+
+export function acknowledgeReliableSend<T>(clientMessageID: string, result: T): boolean {
+  const pending = pendingSends.get(clientMessageID) as PendingSend<T> | undefined;
+  if (!pending) return false;
+
+  pendingSends.delete(clientMessageID);
+  if (pending.timer) clearTimeout(pending.timer);
+  try {
+    pending.onConfirmed(result);
+  } finally {
+    pending.resolve(result);
+  }
+  return true;
+}
+
+export function retryReliableSend(clientMessageID: string): void {
+  const pending = pendingSends.get(clientMessageID);
+  if (!pending || pending.inFlight) return;
+  if (pending.timer) {
+    clearTimeout(pending.timer);
+    pending.timer = null;
+  }
+  void runSend(clientMessageID);
+}
+
+export function cancelReliableSend(clientMessageID: string): void {
+  const pending = pendingSends.get(clientMessageID);
+  if (!pending) return;
+  pendingSends.delete(clientMessageID);
+  if (pending.timer) clearTimeout(pending.timer);
+  pending.resolve(null);
+}
+
+export function cancelAllReliableSends(): void {
+  for (const clientMessageID of [...pendingSends.keys()]) {
+    cancelReliableSend(clientMessageID);
+  }
+}
+
+export function retryFailedReliableSends(): void {
+  for (const [clientMessageID, pending] of pendingSends) {
+    if (pending.status === 'failed') retryReliableSend(clientMessageID);
+  }
+}
+
+async function runSend(clientMessageID: string): Promise<void> {
+  const pending = pendingSends.get(clientMessageID);
+  if (!pending || pending.inFlight) return;
+
+  pending.inFlight = true;
+  pending.status = 'pending';
+  pending.attempts += 1;
+  pending.onRetrying();
+  try {
+    const result = await pending.request();
+    acknowledgeReliableSend(clientMessageID, result);
+  } catch {
+    const current = pendingSends.get(clientMessageID);
+    if (current !== pending) return;
+    pending.inFlight = false;
+    pending.status = 'failed';
+    pending.onFailed();
+    if (pending.attempts < 3) {
+      const delay = pending.attempts === 1 ? 3_000 : 2_000 * pending.attempts;
+      pending.timer = setTimeout(() => retryReliableSend(clientMessageID), delay);
+    }
+  }
+}

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -26,6 +26,7 @@ export interface Channel {
 
 export interface Message {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   user_id: string;
   display_name: string;

--- a/frontend/lib/ws-client.ts
+++ b/frontend/lib/ws-client.ts
@@ -158,6 +158,14 @@ export class WSClient {
     this.setState('disconnected');
   }
 
+  forceReconnect(): void {
+    this.intentionalClose = false;
+    this.cancelReconnect();
+    this.cleanupSocket();
+    this.setState('disconnected');
+    this.connect();
+  }
+
   /** 订阅频道（未连接时自动触发连接） */
   subscribe(channelId: string): void {
     this.subscribedChannels.add(channelId);

--- a/frontend/lib/ws-context.tsx
+++ b/frontend/lib/ws-context.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react';
 import { defaultTokenStorage } from './api-client';
 import { WSClient, type WSClientConfig } from './ws-client';
+import { retryFailedReliableSends } from './reliable-send';
 import type {
   ConnectionState,
   WSMessage,
@@ -41,6 +42,7 @@ export interface WSContextValue {
   connect: () => void;
   /** 手动断开连接 */
   disconnect: () => void;
+  forceReconnect: () => void;
   /** 订阅频道 */
   subscribe: (channelId: string) => void;
   /** 取消订阅频道 */
@@ -116,6 +118,7 @@ export function WSProvider({
         if (event.type === 'message.new') {
           setLastMessage({
             id: event.id,
+            client_msg_id: event.client_msg_id,
             channel_id: event.channel_id,
             sender_type: event.sender_type as WSMessage['sender_type'],
             sender_id: event.sender_id,
@@ -156,6 +159,32 @@ export function WSProvider({
   const disconnect = useCallback(() => {
     clientRef.current?.disconnect();
   }, []);
+
+  const forceReconnect = useCallback(() => {
+    clientRef.current?.forceReconnect();
+  }, []);
+
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') retryFailedReliableSends();
+    };
+    const onPageShow = () => {
+      retryFailedReliableSends();
+      forceReconnect();
+    };
+    const onOnline = () => {
+      retryFailedReliableSends();
+      forceReconnect();
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('pageshow', onPageShow);
+    window.addEventListener('online', onOnline);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('pageshow', onPageShow);
+      window.removeEventListener('online', onOnline);
+    };
+  }, [forceReconnect]);
 
   const subscribe = useCallback((channelId: string) => {
     clientRef.current?.subscribe(channelId);
@@ -200,6 +229,7 @@ export function WSProvider({
       lastMessage,
       connect,
       disconnect,
+      forceReconnect,
       subscribe,
       unsubscribe,
       subscribeThread,
@@ -215,6 +245,7 @@ export function WSProvider({
       lastMessage,
       connect,
       disconnect,
+      forceReconnect,
       subscribe,
       unsubscribe,
       subscribeThread,
@@ -237,4 +268,3 @@ export function useWebSocket(): WSContextValue {
   }
   return context;
 }
-

--- a/frontend/lib/ws-types.ts
+++ b/frontend/lib/ws-types.ts
@@ -14,6 +14,7 @@ export type WSMessageSource = 'user' | 'agent' | 'system';
 /** 消息体（用于前端展示和状态管理） */
 export interface WSMessage {
   id: string;
+  client_msg_id?: string;
   channel_id: string;
   sender_type: WSMessageSource;
   sender_id: string;
@@ -49,13 +50,13 @@ export type WSServerEvent =
   | { type: 'connected'; user_id: string }
   | { type: 'error'; code: string; message: string }
   // ---- 消息事件 ----
-  | { type: 'message.new'; id: string; channel_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; metadata?: Record<string, unknown>; thread_id?: string; thinking_node_id?: string; created_at: string; attachments?: Attachment[] }
+  | { type: 'message.new'; id: string; client_msg_id?: string; channel_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; metadata?: Record<string, unknown>; thread_id?: string; thinking_node_id?: string; created_at: string; attachments?: Attachment[]; task_number?: number; task_title?: string; task_status?: string; task_claimer_name?: string; task_claimer_deleted?: boolean; reply_count?: number; has_unread_thread?: boolean }
   | { type: 'message.updated'; id: string; channel_id: string; content: string; sender_type?: string; sender_id?: string; updated_at: string; task_number?: number; task_title?: string; task_status?: string; task_claimer_name?: string; task_claimer_deleted?: boolean; reply_count?: number }
   | { type: 'message.deleted'; channel_id: string; message_id: string }
   | { type: 'thinking.updated'; channel_id: string; space_id?: string; node_id?: string }
   // ---- 线程事件 ----
   // thread.message.new: 后端 ThreadMessageNewPayload 为 {message:{...}, thread:{...}} 嵌套结构
-  | { type: 'thread.message.new'; message: { id: string; channel_id: string; thread_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; created_at: string; attachments?: Attachment[] }; thread: { thread_id: string; reply_count: number; last_reply_at: string } }
+  | { type: 'thread.message.new'; message: { id: string; client_msg_id?: string; channel_id: string; thread_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; created_at: string; attachments?: Attachment[] }; thread: { thread_id: string; reply_count: number; last_reply_at: string } }
   // thread.reply: 后端 ThreadReplyNotifyPayload 包含 latest_reply 子对象
   | { type: 'thread.reply'; channel_id: string; thread_id: string; root_message_id?: string; reply_count: number; last_reply_at: string; latest_reply?: { id: string; sender_id: string; sender_name: string; content: string; created_at: string } }
   // ---- 输入状态 ----
@@ -86,7 +87,7 @@ export type WSServerEvent =
   | { type: 'relationship_deleted'; id: string; from_agent_id: string; to_agent_id: string }
   | { type: 'agent_deleted'; agent_id: string }
   // ---- DM 事件 ----
-  | { type: 'dm.message.new'; id: string; dm_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; created_at: string; attachments?: Attachment[]; thread_id?: string }
+  | { type: 'dm.message.new'; id: string; client_msg_id?: string; dm_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; created_at: string; attachments?: Attachment[]; thread_id?: string; task_number?: number; task_title?: string; task_status?: string; task_claimer_name?: string; task_claimer_deleted?: boolean }
   | { type: 'dm.updated'; dm_id: string; last_message?: { content: string; sender_id: string; sender_name: string; created_at: string }; last_reply_at?: string; unread_count: number }
   // ---- Inbox events (v1.5) ----
   | { type: 'inbox.updated'; }
@@ -101,6 +102,8 @@ export type WSClientCommand =
   | { type: 'thread.unsubscribe'; thread_id: string }
   | { type: 'dm.subscribe'; dm_id: string }
   | { type: 'dm.unsubscribe'; dm_id: string }
+  | { type: 'message.send'; channel_id: string; content: string; attachment_ids?: string[]; client_msg_id?: string }
+  | { type: 'thread.reply'; channel_id: string; thread_id: string; content: string; attachment_ids?: string[]; client_msg_id?: string }
   | { type: 'ping' };
 
 /** WebSocket 连接状态 */

--- a/internal/server/handler/dm.go
+++ b/internal/server/handler/dm.go
@@ -26,16 +26,18 @@ type DMHandler struct {
 	agentSvc   *service.AgentService
 	mentionSvc *service.MentionService
 	taskSvc    *service.TaskService
+	sendDedupe *service.SendDedupe
 }
 
 // NewDMHandler creates a new DMHandler.
-func NewDMHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService, taskSvc *service.TaskService) *DMHandler {
+func NewDMHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService, taskSvc *service.TaskService, sendDedupe *service.SendDedupe) *DMHandler {
 	return &DMHandler{
 		pool:       pool,
 		hub:        hub,
 		agentSvc:   agentSvc,
 		mentionSvc: service.NewMentionService(pool),
 		taskSvc:    taskSvc,
+		sendDedupe: sendDedupe,
 	}
 }
 
@@ -620,6 +622,16 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "message content exceeds maximum length of 10000 characters")
 		return
 	}
+	clientMsgID, validClientMsgID := validateClientMessageID(req.ClientMsgID)
+	if !validClientMsgID {
+		writeError(w, http.StatusBadRequest, "client message ID exceeds maximum length of 128 characters")
+		return
+	}
+	sendClaim, proceed := beginReliableSend(w, r, h.sendDedupe, userID, clientMsgID)
+	if !proceed {
+		return
+	}
+	defer sendClaim.Abort()
 
 	// Verify user is a DM participant
 	var isParticipant bool
@@ -729,9 +741,15 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 
 	// If as_task, convert to task and return task response (align with channel behavior)
 	if req.AsTask && h.taskSvc != nil {
-		// Broadcast message.new first so other DM participants see the message
+		task, convertErr := h.taskSvc.ConvertMessageToTask(r.Context(), dmID, messageID, userID)
+		if convertErr != nil {
+			slog.Error("failed to convert DM message to task", "error", convertErr, "message_id", messageID)
+			writeError(w, http.StatusInternalServerError, "failed to create task")
+			return
+		}
+		taskResp := toTaskResponse(task)
 		if h.hub != nil {
-			msgPayload := ws.Envelope(ws.EventMessageNew, ws.MessageNewPayload{
+			h.hub.BroadcastToChannel(dmID, ws.Envelope(ws.EventMessageNew, ws.MessageNewPayload{
 				ID:            messageID,
 				ChannelID:     dmID,
 				SenderType:    senderType,
@@ -742,18 +760,12 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 				ContentType:   "text",
 				AttachmentIDs: attachmentIDs,
 				Attachments:   toWSAttachmentMeta(attachments),
+				TaskNumber:    task.TaskNumber,
+				TaskStatus:    task.Status,
 				CreatedAt:     now.Format(time.RFC3339),
-			})
-			h.hub.BroadcastToChannel(dmID, msgPayload)
+				ClientMsgID:   clientMsgID,
+			}))
 		}
-
-		task, convertErr := h.taskSvc.ConvertMessageToTask(r.Context(), dmID, messageID, userID)
-		if convertErr != nil {
-			slog.Error("failed to convert DM message to task", "error", convertErr, "message_id", messageID)
-			writeError(w, http.StatusInternalServerError, "failed to create task")
-			return
-		}
-		taskResp := toTaskResponse(task)
 		ws.BroadcastTaskCreated(h.hub, ws.TaskCreatedPayload{
 			ID:               task.ID,
 			TaskNumber:       task.TaskNumber,
@@ -778,7 +790,7 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		if h.agentSvc != nil {
 			go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, nil, nil)
 		}
-		writeJSON(w, http.StatusCreated, TaskResponse{
+		taskResponse := TaskResponse{
 			ID:          taskResp.ID,
 			TaskNumber:  taskResp.TaskNumber,
 			ChannelID:   taskResp.ChannelID,
@@ -794,7 +806,9 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 			MessageID:   taskResp.MessageID,
 			CreatedAt:   taskResp.CreatedAt,
 			UpdatedAt:   taskResp.UpdatedAt,
-		})
+			ClientMsgID: clientMsgID,
+		}
+		completeReliableSend(w, http.StatusCreated, taskResponse, sendClaim)
 		return
 	}
 
@@ -811,6 +825,7 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs: attachmentIDs,
 		Attachments:   toWSAttachmentMeta(attachments),
 		CreatedAt:     now.Format(time.RFC3339),
+		ClientMsgID:   clientMsgID,
 	})
 	h.hub.BroadcastToChannel(dmID, msgPayload)
 
@@ -828,6 +843,7 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs: attachmentIDs,
 		Attachments:   toWSAttachmentMeta(attachments),
 		CreatedAt:     now.Format(time.RFC3339),
+		ClientMsgID:   clientMsgID,
 	})
 	h.hub.BroadcastToChannel(dmID, dmMsgPayload)
 
@@ -865,7 +881,7 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	writeJSON(w, http.StatusCreated, MessageResponse{
+	resp := MessageResponse{
 		ID:            messageID,
 		ChannelID:     dmID,
 		SenderType:    senderType,
@@ -877,7 +893,9 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs: attachmentIDs,
 		Attachments:   attachments,
 		CreatedAt:     now.Format(time.RFC3339),
-	})
+		ClientMsgID:   clientMsgID,
+	}
+	completeReliableSend(w, http.StatusCreated, resp, sendClaim)
 }
 
 // UpdateMessage handles PATCH /api/v1/dm/{dmID}/messages/{messageID}

--- a/internal/server/handler/helpers.go
+++ b/internal/server/handler/helpers.go
@@ -4,9 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/solo-ai/solo/internal/server/service"
 )
 
 // ErrorResponse is the standard API error response body.
@@ -23,6 +26,47 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, ErrorResponse{Error: http.StatusText(status), Message: message})
+}
+
+func validateClientMessageID(raw string) (string, bool) {
+	id := strings.TrimSpace(raw)
+	return id, len(id) <= 128
+}
+
+func beginReliableSend(w http.ResponseWriter, r *http.Request, dedupe *service.SendDedupe, senderID, clientMessageID string) (*service.SendDedupeClaim, bool) {
+	if dedupe == nil || clientMessageID == "" {
+		return nil, true
+	}
+	claim, cached, err := dedupe.Acquire(r.Context(), senderID+":"+clientMessageID)
+	if err != nil {
+		return nil, false
+	}
+	if cached != nil {
+		writeJSON(w, cached.Status, markSendDeduplicated(cached.Body))
+		return nil, false
+	}
+	return claim, true
+}
+
+func completeReliableSend(w http.ResponseWriter, status int, body any, claim *service.SendDedupeClaim) {
+	claim.Complete(status, body)
+	writeJSON(w, status, body)
+}
+
+func markSendDeduplicated(body any) any {
+	switch response := body.(type) {
+	case MessageResponse:
+		response.Deduplicated = true
+		return response
+	case ThreadReplyResponse:
+		response.Deduplicated = true
+		return response
+	case TaskResponse:
+		response.Deduplicated = true
+		return response
+	default:
+		return body
+	}
 }
 
 // requireUserID extracts the X-User-ID header set by the auth middleware.

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -71,16 +71,18 @@ type MessageHandler struct {
 	mentionSvc *service.MentionService
 	agentSvc   *service.AgentService
 	taskSvc    *service.TaskService
+	sendDedupe *service.SendDedupe
 }
 
 // NewMessageHandler creates a new MessageHandler.
-func NewMessageHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService, taskSvc *service.TaskService) *MessageHandler {
+func NewMessageHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService, taskSvc *service.TaskService, sendDedupe *service.SendDedupe) *MessageHandler {
 	return &MessageHandler{
 		pool:       pool,
 		hub:        hub,
 		mentionSvc: service.NewMentionService(pool),
 		agentSvc:   agentSvc,
 		taskSvc:    taskSvc,
+		sendDedupe: sendDedupe,
 	}
 }
 
@@ -93,6 +95,7 @@ type CreateMessageRequest struct {
 	ThreadID       string   `json:"thread_id,omitempty"`
 	ThinkingNodeID string   `json:"thinking_node_id,omitempty"`
 	RunID          string   `json:"run_id,omitempty"`
+	ClientMsgID    string   `json:"client_msg_id,omitempty"`
 }
 
 // AttachmentMeta is the attachment metadata included in message responses.
@@ -128,6 +131,8 @@ type MessageResponse struct {
 	TaskClaimerDeleted bool             `json:"task_claimer_deleted"`
 	HasUnreadThread    bool             `json:"has_unread_thread,omitempty"`
 	ThinkingNodeID     string           `json:"thinking_node_id,omitempty"`
+	ClientMsgID        string           `json:"client_msg_id,omitempty"`
+	Deduplicated       bool             `json:"deduplicated,omitempty"`
 }
 
 type MessageListResponse struct {
@@ -187,6 +192,16 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	clientMsgID, validClientMsgID := validateClientMessageID(req.ClientMsgID)
+	if !validClientMsgID {
+		writeError(w, http.StatusBadRequest, "client message ID exceeds maximum length of 128 characters")
+		return
+	}
+	sendClaim, proceed := beginReliableSend(w, r, h.sendDedupe, userID, clientMsgID)
+	if !proceed {
+		return
+	}
+	defer sendClaim.Abort()
 
 	// Verify sender is a member of the channel and channel is not archived
 	var isMember bool
@@ -412,11 +427,12 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 				"channel_id": channelID, "node_id": updatedNodeID,
 			}))
 		}
-		writeJSON(w, http.StatusCreated, MessageResponse{
+		resp := MessageResponse{
 			ID: uuid.NewString(), ChannelID: channelID, SenderType: "agent", SenderID: userID,
 			ContentType: "thinking_handoff_protocol", ThinkingNodeID: thinkingNodeID,
-			CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		})
+			ClientMsgID: clientMsgID, CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		completeReliableSend(w, http.StatusCreated, resp, sendClaim)
 		return
 	}
 
@@ -615,6 +631,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 			TaskNumber:        taskNumber,
 			TaskStatus:        taskStatus,
 			CreatedAt:         now.Format(time.RFC3339),
+			ClientMsgID:       clientMsgID,
 		}
 		msgPayload := ws.Envelope(ws.EventMessageNew, msgData)
 		h.hub.BroadcastToChannel(channelID, msgPayload)
@@ -672,14 +689,16 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 		AttachmentIDs:     attachmentIDs,
 		Attachments:       attachments,
 		ThinkingNodeID:    thinkingNodeID,
+		ClientMsgID:       clientMsgID,
 		CreatedAt:         now.Format(time.RFC3339),
 	}
 
 	// If as_task, return the created task response instead of the message response.
 	if taskResp != nil {
-		writeJSON(w, http.StatusCreated, taskResp)
+		taskResp.ClientMsgID = clientMsgID
+		completeReliableSend(w, http.StatusCreated, *taskResp, sendClaim)
 	} else {
-		writeJSON(w, http.StatusCreated, resp)
+		completeReliableSend(w, http.StatusCreated, resp, sendClaim)
 	}
 }
 
@@ -1154,6 +1173,7 @@ func (h *MessageHandler) broadcastDMIfNeeded(channelID string, msg ws.MessageNew
 		Attachments:   msg.Attachments,
 		ThreadID:      msg.ThreadID,
 		CreatedAt:     msg.CreatedAt,
+		ClientMsgID:   msg.ClientMsgID,
 	}
 	h.hub.BroadcastToChannel(channelID, ws.Envelope(ws.EventDMMessageNew, dmPayload))
 }

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -83,6 +83,8 @@ type TaskResponse struct {
 	ArtifactStatus   string  `json:"artifact_status,omitempty"`
 	CreatedAt        string  `json:"created_at"`
 	UpdatedAt        string  `json:"updated_at"`
+	ClientMsgID      string  `json:"client_msg_id,omitempty"`
+	Deduplicated     bool    `json:"deduplicated,omitempty"`
 }
 
 func toTaskResponse(t *service.Task) TaskResponse {

--- a/internal/server/handler/thread.go
+++ b/internal/server/handler/thread.go
@@ -29,12 +29,13 @@ type ThreadHandler struct {
 	mentionSvc *service.MentionService
 	agentSvc   *service.AgentService
 	hub        *ws.Hub
+	sendDedupe *service.SendDedupe
 }
 
 // NewThreadHandler creates a new ThreadHandler.
-func NewThreadHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService) *ThreadHandler {
+func NewThreadHandler(pool *pgxpool.Pool, hub *ws.Hub, agentSvc *service.AgentService, sendDedupe *service.SendDedupe) *ThreadHandler {
 	mentionSvc := service.NewMentionService(pool)
-	return &ThreadHandler{pool: pool, hub: hub, agentSvc: agentSvc, mentionSvc: mentionSvc}
+	return &ThreadHandler{pool: pool, hub: hub, agentSvc: agentSvc, mentionSvc: mentionSvc, sendDedupe: sendDedupe}
 }
 
 // --- Request/Response types ---
@@ -43,6 +44,7 @@ type ThreadReplyRequest struct {
 	Content           string   `json:"content"`
 	MentionedAgentIDs []string `json:"mentioned_agent_ids,omitempty"`
 	AttachmentIDs     []string `json:"attachment_ids,omitempty"`
+	ClientMsgID       string   `json:"client_msg_id,omitempty"`
 }
 
 type ThreadResponse struct {
@@ -68,6 +70,8 @@ type ThreadReplyResponse struct {
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
+	ClientMsgID   string           `json:"client_msg_id,omitempty"`
+	Deduplicated  bool             `json:"deduplicated,omitempty"`
 }
 
 type ThreadMessageListResponse struct {
@@ -131,6 +135,16 @@ func (h *ThreadHandler) CreateThreadReply(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusBadRequest, "reply content exceeds maximum length of 10000 characters")
 		return
 	}
+	clientMsgID, validClientMsgID := validateClientMessageID(req.ClientMsgID)
+	if !validClientMsgID {
+		writeError(w, http.StatusBadRequest, "client message ID exceeds maximum length of 128 characters")
+		return
+	}
+	sendClaim, proceed := beginReliableSend(w, r, h.sendDedupe, userID, clientMsgID)
+	if !proceed {
+		return
+	}
+	defer sendClaim.Abort()
 
 	// Verify user is a member of the channel (or DM)
 	isMember, err := h.isChannelOrDMMember(r.Context(), channelID, userID)
@@ -360,6 +374,7 @@ func (h *ThreadHandler) CreateThreadReply(w http.ResponseWriter, r *http.Request
 				AttachmentIDs: attachmentIDs,
 				Attachments:   toWSAttachmentMeta(attachments),
 				CreatedAt:     now.UTC().Format(time.RFC3339),
+				ClientMsgID:   clientMsgID,
 			},
 			Thread: ws.ThreadMetadataItem{
 				ThreadID:    threadID,
@@ -367,10 +382,12 @@ func (h *ThreadHandler) CreateThreadReply(w http.ResponseWriter, r *http.Request
 				LastReplyAt: now.UTC().Format(time.RFC3339),
 			},
 		}
-		h.hub.BroadcastToThread(threadID, ws.Envelope(ws.EventThreadMessageNew, threadMsg))
+		message := ws.Envelope(ws.EventThreadMessageNew, threadMsg)
+		h.hub.BroadcastToThread(threadID, message)
+		h.hub.SendToUser(userID, message)
 	}
 
-	writeJSON(w, http.StatusCreated, ThreadReplyResponse{
+	resp := ThreadReplyResponse{
 		ID:            replyID,
 		ChannelID:     channelID,
 		ThreadID:      threadID,
@@ -383,7 +400,9 @@ func (h *ThreadHandler) CreateThreadReply(w http.ResponseWriter, r *http.Request
 		AttachmentIDs: attachmentIDs,
 		Attachments:   attachments,
 		CreatedAt:     now.Format(time.RFC3339),
-	})
+		ClientMsgID:   clientMsgID,
+	}
+	completeReliableSend(w, http.StatusCreated, resp, sendClaim)
 }
 
 // ListThreadMessages handles GET /api/v1/channels/{channelID}/messages/{messageID}/thread

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
@@ -49,6 +50,7 @@ func NewRouter(pool *pgxpool.Pool, hub *ws.Hub, dm *service.DaemonManager, agent
 	workspaceRoot := defaultAgentWorkspaceRoot()
 	relationshipMD := service.NewRelationshipsMDGenerator(pool, workspaceRoot)
 	taskSvc := service.NewTaskService(pool)
+	sendDedupe := service.NewSendDedupe(1000, 5*time.Minute)
 	taskSvc.SetAgentNotifier(service.NewAgentNotifier(pool, hub, agentSvc))
 	relationshipSvc := service.NewAgentRelationshipService(pool, relationshipMD)
 	templateSvc := service.NewTemplateService(pool, relationshipMD)
@@ -82,13 +84,13 @@ func NewRouter(pool *pgxpool.Pool, hub *ws.Hub, dm *service.DaemonManager, agent
 	authHandler := handler.NewAuthHandler(pool, agentSvc)
 	channelHandler := handler.NewChannelHandler(pool, dm, templateSvc)
 	memberHandler := handler.NewMemberHandler(pool, agentSvc, dm)
-	messageHandler := handler.NewMessageHandler(pool, hub, agentSvc, taskSvc)
+	messageHandler := handler.NewMessageHandler(pool, hub, agentSvc, taskSvc, sendDedupe)
 	agentHandler := handler.NewAgentHandler(pool, dm, hub, agentSvc)
 	agentRunHandler := handler.NewAgentRunHandler(pool)
 	dashboardHandler := handler.NewDashboardHandler(pool)
-	threadHandler := handler.NewThreadHandler(pool, hub, agentSvc)
+	threadHandler := handler.NewThreadHandler(pool, hub, agentSvc, sendDedupe)
 	thinkingHandler := handler.NewThinkingHandler(pool, hub, agentSvc)
-	dmHandler := handler.NewDMHandler(pool, hub, agentSvc, taskSvc)
+	dmHandler := handler.NewDMHandler(pool, hub, agentSvc, taskSvc, sendDedupe)
 	daemonHandler := handler.NewDaemonHandler(dm, agentSvc, computerSvc)
 	mentionSvc := service.NewMentionService(pool)
 	taskHandler := handler.NewTaskHandler(pool, hub, agentSvc, taskSvc, mentionSvc)

--- a/internal/server/service/send_dedupe.go
+++ b/internal/server/service/send_dedupe.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// SendDedupe coalesces concurrent message sends and briefly caches successful results.
+type SendDedupe struct {
+	mu       sync.Mutex
+	entries  map[string]*sendDedupeEntry
+	capacity int
+	ttl      time.Duration
+}
+
+type sendDedupeEntry struct {
+	done      chan struct{}
+	result    *SendDedupeResult
+	createdAt time.Time
+	expiresAt time.Time
+}
+
+type SendDedupeResult struct {
+	Status int
+	Body   any
+}
+
+type SendDedupeClaim struct {
+	cache *SendDedupe
+	key   string
+	entry *sendDedupeEntry
+}
+
+func NewSendDedupe(capacity int, ttl time.Duration) *SendDedupe {
+	return &SendDedupe{entries: make(map[string]*sendDedupeEntry), capacity: capacity, ttl: ttl}
+}
+
+// Acquire returns either ownership of a new send or the completed result for a duplicate.
+func (d *SendDedupe) Acquire(ctx context.Context, key string) (*SendDedupeClaim, *SendDedupeResult, error) {
+	for {
+		now := time.Now()
+		d.mu.Lock()
+		d.pruneExpired(now)
+		if entry, ok := d.entries[key]; ok {
+			if entry.result != nil {
+				result := *entry.result
+				d.mu.Unlock()
+				return nil, &result, nil
+			}
+			done := entry.done
+			d.mu.Unlock()
+			select {
+			case <-done:
+				continue
+			case <-ctx.Done():
+				return nil, nil, ctx.Err()
+			}
+		}
+
+		entry := &sendDedupeEntry{done: make(chan struct{}), createdAt: now}
+		d.entries[key] = entry
+		d.mu.Unlock()
+		return &SendDedupeClaim{cache: d, key: key, entry: entry}, nil, nil
+	}
+}
+
+func (c *SendDedupeClaim) Complete(status int, body any) {
+	if c == nil {
+		return
+	}
+	c.cache.mu.Lock()
+	defer c.cache.mu.Unlock()
+	entry, ok := c.cache.entries[c.key]
+	if !ok || entry != c.entry || entry.result != nil {
+		return
+	}
+	entry.result = &SendDedupeResult{Status: status, Body: body}
+	entry.expiresAt = time.Now().Add(c.cache.ttl)
+	close(entry.done)
+	c.cache.evictCompleted()
+}
+
+// Abort releases waiters after a failed send so one of them can retry the work.
+func (c *SendDedupeClaim) Abort() {
+	if c == nil {
+		return
+	}
+	c.cache.mu.Lock()
+	defer c.cache.mu.Unlock()
+	entry, ok := c.cache.entries[c.key]
+	if !ok || entry != c.entry || entry.result != nil {
+		return
+	}
+	delete(c.cache.entries, c.key)
+	close(entry.done)
+}
+
+func (d *SendDedupe) pruneExpired(now time.Time) {
+	for key, entry := range d.entries {
+		if entry.result != nil && !entry.expiresAt.After(now) {
+			delete(d.entries, key)
+		}
+	}
+}
+
+func (d *SendDedupe) evictCompleted() {
+	for len(d.entries) > d.capacity {
+		var oldestKey string
+		var oldest time.Time
+		for key, entry := range d.entries {
+			if entry.result != nil && (oldestKey == "" || entry.createdAt.Before(oldest)) {
+				oldestKey, oldest = key, entry.createdAt
+			}
+		}
+		if oldestKey == "" {
+			return
+		}
+		delete(d.entries, oldestKey)
+	}
+}

--- a/internal/server/service/send_dedupe_test.go
+++ b/internal/server/service/send_dedupe_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSendDedupeCoalescesConcurrentSends(t *testing.T) {
+	cache := NewSendDedupe(1000, time.Minute)
+	owner, cached, err := cache.Acquire(context.Background(), "sender:client")
+	if err != nil || owner == nil || cached != nil {
+		t.Fatalf("first acquire = claim %v, cached %v, err %v", owner, cached, err)
+	}
+
+	result := make(chan *SendDedupeResult, 1)
+	go func() {
+		_, duplicate, acquireErr := cache.Acquire(context.Background(), "sender:client")
+		if acquireErr != nil {
+			t.Errorf("duplicate acquire: %v", acquireErr)
+		}
+		result <- duplicate
+	}()
+
+	select {
+	case <-result:
+		t.Fatal("duplicate returned before the owner completed")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	owner.Complete(201, "created")
+	select {
+	case duplicate := <-result:
+		if duplicate == nil || duplicate.Status != 201 || duplicate.Body != "created" {
+			t.Fatalf("duplicate result = %#v", duplicate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("duplicate did not receive the completed result")
+	}
+}
+
+func TestSendDedupeAbortAllowsRetry(t *testing.T) {
+	cache := NewSendDedupe(1000, time.Minute)
+	owner, _, _ := cache.Acquire(context.Background(), "sender:client")
+	owner.Abort()
+
+	retry, cached, err := cache.Acquire(context.Background(), "sender:client")
+	if err != nil || retry == nil || cached != nil {
+		t.Fatalf("retry acquire = claim %v, cached %v, err %v", retry, cached, err)
+	}
+	retry.Abort()
+}
+
+func TestSendDedupeExpiresAndCapsCompletedResults(t *testing.T) {
+	expiring := NewSendDedupe(1, time.Millisecond)
+	owner, _, _ := expiring.Acquire(context.Background(), "expired")
+	owner.Complete(201, "old")
+	time.Sleep(2 * time.Millisecond)
+	retry, cached, err := expiring.Acquire(context.Background(), "expired")
+	if err != nil || retry == nil || cached != nil {
+		t.Fatalf("expired acquire = claim %v, cached %v, err %v", retry, cached, err)
+	}
+	retry.Abort()
+
+	capped := NewSendDedupe(1, time.Minute)
+	first, _, _ := capped.Acquire(context.Background(), "first")
+	first.Complete(201, "first")
+	second, _, _ := capped.Acquire(context.Background(), "second")
+	second.Complete(201, "second")
+	replaced, cached, err := capped.Acquire(context.Background(), "first")
+	if err != nil || replaced == nil || cached != nil {
+		t.Fatalf("evicted acquire = claim %v, cached %v, err %v", replaced, cached, err)
+	}
+	replaced.Abort()
+}

--- a/internal/server/ws/hub.go
+++ b/internal/server/ws/hub.go
@@ -321,6 +321,11 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 // handleMessageSend processes a message.send event from a client.
 func (h *Hub) handleMessageSend(client *Client, payload MessageSendPayload) {
 	// Validate
+	payload.ClientMsgID = strings.TrimSpace(payload.ClientMsgID)
+	if len(payload.ClientMsgID) > 128 {
+		client.sendError("INVALID_PAYLOAD", "client_msg_id exceeds maximum length of 128 characters")
+		return
+	}
 	if payload.ChannelID == "" {
 		client.sendError("INVALID_PAYLOAD", "channel_id is required")
 		return
@@ -441,6 +446,7 @@ func (h *Hub) handleMessageSend(client *Client, payload MessageSendPayload) {
 		ContentType:   "text",
 		AttachmentIDs: attachmentIDs,
 		CreatedAt:     now.Format(time.RFC3339),
+		ClientMsgID:   payload.ClientMsgID,
 	}
 
 	h.BroadcastToChannel(payload.ChannelID, Envelope(EventMessageNew, msgNewPayload))
@@ -510,6 +516,7 @@ func (h *Hub) broadcastDMMessageIfNeeded(channelID string, msg MessageNewPayload
 		ContentType:   msg.ContentType,
 		AttachmentIDs: msg.AttachmentIDs,
 		CreatedAt:     msg.CreatedAt,
+		ClientMsgID:   msg.ClientMsgID,
 	}
 	h.BroadcastToChannel(channelID, Envelope(EventDMMessageNew, dmPayload))
 }
@@ -531,6 +538,11 @@ func (h *Hub) handleTyping(client *Client, payload TypingPayload) {
 // handleThreadReply processes a thread.reply event from a client.
 func (h *Hub) handleThreadReply(client *Client, payload ThreadReplyPayload) {
 	// Validate
+	payload.ClientMsgID = strings.TrimSpace(payload.ClientMsgID)
+	if len(payload.ClientMsgID) > 128 {
+		client.sendError("INVALID_PAYLOAD", "client_msg_id exceeds maximum length of 128 characters")
+		return
+	}
 	if payload.ChannelID == "" {
 		client.sendError("INVALID_PAYLOAD", "channel_id is required")
 		return
@@ -700,6 +712,7 @@ func (h *Hub) handleThreadReply(client *Client, payload ThreadReplyPayload) {
 			ContentType:   "text",
 			AttachmentIDs: attachmentIDs,
 			CreatedAt:     now.Format(time.RFC3339),
+			ClientMsgID:   payload.ClientMsgID,
 		},
 		Thread: ThreadMetadataItem{
 			ThreadID:    payload.ThreadID,

--- a/internal/server/ws/message.go
+++ b/internal/server/ws/message.go
@@ -107,6 +107,7 @@ type MessageSendPayload struct {
 	ChannelID     string   `json:"channel_id"`
 	Content       string   `json:"content"`
 	AttachmentIDs []string `json:"attachment_ids,omitempty"`
+	ClientMsgID   string   `json:"client_msg_id,omitempty"`
 }
 
 type TypingPayload struct {
@@ -118,6 +119,7 @@ type ThreadReplyPayload struct {
 	ThreadID      string   `json:"thread_id"`
 	Content       string   `json:"content"`
 	AttachmentIDs []string `json:"attachment_ids,omitempty"`
+	ClientMsgID   string   `json:"client_msg_id,omitempty"`
 }
 
 type ThreadSubscribePayload struct {
@@ -167,6 +169,7 @@ type MessageNewPayload struct {
 	TaskStatus         string           `json:"task_status,omitempty"`
 	TaskClaimerName    string           `json:"task_claimer_name,omitempty"`
 	TaskClaimerDeleted bool             `json:"task_claimer_deleted"`
+	ClientMsgID        string           `json:"client_msg_id,omitempty"`
 }
 
 // AgentStreamTokenPayload is broadcast on message.agent_typing for streaming tokens.
@@ -260,6 +263,7 @@ type ThreadMessageItem struct {
 	AttachmentIDs []string         `json:"attachment_ids,omitempty"`
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	CreatedAt     string           `json:"created_at"`
+	ClientMsgID   string           `json:"client_msg_id,omitempty"`
 }
 
 // ThreadMetadataItem is the thread metadata portion of a thread.message.new payload.
@@ -340,6 +344,7 @@ type DMMessageNewPayload struct {
 	Attachments   []AttachmentMeta `json:"attachments,omitempty"`
 	ThreadID      string           `json:"thread_id,omitempty"`
 	CreatedAt     string           `json:"created_at"`
+	ClientMsgID   string           `json:"client_msg_id,omitempty"`
 }
 
 // TaskCreatedPayload is broadcast on task.created.


### PR DESCRIPTION
## What changed

- Add optional `client_msg_id` across channel, DM, thread, WebSocket, CLI, and daemon message-send paths.
- Reconcile optimistic messages from either HTTP or WebSocket confirmation, with bounded retry and online/visibility recovery.
- Add a shared process-local server dedupe cache that coalesces concurrent duplicates and reuses successful results for 5 minutes (maximum 1,000 entries).
- Add real end-to-end coverage for messages, tasks, first thread replies, DMs, PostgreSQL persistence, and Agent/CLI delivery.

## Why

A message could be persisted and broadcast while its HTTP acknowledgement was delayed or lost. The client then showed a false failure or retried, and the server had no idempotency key to prevent duplicate inserts, fanout, tasks, or Agent runs.

## Impact

Messages clear from the composer immediately, remain visibly pending/failed when necessary, and reconcile on the first HTTP or WebSocket acknowledgement. Retries reuse the same logical message identity, including through the CLI → daemon → server path.

The dedupe window is intentionally process-local, matching the source design: server restarts and multi-instance deployments are not covered by this cache.

## Validation

- `go test ./...`
- `go test -race ./internal/server/service -run TestSendDedupe`
- `tsc --noEmit -p frontend/tsconfig.json`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- `make rebuild` plus real Playwright/PostgreSQL/WebSocket/Agent E2E: 3 passed
