### PR TITLE
Unify Agent scope routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-scope-router
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -44,6 +44,9 @@ test-e2e-agent-delivery: rebuild ## Rebuild and verify the real Agent result del
 
 test-e2e-agent-session-resume: rebuild ## Rebuild and verify real Channel Session restart continuity
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "resumes the same real Channel provider Session"
+
+test-e2e-agent-scope-router: rebuild ## Rebuild and verify the real Coordinator-first Agent router
+	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "routes an unmentioned Channel message only to the unique Coordinator"
 
 stop: ## Shut down all services
 	@bash scripts/stop-services.sh

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -61,6 +61,16 @@ interface TaskRetryState {
   exhausted_messages: number;
 }
 
+interface RouterState {
+  runs: number;
+  lead_runs: number;
+  worker_runs: number;
+  completed: number;
+  lead_message_id: string;
+  worker_replies: number;
+  unresolved_runs: number;
+}
+
 function databaseJSON<T>(query: string): T {
   const output = execFileSync('docker', [
     'exec',
@@ -307,6 +317,107 @@ test.describe('real Agent result delivery contract', () => {
       await expect(persistedMessage).toBeVisible();
     } finally {
       if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('routes an unmentioned Channel message only to the unique Coordinator', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    const leadAck = `ROUTER_LEAD_ACK_${suffix.toUpperCase()}`;
+    const workerAck = `ROUTER_WORKER_ACK_${suffix.toUpperCase()}`;
+    const unresolvedContent = `@MissingRouter${suffix} SHOULD_NOT_WAKE`;
+    const routedContent = `ROUTER_E2E_${suffix}`;
+    let channel: Entity | null = null;
+    let lead: Entity | null = null;
+    let worker: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `scope-router-e2e-${suffix}`,
+        description: 'Real Agent scope router E2E',
+      });
+      lead = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `RouterLead${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: `When introducing yourself, use solo message send to send exactly LEAD_READY. For a human message beginning ROUTER_E2E_, use solo message send to send exactly ${leadAck}. Send no other visible text.`,
+      });
+      worker = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `RouterWorker${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: `When introducing yourself, use solo message send to send exactly WORKER_READY. For a human message beginning ROUTER_E2E_, use solo message send to send exactly ${workerAck}. Send no other visible text.`,
+      });
+      await api(request, auth.access_token, 'post', '/api/v1/agent-relationships', {
+        from_agent_id: lead.id,
+        to_agent_id: worker.id,
+        rel_type: 'assigns_to',
+      });
+
+      await expect.poll(() => databaseJSON<{ done: boolean }>(`
+        SELECT json_build_object('done',
+          COUNT(DISTINCT agent_id) FILTER (WHERE status = 'completed') = 2
+          AND COUNT(*) FILTER (WHERE status IN ('queued','thinking','running','streaming','waiting_input','waiting_approval')) = 0
+        )::text
+          FROM agent_runs
+         WHERE agent_id IN ('${lead!.id}', '${worker!.id}')
+      `).done, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(true);
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      const composer = page.getByPlaceholder('Type a message...');
+      await composer.fill(unresolvedContent);
+      await composer.press('Enter');
+      await expect(page.getByLabel('Message list').getByText(unresolvedContent, { exact: true })).toBeVisible();
+      await composer.fill(routedContent);
+      await composer.press('Enter');
+
+      await expect.poll(() => databaseJSON<{ unresolved: string; routed: string }>(`
+        SELECT json_build_object(
+          'unresolved', COALESCE((SELECT id::text FROM messages WHERE channel_id = '${channel!.id}' AND content = '${unresolvedContent}' LIMIT 1), ''),
+          'routed', COALESCE((SELECT id::text FROM messages WHERE channel_id = '${channel!.id}' AND content = '${routedContent}' LIMIT 1), '')
+        )::text
+      `), { intervals: [250, 500, 1000] }).toMatchObject({
+        unresolved: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        routed: expect.stringMatching(/^[0-9a-f-]{36}$/),
+      });
+      const triggerIDs = databaseJSON<{ unresolved: string; routed: string }>(`
+        SELECT json_build_object(
+          'unresolved', COALESCE((SELECT id::text FROM messages WHERE channel_id = '${channel.id}' AND content = '${unresolvedContent}' LIMIT 1), ''),
+          'routed', COALESCE((SELECT id::text FROM messages WHERE channel_id = '${channel.id}' AND content = '${routedContent}' LIMIT 1), '')
+        )::text
+      `);
+
+      const readRouterState = () => databaseJSON<RouterState>(`
+        SELECT json_build_object(
+          'runs', COUNT(*) FILTER (WHERE trigger_message_id = '${triggerIDs.routed}'),
+          'lead_runs', COUNT(*) FILTER (WHERE trigger_message_id = '${triggerIDs.routed}' AND agent_id = '${lead.id}'),
+          'worker_runs', COUNT(*) FILTER (WHERE trigger_message_id = '${triggerIDs.routed}' AND agent_id = '${worker.id}'),
+          'completed', COUNT(*) FILTER (WHERE trigger_message_id = '${triggerIDs.routed}' AND status = 'completed'),
+          'lead_message_id', COALESCE((SELECT id::text FROM messages WHERE channel_id = '${channel.id}' AND sender_id = '${lead.id}' AND content = '${leadAck}' ORDER BY created_at DESC LIMIT 1), ''),
+          'worker_replies', (SELECT COUNT(*) FROM messages WHERE channel_id = '${channel.id}' AND sender_id = '${worker.id}' AND content = '${workerAck}'),
+          'unresolved_runs', COUNT(*) FILTER (WHERE trigger_message_id = '${triggerIDs.unresolved}')
+        )::text
+          FROM agent_runs
+         WHERE agent_id IN ('${lead.id}', '${worker.id}')
+      `);
+      await expect.poll(readRouterState, { timeout: 180000, intervals: [500, 1000, 2000] }).toMatchObject({
+        runs: 1,
+        lead_runs: 1,
+        worker_runs: 0,
+        completed: 1,
+        lead_message_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+        worker_replies: 0,
+        unresolved_runs: 0,
+      });
+
+      const state = readRouterState();
+      await expect(page.locator(`[data-message-id="${state.lead_message_id}"]`)).toContainText(leadAck);
+      await expect(page.getByLabel('Message list').getByText(workerAck, { exact: true })).toHaveCount(0);
+    } finally {
+      if (worker) await api(request, auth.access_token, 'delete', `/api/v1/agents/${worker.id}`).catch(() => undefined);
+      if (lead) await api(request, auth.access_token, 'delete', `/api/v1/agents/${lead.id}`).catch(() => undefined);
       if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
     }
   });

--- a/internal/server/handler/dm.go
+++ b/internal/server/handler/dm.go
@@ -788,7 +788,7 @@ func (h *DMHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		threadSvc := service.NewThreadService(h.pool)
 		_, _, _ = threadSvc.GetOrCreateThread(r.Context(), dmID, task.MessageID)
 		if h.agentSvc != nil {
-			go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, nil, nil)
+			go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, task.MessageID, nil, false, nil)
 		}
 		taskResponse := TaskResponse{
 			ID:          taskResp.ID,
@@ -1205,7 +1205,7 @@ func (h *DMHandler) ConvertMessageToTask(w http.ResponseWriter, r *http.Request)
 
 	// Trigger DM agent participant for auto-claim
 	if h.agentSvc != nil {
-		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, nil, nil)
+		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, task.MessageID, nil, false, nil)
 	}
 }
 
@@ -1332,7 +1332,7 @@ func (h *DMHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 
 	// Trigger DM agent participant for auto-claim
 	if h.agentSvc != nil {
-		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, nil, nil)
+		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), dmID, task.ID, task.TaskNumber, task.Title, task.MessageID, nil, false, nil)
 	}
 
 	writeJSON(w, http.StatusCreated, TaskResponse{

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -257,7 +257,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve @mentions (SOLO-52-B)
-	mentionedAgentIDs, _, err := h.mentionSvc.ResolveMentions(r.Context(), content, channelID)
+	mentionedAgentIDs, hasMentions, err := h.mentionSvc.ResolveMentions(r.Context(), content, channelID)
 	if err != nil {
 		slog.Error("failed to resolve mentions", "error", err)
 		mentionedAgentIDs = nil
@@ -605,7 +605,7 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 			// Trigger all channel agents for this task (auto-claim)
 			if h.agentSvc != nil {
-				go h.agentSvc.TriggerAllAgentsForTask(context.Background(), channelID, task.ID, task.TaskNumber, task.Title, mentionedAgentIDs, nil)
+				go h.agentSvc.TriggerAllAgentsForTask(context.Background(), channelID, task.ID, task.TaskNumber, task.Title, task.MessageID, mentionedAgentIDs, hasMentions, nil)
 			}
 		}
 	}
@@ -665,7 +665,6 @@ func (h *MessageHandler) Create(w http.ResponseWriter, r *http.Request) {
 	// thread context and know to reply in the thread. Channel messages use
 	// TriggerAgentResponse (existing behavior).
 	if h.agentSvc != nil && !req.AsTask {
-		hasMentions := len(mentionedAgentIDs) > 0
 		if thinkingNodeID != "" {
 			go h.agentSvc.TriggerAgentResponseInNode(context.Background(), channelID, thinkingNodeID, messageID, senderType, userID, mentionedAgentIDs, hasMentions, nil)
 		} else if threadID != "" {

--- a/internal/server/handler/task.go
+++ b/internal/server/handler/task.go
@@ -284,13 +284,15 @@ func (h *TaskHandler) Create(w http.ResponseWriter, r *http.Request) {
 			contentForMentions += " " + task.Description
 		}
 		var mentionedAgentIDs []string
+		var hasMentions bool
 		if h.mentionSvc != nil {
-			ids, _, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			ids, hasRefs, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			hasMentions = hasRefs
 			if err == nil {
 				mentionedAgentIDs = ids
 			}
 		}
-		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, mentionedAgentIDs, nil)
+		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, task.MessageID, mentionedAgentIDs, hasMentions, nil)
 	}
 }
 
@@ -905,13 +907,15 @@ func (h *TaskHandler) ConvertToTask(w http.ResponseWriter, r *http.Request) {
 			contentForMentions += " " + task.Description
 		}
 		var mentionedAgentIDs []string
+		var hasMentions bool
 		if h.mentionSvc != nil {
-			ids, _, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			ids, hasRefs, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			hasMentions = hasRefs
 			if err == nil {
 				mentionedAgentIDs = ids
 			}
 		}
-		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, mentionedAgentIDs, nil)
+		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, task.MessageID, mentionedAgentIDs, hasMentions, nil)
 	}
 
 	// Broadcast message.updated for the original message so the frontend
@@ -1223,13 +1227,15 @@ func (h *TaskHandler) CreateGlobal(w http.ResponseWriter, r *http.Request) {
 			contentForMentions += " " + task.Description
 		}
 		var mentionedAgentIDs []string
+		var hasMentions bool
 		if h.mentionSvc != nil {
-			ids, _, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			ids, hasRefs, err := h.mentionSvc.ResolveMentions(r.Context(), contentForMentions, task.ChannelID)
+			hasMentions = hasRefs
 			if err == nil {
 				mentionedAgentIDs = ids
 			}
 		}
-		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, mentionedAgentIDs, nil)
+		go h.agentSvc.TriggerAllAgentsForTask(context.Background(), task.ChannelID, task.ID, task.TaskNumber, task.Title, task.MessageID, mentionedAgentIDs, hasMentions, nil)
 	}
 }
 

--- a/internal/server/handler/thread.go
+++ b/internal/server/handler/thread.go
@@ -233,11 +233,11 @@ func (h *ThreadHandler) CreateThreadReply(w http.ResponseWriter, r *http.Request
 	var mentionHasMentions bool
 	if len(mentionedAgentIDs) == 0 && h.mentionSvc != nil {
 		resolved, hasRefs, err := h.mentionSvc.ResolveMentions(r.Context(), content, channelID)
+		mentionHasMentions = hasRefs
 		if err != nil {
 			slog.Warn("failed to resolve mentions in thread reply", "error", err)
 		} else {
 			mentionedAgentIDs = resolved
-			mentionHasMentions = hasRefs
 		}
 	}
 

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -152,8 +152,8 @@ func (s *AgentService) updateThreadDebounce(channelID, threadID, agentID string)
 //
 // mentionedAgentIDs: if non-empty, only the mentioned agents are triggered.
 // If empty but hasMentions is true, @patterns existed but none resolved — suppress
-// all agent responses. If empty and hasMentions is false, trigger the channel
-// coordinator (or the first active agent as fallback).
+// all agent responses. If empty and hasMentions is false, use the shared
+// Coordinator-first Channel fallback.
 //
 // Called after a message is persisted and broadcast.
 func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, messageID, senderType, senderID string, mentionedAgentIDs []string, hasMentions bool, agentChain []string) {
@@ -174,10 +174,18 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 	// This tells each agent WHO was mentioned, enabling "if it's for someone else, stay out."
 	mentionedNames := s.resolveMentionedNames(ctx, mentionedAgentIDs)
 
-	targetAgents := s.routeChannelTargets(ctx, agents, mentionedAgentIDs, hasMentions)
+	excludeAgentID := ""
 	if senderType == "agent" {
-		targetAgents = excludeAgent(targetAgents, senderID)
+		excludeAgentID = senderID
 	}
+	targetAgents, _ := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:             wakeScopeChannel,
+		ChannelID:         channelID,
+		TriggerMessageID:  messageID,
+		MentionedAgentIDs: mentionedAgentIDs,
+		HasMentions:       hasMentions,
+		ExcludeAgentID:    excludeAgentID,
+	})
 
 	if len(targetAgents) == 0 {
 		return
@@ -511,17 +519,6 @@ func (s *AgentService) thinkingHandoffs(ctx context.Context, query, nodeID strin
 	return result, rows.Err()
 }
 
-func (s *AgentService) routeChannelTargets(ctx context.Context, agents []agentChannelInfo, mentionedAgentIDs []string, hasMentions bool) []agentChannelInfo {
-	if len(mentionedAgentIDs) > 0 || hasMentions {
-		return filterAgentsByID(agents, selectWakeAgentIDs(wakeRouteInput{
-			ActiveIDs:    agentIDs(agents),
-			MentionedIDs: mentionedAgentIDs,
-			HasMention:   hasMentions,
-		}))
-	}
-	return s.chooseCoordinator(ctx, agents)
-}
-
 func filterAgentsByID(agents []agentChannelInfo, ids []string) []agentChannelInfo {
 	idSet := make(map[string]bool, len(ids))
 	for _, id := range ids {
@@ -534,46 +531,6 @@ func filterAgentsByID(agents []agentChannelInfo, ids []string) []agentChannelInf
 		}
 	}
 	return out
-}
-
-type relationshipEdge struct {
-	from string
-	to   string
-}
-
-func (s *AgentService) chooseCoordinator(ctx context.Context, agents []agentChannelInfo) []agentChannelInfo {
-	if len(agents) <= 1 {
-		return agents
-	}
-
-	rows, err := s.pool.Query(ctx, `
-		SELECT from_agent_id::text, to_agent_id::text
-		  FROM agent_relationships
-		 WHERE rel_type = 'assigns_to'
-	`)
-	if err == nil {
-		defer rows.Close()
-		edges := []relationshipEdge{}
-		for rows.Next() {
-			var fromID, toID string
-			if scanErr := rows.Scan(&fromID, &toID); scanErr != nil {
-				continue
-			}
-			edges = append(edges, relationshipEdge{from: fromID, to: toID})
-		}
-		if chosen := chooseCoordinatorFromEdges(agents, edges); len(chosen) > 0 {
-			return chosen
-		}
-	}
-
-	return agents[:1]
-}
-
-func chooseCoordinatorFromEdges(agents []agentChannelInfo, edges []relationshipEdge) []agentChannelInfo {
-	return filterAgentsByID(agents, selectWakeAgentIDs(wakeRouteInput{
-		ActiveIDs: agentIDs(agents),
-		Edges:     edges,
-	}))
 }
 
 func agentIDs(agents []agentChannelInfo) []string {
@@ -1886,48 +1843,18 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 		return
 	}
 
-	// Determine target agents for this thread follow-up:
-	// - If @mentions provided: only trigger the mentioned agents.
-	// - If no @mentions: only trigger agents that have already replied in this thread.
-	var targetAgents []agentChannelInfo
-	if len(mentionedAgentIDs) > 0 {
-		mentionedSet := make(map[string]bool, len(mentionedAgentIDs))
-		for _, id := range mentionedAgentIDs {
-			mentionedSet[id] = true
-		}
-		for _, ag := range agents {
-			if mentionedSet[ag.ID] {
-				targetAgents = append(targetAgents, ag)
-			}
-		}
-	} else if hasMentions {
-		// Mentions were present but none resolved to active agents — do not fall back.
-		slog.Info("mentions found but none resolved to active agents in thread, skipping", "channel_id", channelID, "thread_id", threadID)
-		return
-	} else {
-		// No @mentions — prefer agents that have already replied in this thread.
-		threadAgentIDs, _ := s.getThreadParticipantAgents(ctx, threadID)
-		if len(threadAgentIDs) > 0 {
-			targetAgents = s.chooseCoordinator(ctx, filterAgentsByID(agents, threadAgentIDs))
-		}
-		// Fallback: if nobody has replied in this thread yet, trigger the
-		// agent whose message was replied to (the root message sender).
-		if len(targetAgents) == 0 {
-			if rootSenderID := s.getThreadRootAgentSender(ctx, threadID); rootSenderID != "" {
-				targetAgents = filterAgentsByID(agents, []string{rootSenderID})
-			}
-		}
-		if len(targetAgents) == 0 {
-			targetAgents = s.chooseCoordinator(ctx, agents)
-		}
-	}
-
-	if len(targetAgents) == 0 {
-		return
-	}
+	excludeAgentID := ""
 	if senderType == "agent" {
-		targetAgents = excludeAgent(targetAgents, senderID)
+		excludeAgentID = senderID
 	}
+	targetAgents, _ := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:             wakeScopeThread,
+		ChannelID:         channelID,
+		ThreadID:          threadID,
+		MentionedAgentIDs: mentionedAgentIDs,
+		HasMentions:       hasMentions,
+		ExcludeAgentID:    excludeAgentID,
+	})
 	if len(targetAgents) == 0 {
 		return
 	}
@@ -2066,19 +1993,6 @@ func shouldTriggerAgentForSender(senderType string, mentionedAgentIDs []string) 
 	return true
 }
 
-func excludeAgent(agents []agentChannelInfo, agentID string) []agentChannelInfo {
-	if agentID == "" {
-		return agents
-	}
-	filtered := make([]agentChannelInfo, 0, len(agents))
-	for _, ag := range agents {
-		if ag.ID != agentID {
-			filtered = append(filtered, ag)
-		}
-	}
-	return filtered
-}
-
 // CheckClaimWindow checks whether the given claimerID is allowed to claim the
 // task at this time. Returns (allowed bool, reason string).
 func (s *AgentService) CheckClaimWindow(taskID, claimerID string) (bool, string) {
@@ -2098,28 +2012,29 @@ func (s *AgentService) CloseClaimWindow(taskID string) {
 // TriggerAllAgentsForTask triggers active agents in a channel to respond
 // to a newly created task. Agent replies are routed to the task's thread.
 //
-// If mentionedAgentIDs is non-empty, only the @mentioned agents are triggered
-// immediately and a 30-second priority claim window is opened. After the window
-// expires, remaining agents are triggered if the task is still unclaimed.
-// Without @mentions, the channel coordinator is triggered.
-func (s *AgentService) TriggerAllAgentsForTask(ctx context.Context, channelID, taskID string, taskNumber int, taskTitle string, mentionedAgentIDs []string, agentChain []string) {
+// Explicit @mentions retain the priority claim window. Otherwise the shared
+// Channel/Task router chooses the coordinator or fallback targets.
+func (s *AgentService) TriggerAllAgentsForTask(ctx context.Context, channelID, taskID string, taskNumber int, taskTitle, triggerMessageID string, mentionedAgentIDs []string, hasMentions bool, agentChain []string) {
 	agents, err := s.getChannelActiveAgents(ctx, channelID)
-	if err != nil || len(agents) == 0 {
+	if err != nil {
+		slog.Error("failed to get channel active agents for task", "channel_id", channelID, "task_id", taskID, "error", err)
 		return
 	}
 
+	targetAgents, _ := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:             wakeScopeTask,
+		ChannelID:         channelID,
+		TriggerMessageID:  triggerMessageID,
+		MentionedAgentIDs: mentionedAgentIDs,
+		HasMentions:       hasMentions,
+	})
+	if len(targetAgents) == 0 {
+		return
+	}
 	if len(mentionedAgentIDs) > 0 {
 		s.claimWindow.OpenWindow(taskID, mentionedAgentIDs)
-		for _, ag := range filterAgentsByID(agents, selectWakeAgentIDs(wakeRouteInput{
-			ActiveIDs:    agentIDs(agents),
-			MentionedIDs: mentionedAgentIDs,
-		})) {
-			go s.TriggerAgentForTask(ctx, channelID, taskID, ag.ID, taskNumber, taskTitle, "", agentChain, mentionedAgentIDs)
-		}
-		return
 	}
-
-	for _, ag := range s.chooseCoordinator(ctx, agents) {
+	for _, ag := range targetAgents {
 		go s.TriggerAgentForTask(ctx, channelID, taskID, ag.ID, taskNumber, taskTitle, "", agentChain, mentionedAgentIDs)
 	}
 }
@@ -2431,46 +2346,6 @@ func (s *AgentService) getChannelActiveAgents(ctx context.Context, channelID str
 	}
 
 	return agents, nil
-}
-
-// getThreadParticipantAgents returns the distinct agent sender IDs that have
-// already replied in the given thread. Used to scope thread follow-up triggers.
-func (s *AgentService) getThreadParticipantAgents(ctx context.Context, threadID string) ([]string, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT DISTINCT sender_id FROM messages
-		 WHERE thread_id = $1 AND sender_type = 'agent'`,
-		threadID,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var agentIDs []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			return nil, err
-		}
-		agentIDs = append(agentIDs, id)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return agentIDs, nil
-}
-
-// getThreadRootAgentSender returns the agent ID of the root message sender
-// in a thread, or empty string if the root message was sent by a human.
-func (s *AgentService) getThreadRootAgentSender(ctx context.Context, threadID string) string {
-	var senderID string
-	_ = s.pool.QueryRow(ctx,
-		`SELECT m.sender_id FROM messages m
-		 JOIN threads t ON t.root_message_id = m.id
-		 WHERE t.id = $1 AND m.sender_type = 'agent'`,
-		threadID,
-	).Scan(&senderID)
-	return senderID
 }
 
 // getRecentMessages returns the most recent N messages in a channel as agent messages.

--- a/internal/server/service/agent_routing_test.go
+++ b/internal/server/service/agent_routing_test.go
@@ -1,86 +1,353 @@
 package service
 
-import "testing"
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
 
-func TestFilterAgentsByID(t *testing.T) {
-	agents := []agentChannelInfo{{ID: "a"}, {ID: "b"}, {ID: "c"}}
-	got := filterAgentsByID(agents, []string{"c", "a"})
-	if len(got) != 2 || got[0].ID != "a" || got[1].ID != "c" {
-		t.Fatalf("unexpected filtered agents: %#v", got)
+	"github.com/google/uuid"
+)
+
+func TestSelectWakeDecision(t *testing.T) {
+	team := []string{"lead", "be", "fe", "qa"}
+	edges := []relationshipEdge{
+		{from: "lead", to: "be"},
+		{from: "lead", to: "fe"},
+		{from: "lead", to: "qa"},
 	}
-}
-
-func TestChooseCoordinatorFromEdges(t *testing.T) {
-	agents := []agentChannelInfo{{ID: "leader"}, {ID: "worker"}}
-	got := chooseCoordinatorFromEdges(agents, []relationshipEdge{{from: "leader", to: "worker"}})
-	if len(got) != 1 || got[0].ID != "leader" {
-		t.Fatalf("expected leader, got %#v", got)
-	}
-}
-
-func TestChooseCoordinatorFromEdgesFallback(t *testing.T) {
-	agents := []agentChannelInfo{{ID: "first"}, {ID: "second"}}
-	got := chooseCoordinatorFromEdges(agents, nil)
-	if len(got) != 1 || got[0].ID != "first" {
-		t.Fatalf("expected first agent fallback, got %#v", got)
-	}
-}
-
-func TestSelectWakeAgentIDsMatchesCurrentTaskRouting(t *testing.T) {
-	active := []string{"lead", "be", "fe"}
-	edges := []relationshipEdge{{from: "lead", to: "be"}, {from: "lead", to: "fe"}}
 
 	tests := []struct {
-		name string
-		in   wakeRouteInput
-		want []string
+		name       string
+		facts      wakeRouteFacts
+		wantIDs    []string
+		wantReason wakeRouteReason
 	}{
 		{
-			name: "explicit mention wins",
-			in: wakeRouteInput{
-				ActiveIDs:    active,
-				MentionedIDs: []string{"be"},
+			name:       "no active agent",
+			facts:      wakeRouteFacts{Scope: wakeScopeChannel},
+			wantReason: wakeReasonNoActiveAgent,
+		},
+		{
+			name: "explicit mentions only wake active matches",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeChannel,
+				ActiveIDs:    team,
+				MentionedIDs: []string{"missing", "fe", "be"},
+				HasMentions:  true,
+			},
+			wantIDs:    []string{"be", "fe"},
+			wantReason: wakeReasonExplicitMention,
+		},
+		{
+			name: "unresolved mention suppresses fallback",
+			facts: wakeRouteFacts{
+				Scope:       wakeScopeChannel,
+				ActiveIDs:   team,
+				HasMentions: true,
+			},
+			wantReason: wakeReasonUnresolvedMention,
+		},
+		{
+			name: "channel uses unique coordinator",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeChannel,
+				ActiveIDs:    team,
+				GraphNodeIDs: team,
 				Edges:        edges,
 			},
-			want: []string{"be"},
+			wantIDs:    []string{"lead"},
+			wantReason: wakeReasonUniqueCoordinator,
 		},
 		{
-			name: "unknown mention suppresses fallback",
-			in: wakeRouteInput{
-				ActiveIDs:  active,
-				HasMention: true,
+			name: "small channel fans out without coordinator",
+			facts: wakeRouteFacts{
+				Scope:     wakeScopeChannel,
+				ActiveIDs: []string{"a", "b", "c"},
 			},
-			want: nil,
+			wantIDs:    []string{"a", "b", "c"},
+			wantReason: wakeReasonSmallTeamFanout,
 		},
 		{
-			name: "unmentioned task uses coordinator",
-			in: wakeRouteInput{
-				ActiveIDs: active,
-				Edges:     edges,
+			name: "large channel uses recent active window",
+			facts: wakeRouteFacts{
+				Scope:           wakeScopeChannel,
+				ActiveIDs:       team,
+				RecentActiveIDs: []string{"qa", "be", "missing"},
 			},
-			want: []string{"lead"},
+			wantIDs:    []string{"qa", "be"},
+			wantReason: wakeReasonRecentWindow,
 		},
 		{
-			name: "no relationship keeps first active fallback",
-			in: wakeRouteInput{
-				ActiveIDs: active,
+			name: "large channel deterministically falls back to first",
+			facts: wakeRouteFacts{
+				Scope:     wakeScopeChannel,
+				ActiveIDs: team,
 			},
-			want: []string{"lead"},
+			wantIDs:    []string{"lead"},
+			wantReason: wakeReasonDeterministicFirst,
+		},
+		{
+			name: "multiple roots are not a unique coordinator",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeChannel,
+				ActiveIDs:    team,
+				GraphNodeIDs: team,
+				Edges: []relationshipEdge{
+					{from: "lead", to: "be"},
+					{from: "fe", to: "qa"},
+				},
+				RecentActiveIDs: []string{"qa"},
+			},
+			wantIDs:    []string{"qa"},
+			wantReason: wakeReasonRecentWindow,
+		},
+		{
+			name: "cycle is not a unique coordinator",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeChannel,
+				ActiveIDs:    team,
+				GraphNodeIDs: team,
+				Edges: []relationshipEdge{
+					{from: "lead", to: "be"},
+					{from: "be", to: "lead"},
+					{from: "fe", to: "qa"},
+				},
+				RecentActiveIDs: []string{"fe"},
+			},
+			wantIDs:    []string{"fe"},
+			wantReason: wakeReasonRecentWindow,
+		},
+		{
+			name: "inactive coordinator is rejected",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeChannel,
+				ActiveIDs:    team,
+				GraphNodeIDs: append([]string{"inactive"}, team...),
+				Edges: []relationshipEdge{
+					{from: "inactive", to: "lead"},
+					{from: "lead", to: "be"},
+					{from: "lead", to: "fe"},
+					{from: "lead", to: "qa"},
+				},
+				RecentActiveIDs: []string{"be"},
+			},
+			wantIDs:    []string{"be"},
+			wantReason: wakeReasonRecentWindow,
+		},
+		{
+			name: "thread participant coordinator wins",
+			facts: wakeRouteFacts{
+				Scope:                wakeScopeThread,
+				ActiveIDs:            team,
+				GraphNodeIDs:         team,
+				Edges:                edges,
+				ThreadParticipantIDs: []string{"be", "lead"},
+			},
+			wantIDs:    []string{"lead"},
+			wantReason: wakeReasonThreadCoordinator,
+		},
+		{
+			name: "thread uses most recent participant otherwise",
+			facts: wakeRouteFacts{
+				Scope:                wakeScopeThread,
+				ActiveIDs:            team,
+				GraphNodeIDs:         team,
+				Edges:                edges,
+				ThreadParticipantIDs: []string{"qa", "be"},
+			},
+			wantIDs:    []string{"qa"},
+			wantReason: wakeReasonThreadRecentParticipant,
+		},
+		{
+			name: "thread root agent precedes channel coordinator",
+			facts: wakeRouteFacts{
+				Scope:             wakeScopeThread,
+				ActiveIDs:         team,
+				GraphNodeIDs:      team,
+				Edges:             edges,
+				ThreadRootAgentID: "be",
+			},
+			wantIDs:    []string{"be"},
+			wantReason: wakeReasonThreadRootAgent,
+		},
+		{
+			name: "empty thread uses channel coordinator",
+			facts: wakeRouteFacts{
+				Scope:        wakeScopeThread,
+				ActiveIDs:    team,
+				GraphNodeIDs: team,
+				Edges:        edges,
+			},
+			wantIDs:    []string{"lead"},
+			wantReason: wakeReasonThreadChannelCoordinator,
+		},
+		{
+			name: "thread never fans out and uses recent channel agent",
+			facts: wakeRouteFacts{
+				Scope:           wakeScopeThread,
+				ActiveIDs:       []string{"a", "b", "c"},
+				RecentActiveIDs: []string{"c", "b"},
+			},
+			wantIDs:    []string{"c"},
+			wantReason: wakeReasonThreadRecentChannelAgent,
+		},
+		{
+			name: "thread deterministic fallback remains single",
+			facts: wakeRouteFacts{
+				Scope:     wakeScopeThread,
+				ActiveIDs: []string{"a", "b", "c"},
+			},
+			wantIDs:    []string{"a"},
+			wantReason: wakeReasonDeterministicFirst,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := selectWakeAgentIDs(tt.in)
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %v, want %v", got, tt.want)
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Fatalf("got %v, want %v", got, tt.want)
-				}
+			got := selectWakeDecision(tt.facts)
+			if !reflect.DeepEqual(got.AgentIDs, tt.wantIDs) || got.Reason != tt.wantReason {
+				t.Fatalf("selectWakeDecision() = %#v, want IDs %v reason %q", got, tt.wantIDs, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestRelationshipGraphForActiveKeepsInactiveRoot(t *testing.T) {
+	nodes, edges := relationshipGraphForActive(
+		[]string{"worker", "isolated"},
+		[]relationshipEdge{
+			{from: "inactive-lead", to: "worker"},
+			{from: "unrelated", to: "other"},
+		},
+	)
+	if !reflect.DeepEqual(nodes, []string{"worker", "isolated", "inactive-lead"}) {
+		t.Fatalf("nodes = %v", nodes)
+	}
+	if !reflect.DeepEqual(edges, []relationshipEdge{{from: "inactive-lead", to: "worker"}}) {
+		t.Fatalf("edges = %v", edges)
+	}
+}
+
+func TestWakeRouterUsesPostgresHistoryAndThreadScope(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	channelID := agentRunChannel(t, pool, ownerID)
+	agentIDList := []string{
+		agentRunAgent(t, pool, ownerID),
+		agentRunAgent(t, pool, ownerID),
+		agentRunAgent(t, pool, ownerID),
+		agentRunAgent(t, pool, ownerID),
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = ANY($1)`, agentIDList)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+	for _, agentID := range agentIDList {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO channel_members (channel_id, member_type, member_id)
+			VALUES ($1, 'agent', $2)
+			ON CONFLICT DO NOTHING
+		`, channelID, agentID); err != nil {
+			t.Fatalf("add channel agent: %v", err)
+		}
+	}
+
+	baseTime := time.Now().UTC().Add(-time.Hour)
+	oldAgentMessageID := uuid.NewString()
+	mentionedMessageID := uuid.NewString()
+	triggerMessageID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, mentioned_agent_ids, created_at, updated_at)
+		VALUES
+			($1, $4, 'agent', $5, 'older agent activity', '{}', $8, $8),
+			($2, $4, 'user', $6, 'recent mention', ARRAY[$7]::uuid[], $9, $9),
+			($3, $4, 'user', $6, 'trigger', '{}', $10, $10)
+	`, oldAgentMessageID, mentionedMessageID, triggerMessageID, channelID, agentIDList[0], ownerID, agentIDList[2], baseTime, baseTime.Add(time.Minute), baseTime.Add(2*time.Minute)); err != nil {
+		t.Fatalf("insert channel history: %v", err)
+	}
+
+	service := &AgentService{pool: pool}
+	agents, err := service.getChannelActiveAgents(ctx, channelID)
+	if err != nil {
+		t.Fatalf("get active agents: %v", err)
+	}
+	unknownIDs, hasMentions, err := NewMentionService(pool).ResolveMentions(ctx, "ask @missing-agent", channelID)
+	if err != nil || !hasMentions || len(unknownIDs) != 0 {
+		t.Fatalf("unknown mention = IDs %v hasMentions %v error %v", unknownIDs, hasMentions, err)
+	}
+	_, unresolvedDecision := service.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:       wakeScopeChannel,
+		ChannelID:   channelID,
+		HasMentions: hasMentions,
+	})
+	if unresolvedDecision.Reason != wakeReasonUnresolvedMention || len(unresolvedDecision.AgentIDs) != 0 {
+		t.Fatalf("unresolved mention decision = %#v", unresolvedDecision)
+	}
+	_, decision := service.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:            wakeScopeChannel,
+		ChannelID:        channelID,
+		TriggerMessageID: triggerMessageID,
+	})
+	if decision.Reason != wakeReasonRecentWindow || !reflect.DeepEqual(decision.AgentIDs, []string{agentIDList[2], agentIDList[0]}) {
+		t.Fatalf("recent-window decision = %#v", decision)
+	}
+
+	for _, childID := range agentIDList[1:] {
+		if _, err := pool.Exec(ctx, `
+			INSERT INTO agent_relationships (from_agent_id, to_agent_id, rel_type)
+			VALUES ($1, $2, 'assigns_to')
+		`, agentIDList[0], childID); err != nil {
+			t.Fatalf("insert relationship: %v", err)
+		}
+	}
+	_, decision = service.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:            wakeScopeChannel,
+		ChannelID:        channelID,
+		TriggerMessageID: triggerMessageID,
+	})
+	if decision.Reason != wakeReasonUniqueCoordinator || !reflect.DeepEqual(decision.AgentIDs, agentIDList[:1]) {
+		t.Fatalf("coordinator decision = %#v", decision)
+	}
+
+	rootMessageID := uuid.NewString()
+	threadID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, created_at, updated_at)
+		VALUES ($1, $2, 'agent', $3, 'thread root', $4, $4)
+	`, rootMessageID, channelID, agentIDList[1], baseTime.Add(3*time.Minute)); err != nil {
+		t.Fatalf("insert thread root: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO threads (id, channel_id, root_message_id, created_at)
+		VALUES ($1, $2, $3, $4)
+	`, threadID, channelID, rootMessageID, baseTime.Add(3*time.Minute)); err != nil {
+		t.Fatalf("insert thread: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, thread_id, created_at, updated_at)
+		VALUES
+			($1, $2, 'agent', $3, 'older reply', $4, $5, $5),
+			($6, $2, 'agent', $7, 'newer reply', $4, $8, $8)
+	`, uuid.NewString(), channelID, agentIDList[2], threadID, baseTime.Add(4*time.Minute),
+		uuid.NewString(), agentIDList[3], baseTime.Add(5*time.Minute)); err != nil {
+		t.Fatalf("insert thread replies: %v", err)
+	}
+	_, decision = service.routeWakeTargets(ctx, agents, wakeRouteRequest{
+		Scope:     wakeScopeThread,
+		ChannelID: channelID,
+		ThreadID:  threadID,
+	})
+	if decision.Reason != wakeReasonThreadRecentParticipant || !reflect.DeepEqual(decision.AgentIDs, agentIDList[3:]) {
+		t.Fatalf("thread participant decision = %#v", decision)
+	}
+}
+
+func TestExcludeIDPreventsSelfMentionLoop(t *testing.T) {
+	if got := excludeID([]string{"sender", "peer"}, "sender"); !reflect.DeepEqual(got, []string{"peer"}) {
+		t.Fatalf("excludeID() = %v", got)
 	}
 }
 
@@ -102,13 +369,5 @@ func TestShouldTriggerAgentForSender(t *testing.T) {
 				t.Fatalf("got %v, want %v", got, tt.wantTrigger)
 			}
 		})
-	}
-}
-
-func TestExcludeAgentPreventsSelfMentionLoop(t *testing.T) {
-	agents := []agentChannelInfo{{ID: "sender"}, {ID: "peer"}}
-	got := excludeAgent(agents, "sender")
-	if len(got) != 1 || got[0].ID != "peer" {
-		t.Fatalf("unexpected remaining agents: %#v", got)
 	}
 }

--- a/internal/server/service/agent_wake_routing.go
+++ b/internal/server/service/agent_wake_routing.go
@@ -1,54 +1,420 @@
 package service
 
-type wakeRouteInput struct {
-	ActiveIDs    []string
-	MentionedIDs []string
-	HasMention   bool
-	Edges        []relationshipEdge
+import (
+	"context"
+	"log/slog"
+)
+
+const (
+	wakeRecentWindowSize   = 20
+	wakeSmallTeamThreshold = 4
+)
+
+type wakeRouteScope string
+
+const (
+	wakeScopeChannel wakeRouteScope = "channel"
+	wakeScopeTask    wakeRouteScope = "task"
+	wakeScopeThread  wakeRouteScope = "thread"
+)
+
+type wakeRouteReason string
+
+const (
+	wakeReasonExplicitMention          wakeRouteReason = "explicit_mention"
+	wakeReasonUnresolvedMention        wakeRouteReason = "unresolved_mention"
+	wakeReasonUniqueCoordinator        wakeRouteReason = "unique_coordinator"
+	wakeReasonSmallTeamFanout          wakeRouteReason = "small_team_fanout"
+	wakeReasonRecentWindow             wakeRouteReason = "recent_window"
+	wakeReasonThreadCoordinator        wakeRouteReason = "thread_participant_coordinator"
+	wakeReasonThreadRecentParticipant  wakeRouteReason = "thread_recent_participant"
+	wakeReasonThreadRootAgent          wakeRouteReason = "thread_root_agent"
+	wakeReasonThreadChannelCoordinator wakeRouteReason = "thread_channel_coordinator"
+	wakeReasonThreadRecentChannelAgent wakeRouteReason = "thread_recent_channel_agent"
+	wakeReasonDeterministicFirst       wakeRouteReason = "deterministic_first"
+	wakeReasonNoActiveAgent            wakeRouteReason = "no_active_agent"
+)
+
+type wakeRouteRequest struct {
+	Scope             wakeRouteScope
+	ChannelID         string
+	ThreadID          string
+	TriggerMessageID  string
+	MentionedAgentIDs []string
+	HasMentions       bool
+	ExcludeAgentID    string
 }
 
-func selectWakeAgentIDs(in wakeRouteInput) []string {
-	if len(in.MentionedIDs) > 0 {
-		return activeMentionedIDs(in.ActiveIDs, in.MentionedIDs)
-	}
-	if in.HasMention {
-		return nil
-	}
-	return selectCoordinatorID(in.ActiveIDs, in.Edges)
+type wakeRouteFacts struct {
+	Scope                wakeRouteScope
+	ActiveIDs            []string
+	MentionedIDs         []string
+	HasMentions          bool
+	GraphNodeIDs         []string
+	Edges                []relationshipEdge
+	RecentActiveIDs      []string
+	ThreadParticipantIDs []string
+	ThreadRootAgentID    string
 }
 
-func activeMentionedIDs(activeIDs, mentionedIDs []string) []string {
-	mentioned := make(map[string]bool, len(mentionedIDs))
-	for _, id := range mentionedIDs {
-		mentioned[id] = true
+type wakeRouteDecision struct {
+	AgentIDs []string
+	Reason   wakeRouteReason
+}
+
+type relationshipEdge struct {
+	from string
+	to   string
+}
+
+func (s *AgentService) routeWakeTargets(ctx context.Context, agents []agentChannelInfo, req wakeRouteRequest) ([]agentChannelInfo, wakeRouteDecision) {
+	activeIDs := agentIDs(agents)
+	if req.ExcludeAgentID != "" {
+		activeIDs = excludeID(activeIDs, req.ExcludeAgentID)
 	}
-	out := []string{}
-	for _, id := range activeIDs {
-		if mentioned[id] {
-			out = append(out, id)
+	facts := wakeRouteFacts{
+		Scope:        req.Scope,
+		ActiveIDs:    activeIDs,
+		MentionedIDs: req.MentionedAgentIDs,
+		HasMentions:  req.HasMentions,
+	}
+
+	// Explicit and unresolved mentions do not need relationship or history reads.
+	decision := selectWakeDecision(facts)
+	if decision.Reason != wakeReasonExplicitMention && decision.Reason != wakeReasonUnresolvedMention && decision.Reason != wakeReasonNoActiveAgent {
+		allEdges, err := s.getWakeRelationshipEdges(ctx)
+		if err != nil {
+			slog.Error("failed to load agent relationship graph for wake routing", "channel_id", req.ChannelID, "error", err)
+		} else {
+			facts.GraphNodeIDs, facts.Edges = relationshipGraphForActive(activeIDs, allEdges)
+		}
+
+		if req.Scope == wakeScopeThread {
+			facts.ThreadParticipantIDs, err = s.getThreadParticipantAgents(ctx, req.ThreadID)
+			if err != nil {
+				slog.Error("failed to load thread agent participants for wake routing", "channel_id", req.ChannelID, "thread_id", req.ThreadID, "error", err)
+			}
+			facts.ThreadRootAgentID, err = s.getThreadRootAgentSender(ctx, req.ThreadID)
+			if err != nil {
+				slog.Error("failed to load thread root agent for wake routing", "channel_id", req.ChannelID, "thread_id", req.ThreadID, "error", err)
+			}
+		}
+
+		decision = selectWakeDecision(facts)
+		if decision.Reason == wakeReasonDeterministicFirst {
+			facts.RecentActiveIDs, err = s.getRecentChannelAgentIDs(ctx, req.ChannelID, req.TriggerMessageID)
+			if err != nil {
+				slog.Error("failed to load recent channel agents for wake routing", "channel_id", req.ChannelID, "error", err)
+			} else {
+				decision = selectWakeDecision(facts)
+			}
 		}
 	}
-	return out
+
+	slog.Info("agent wake route decided",
+		"scope", req.Scope,
+		"channel_id", req.ChannelID,
+		"thread_id", req.ThreadID,
+		"trigger_message_id", req.TriggerMessageID,
+		"reason", decision.Reason,
+		"target_ids", decision.AgentIDs,
+		"target_count", len(decision.AgentIDs),
+	)
+	return filterAgentsByID(agents, decision.AgentIDs), decision
 }
 
-func selectCoordinatorID(activeIDs []string, edges []relationshipEdge) []string {
-	if len(activeIDs) <= 1 {
-		return append([]string(nil), activeIDs...)
+func selectWakeDecision(facts wakeRouteFacts) wakeRouteDecision {
+	if len(facts.ActiveIDs) == 0 {
+		return wakeRouteDecision{Reason: wakeReasonNoActiveAgent}
 	}
-	active := make(map[string]bool, len(activeIDs))
-	for _, id := range activeIDs {
-		active[id] = true
+	if len(facts.MentionedIDs) > 0 {
+		ids := intersectInOrder(facts.ActiveIDs, facts.MentionedIDs)
+		if len(ids) == 0 {
+			return wakeRouteDecision{Reason: wakeReasonUnresolvedMention}
+		}
+		return wakeRouteDecision{AgentIDs: ids, Reason: wakeReasonExplicitMention}
 	}
-	hasParent := map[string]bool{}
+	if facts.HasMentions {
+		return wakeRouteDecision{Reason: wakeReasonUnresolvedMention}
+	}
+
+	coordinatorID := uniqueCoordinatorID(facts.GraphNodeIDs, facts.Edges, facts.ActiveIDs)
+	if facts.Scope == wakeScopeThread {
+		participants := intersectPreferredOrder(facts.ThreadParticipantIDs, facts.ActiveIDs)
+		if len(participants) > 0 {
+			if containsID(participants, coordinatorID) {
+				return wakeRouteDecision{AgentIDs: []string{coordinatorID}, Reason: wakeReasonThreadCoordinator}
+			}
+			return wakeRouteDecision{AgentIDs: participants[:1], Reason: wakeReasonThreadRecentParticipant}
+		}
+		if containsID(facts.ActiveIDs, facts.ThreadRootAgentID) {
+			return wakeRouteDecision{AgentIDs: []string{facts.ThreadRootAgentID}, Reason: wakeReasonThreadRootAgent}
+		}
+		if coordinatorID != "" {
+			return wakeRouteDecision{AgentIDs: []string{coordinatorID}, Reason: wakeReasonThreadChannelCoordinator}
+		}
+		if recent := intersectPreferredOrder(facts.RecentActiveIDs, facts.ActiveIDs); len(recent) > 0 {
+			return wakeRouteDecision{AgentIDs: recent[:1], Reason: wakeReasonThreadRecentChannelAgent}
+		}
+		return wakeRouteDecision{AgentIDs: facts.ActiveIDs[:1], Reason: wakeReasonDeterministicFirst}
+	}
+
+	if coordinatorID != "" {
+		return wakeRouteDecision{AgentIDs: []string{coordinatorID}, Reason: wakeReasonUniqueCoordinator}
+	}
+	if len(facts.ActiveIDs) < wakeSmallTeamThreshold {
+		return wakeRouteDecision{AgentIDs: append([]string(nil), facts.ActiveIDs...), Reason: wakeReasonSmallTeamFanout}
+	}
+	if recent := intersectPreferredOrder(facts.RecentActiveIDs, facts.ActiveIDs); len(recent) > 0 {
+		return wakeRouteDecision{AgentIDs: recent, Reason: wakeReasonRecentWindow}
+	}
+	return wakeRouteDecision{AgentIDs: facts.ActiveIDs[:1], Reason: wakeReasonDeterministicFirst}
+}
+
+func uniqueCoordinatorID(nodeIDs []string, edges []relationshipEdge, activeIDs []string) string {
+	if len(edges) == 0 {
+		return ""
+	}
+	nodes := make(map[string]bool, len(nodeIDs))
+	for _, id := range nodeIDs {
+		if id != "" {
+			nodes[id] = true
+		}
+	}
+	if len(nodes) == 0 {
+		return ""
+	}
+
+	indegree := make(map[string]int, len(nodes))
+	adjacent := make(map[string][]string, len(nodes))
+	for id := range nodes {
+		indegree[id] = 0
+	}
 	for _, edge := range edges {
-		if active[edge.from] && active[edge.to] {
-			hasParent[edge.to] = true
+		if !nodes[edge.from] || !nodes[edge.to] {
+			continue
+		}
+		adjacent[edge.from] = append(adjacent[edge.from], edge.to)
+		indegree[edge.to]++
+	}
+
+	roots := make([]string, 0, 2)
+	for id, degree := range indegree {
+		if degree == 0 {
+			roots = append(roots, id)
 		}
 	}
+	if len(roots) != 1 {
+		return ""
+	}
+
+	queue := []string{roots[0]}
+	visited := 0
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		visited++
+		for _, next := range adjacent[id] {
+			indegree[next]--
+			if indegree[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+	if visited != len(nodes) || !containsID(activeIDs, roots[0]) {
+		return ""
+	}
+	return roots[0]
+}
+
+func relationshipGraphForActive(activeIDs []string, allEdges []relationshipEdge) ([]string, []relationshipEdge) {
+	reachable := make(map[string]bool, len(activeIDs))
 	for _, id := range activeIDs {
-		if !hasParent[id] {
-			return []string{id}
+		reachable[id] = true
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, edge := range allEdges {
+			if reachable[edge.from] && !reachable[edge.to] {
+				reachable[edge.to] = true
+				changed = true
+			}
+			if reachable[edge.to] && !reachable[edge.from] {
+				reachable[edge.from] = true
+				changed = true
+			}
 		}
 	}
-	return []string{activeIDs[0]}
+
+	nodes := append([]string(nil), activeIDs...)
+	seen := make(map[string]bool, len(reachable))
+	for _, id := range nodes {
+		seen[id] = true
+	}
+	edges := make([]relationshipEdge, 0, len(allEdges))
+	for _, edge := range allEdges {
+		if !reachable[edge.from] || !reachable[edge.to] {
+			continue
+		}
+		edges = append(edges, edge)
+		for _, id := range []string{edge.from, edge.to} {
+			if !seen[id] {
+				nodes = append(nodes, id)
+				seen[id] = true
+			}
+		}
+	}
+	return nodes, edges
+}
+
+func (s *AgentService) getWakeRelationshipEdges(ctx context.Context) ([]relationshipEdge, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT from_agent_id::text, to_agent_id::text
+		  FROM agent_relationships
+		 WHERE rel_type = 'assigns_to'
+		 ORDER BY created_at ASC, id ASC
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	edges := []relationshipEdge{}
+	for rows.Next() {
+		var edge relationshipEdge
+		if err := rows.Scan(&edge.from, &edge.to); err != nil {
+			return nil, err
+		}
+		edges = append(edges, edge)
+	}
+	return edges, rows.Err()
+}
+
+func (s *AgentService) getRecentChannelAgentIDs(ctx context.Context, channelID, excludeMessageID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		WITH recent AS (
+			SELECT m.id, m.sender_type, m.sender_id, m.mentioned_agent_ids,
+			       row_number() OVER (ORDER BY m.created_at DESC, m.id DESC) AS message_rank
+			  FROM messages m
+			 WHERE m.channel_id = $1
+			   AND m.thread_id IS NULL
+			   AND m.thinking_node_id IS NULL
+			   AND ($2 = '' OR m.id::text <> $2)
+			 ORDER BY m.created_at DESC, m.id DESC
+			 LIMIT $3
+		), involved AS (
+			SELECT sender_id AS agent_id, message_rank
+			  FROM recent
+			 WHERE sender_type = 'agent'
+			UNION ALL
+			SELECT unnest(COALESCE(mentioned_agent_ids, '{}'::uuid[])) AS agent_id, message_rank
+			  FROM recent
+			UNION ALL
+			SELECT t.claimer_id AS agent_id, recent.message_rank
+			  FROM recent
+			  JOIN tasks t ON t.message_id = recent.id
+			 WHERE t.claimer_id IS NOT NULL
+		)
+		SELECT agent_id::text
+		  FROM involved
+		 WHERE agent_id IS NOT NULL
+		 GROUP BY agent_id
+		 ORDER BY MIN(message_rank) ASC, agent_id::text ASC
+	`, channelID, excludeMessageID, wakeRecentWindowSize)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ids := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (s *AgentService) getThreadParticipantAgents(ctx context.Context, threadID string) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT participant.sender_id::text
+		  FROM (
+			SELECT DISTINCT ON (sender_id) sender_id, created_at, id
+			  FROM messages
+			 WHERE thread_id = $1 AND sender_type = 'agent'
+			 ORDER BY sender_id, created_at DESC, id DESC
+		  ) participant
+		 ORDER BY participant.created_at DESC, participant.id DESC, participant.sender_id ASC
+	`, threadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ids := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (s *AgentService) getThreadRootAgentSender(ctx context.Context, threadID string) (string, error) {
+	var senderID string
+	err := s.pool.QueryRow(ctx, `
+		SELECT COALESCE((
+			SELECT m.sender_id::text
+			  FROM messages m
+			  JOIN threads t ON t.root_message_id = m.id
+			 WHERE t.id = $1 AND m.sender_type = 'agent'
+		), '')
+	`, threadID).Scan(&senderID)
+	return senderID, err
+}
+
+func intersectInOrder(order, allowedIDs []string) []string {
+	allowed := make(map[string]bool, len(allowedIDs))
+	for _, id := range allowedIDs {
+		allowed[id] = true
+	}
+	result := make([]string, 0, len(order))
+	seen := make(map[string]bool, len(order))
+	for _, id := range order {
+		if allowed[id] && !seen[id] {
+			result = append(result, id)
+			seen[id] = true
+		}
+	}
+	return result
+}
+
+func intersectPreferredOrder(preferred, allowedIDs []string) []string {
+	return intersectInOrder(preferred, allowedIDs)
+}
+
+func excludeID(ids []string, excluded string) []string {
+	result := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id != excluded {
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
+func containsID(ids []string, target string) bool {
+	if target == "" {
+		return false
+	}
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/ws/hub.go
+++ b/internal/server/ws/hub.go
@@ -373,7 +373,6 @@ func (h *Hub) handleMessageSend(client *Client, payload MessageSendPayload) {
 		slog.Error("ws: failed to resolve mentions", "error", err, "user_id", client.userID)
 		// Non-fatal: continue without mentions
 		mentionedAgentIDs = nil
-		hasMentions = false
 	}
 
 	// Validate attachment ownership
@@ -594,7 +593,6 @@ func (h *Hub) handleThreadReply(client *Client, payload ThreadReplyPayload) {
 	if err != nil {
 		slog.Error("ws: failed to resolve mentions", "error", err, "user_id", client.userID)
 		mentionedAgentIDs = nil
-		hasMentions = false
 	}
 
 	// Validate attachment ownership


### PR DESCRIPTION
## Summary

- centralize Channel, Thread, and Task wake-target decisions in the existing Agent wake router
- keep Coordinator-first behavior while adding bounded small-team fan-out and PostgreSQL recent-window fallback when no unique Coordinator exists
- preserve Thread isolation and single-target fallback semantics
- make unresolved mentions consistently produce zero wakeups across REST, legacy WebSocket, Thread, and Task entry points
- add structured route reasons without adding persistence or frontend routing state

## Why

Wake selection was split between the router, Agent service, and handlers. Coordinator selection accepted ambiguous relationship graphs, Thread had its own routing implementation, and some request paths discarded the original `hasMentions` signal. As a result, invalid mentions could unexpectedly wake a Coordinator and routing failures were difficult to diagnose.

## Behavior and compatibility

- explicit Agent mentions still win
- a valid unique Coordinator remains the only target
- fewer than four active Agents fan out only when no unique Coordinator exists
- four or more active Agents use the prior 20 top-level PostgreSQL messages, then deterministically fall back to the first active Agent
- Thread fallback always selects one Agent and never imports parent Channel conversation context
- Task mention priority windows are unchanged; fallback fan-out relies on the existing PostgreSQL claim lock
- no migration, Inbox model, memory window store, routing result table, or new frontend state

## Validation

- `go test ./...`
- `go vet ./...`
- `npm run build`
- `npm run lint` — 0 errors; existing warnings only
- real PostgreSQL integration coverage for relationship graphs, recent-window selection, unresolved mentions, and Thread participants
- `make test-e2e-agent-scope-router` — real browser → REST → PostgreSQL → Router → Daemon → Claude Runtime → `solo message send` → persisted/UI-visible reply
