### PR TITLE
Sleep idle Agent sessions and resume on wake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ DAEMON_ID=daemon-01
 # this URL from SERVER_PORT.
 DAEMON_SERVER_URL=http://127.0.0.1:8080
 
+# Release idle provider processes while keeping their sessions resumable.
+AGENT_SESSION_IDLE_TTL=30m
+THINKING_SESSION_IDLE_TTL=30m
+SESSION_IDLE_SWEEP_INTERVAL=1m
+
 # ---- Logging ----
 # Log level: debug, info, warn, error
 LOG_LEVEL=debug

--- a/.env.production
+++ b/.env.production
@@ -54,6 +54,11 @@ DAEMON_ID=daemon-01
 # Server URL for daemon registration (internal Docker network address)
 DAEMON_SERVER_URL=http://server:8080
 
+# Release idle provider processes while keeping their sessions resumable.
+AGENT_SESSION_IDLE_TTL=30m
+THINKING_SESSION_IDLE_TTL=30m
+SESSION_IDLE_SWEEP_INTERVAL=1m
+
 # ---- Daemon Multi-Instance Configuration (optional) ----
 # To run multiple daemon instances, start additional containers with:
 #   DAEMON_ID=daemon-02  DAEMON_PORT=8082

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-scope-router test-e2e-send-freshness
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -44,6 +44,11 @@ test-e2e-agent-delivery: rebuild ## Rebuild and verify the real Agent result del
 
 test-e2e-agent-session-resume: rebuild ## Rebuild and verify real Channel Session restart continuity
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "resumes the same real Channel provider Session"
+
+test-e2e-agent-idle-resume: export AGENT_SESSION_IDLE_TTL=3s
+test-e2e-agent-idle-resume: export SESSION_IDLE_SWEEP_INTERVAL=1s
+test-e2e-agent-idle-resume: rebuild ## Rebuild and verify real Channel Agent idle sleep and wake
+	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 SOLO_E2E_EXPECT_AGENT_IDLE_REAPER=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "sleeps an idle Channel Agent"
 
 test-e2e-agent-scope-router: rebuild ## Rebuild and verify the real Coordinator-first Agent router
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "routes an unmentioned Channel message only to the unique Coordinator"

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -31,8 +31,9 @@ import (
 const backendFinalResultWaitAfter = 5 * time.Second
 
 const (
-	defaultThinkingSessionIdleTTL       = 30 * time.Minute
-	defaultThinkingSessionSweepInterval = time.Minute
+	defaultAgentSessionIdleTTL      = 30 * time.Minute
+	defaultThinkingSessionIdleTTL   = 30 * time.Minute
+	defaultSessionIdleSweepInterval = time.Minute
 )
 
 // agentTokenState holds a cached JWT for an agent plus its expiry.
@@ -53,8 +54,9 @@ type daemonHandler struct {
 	workspaceManager *agent.WorkspaceManager
 	memoryManager    *agent.MemoryManager
 	sessionManagers  map[string]*agent.AgentSessionManager // v1.4: per-provider persistent sessions
+	agentIdleTTL     time.Duration
 	thinkingIdleTTL  time.Duration
-	thinkingSweep    time.Duration
+	sessionIdleSweep time.Duration
 	shuttingDown     atomic.Bool
 
 	// v1.4: per-agent token store for persistent session token auto-refresh (SOLO-254-B).
@@ -77,8 +79,9 @@ func newDaemonHandler(pool *pgxpool.Pool, tm *taskManager, provider llm.Provider
 		workspaceManager: agent.NewWorkspaceManager(""),
 		memoryManager:    agent.NewMemoryManager(""),
 		agentTokens:      make(map[string]*agentTokenState),
+		agentIdleTTL:     durationFromEnv("AGENT_SESSION_IDLE_TTL", defaultAgentSessionIdleTTL),
 		thinkingIdleTTL:  durationFromEnv("THINKING_SESSION_IDLE_TTL", defaultThinkingSessionIdleTTL),
-		thinkingSweep:    durationFromEnv("THINKING_SESSION_SWEEP_INTERVAL", defaultThinkingSessionSweepInterval),
+		sessionIdleSweep: durationFromEnv("SESSION_IDLE_SWEEP_INTERVAL", durationFromEnv("THINKING_SESSION_SWEEP_INTERVAL", defaultSessionIdleSweepInterval)),
 	}
 }
 
@@ -111,17 +114,17 @@ func (h *daemonHandler) getSessionManager(providerType string) *agent.AgentSessi
 	return h.sessionManagers[providerType]
 }
 
-// activeSessionAgentIDs returns all agent IDs that have active persistent
-// sessions across all registered session managers. This is the source of
-// truth for which agents are "online" on this daemon.
-func (h *daemonHandler) activeSessionAgentIDs() []string {
+// cachedSessionAgentIDs returns all Agent IDs with a cached persistent session,
+// including idle sessions whose provider process is asleep. A resumable Agent
+// remains online and routable while its local process is released.
+func (h *daemonHandler) cachedSessionAgentIDs() []string {
 	if h.sessionManagers == nil {
 		return nil
 	}
 	seen := make(map[string]bool)
 	var ids []string
 	for _, sm := range h.sessionManagers {
-		for _, id := range sm.ActiveAgentIDs() {
+		for _, id := range sm.CachedAgentIDs() {
 			if !seen[id] {
 				seen[id] = true
 				ids = append(ids, id)
@@ -146,19 +149,27 @@ func (h *daemonHandler) activeThinkingNodeID(agentID string) (string, error) {
 	return nodeID, nil
 }
 
-// runThinkingSessionReaper releases only idle Thinking node processes. The
-// provider session ID remains in the session manager so the next turn resumes
-// the same conversation; ordinary Agent sessions are deliberately untouched.
-func (h *daemonHandler) runThinkingSessionReaper(ctx context.Context) {
-	ticker := time.NewTicker(h.thinkingSweep)
+// runSessionReaper releases idle provider processes while retaining their
+// session IDs so the next tracked turn resumes the same conversation.
+func (h *daemonHandler) runSessionReaper(ctx context.Context) {
+	ticker := time.NewTicker(h.sessionIdleSweep)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case now := <-ticker.C:
-			idleBefore := now.Add(-h.thinkingIdleTTL)
+			agentIdleBefore := now.Add(-h.agentIdleTTL)
+			thinkingIdleBefore := now.Add(-h.thinkingIdleTTL)
 			for provider, sm := range h.sessionManagers {
-				slept, err := sm.SleepIdleThinkingSessions(idleBefore)
+				slept, err := sm.SleepIdleAgentSessions(agentIdleBefore)
+				if err != nil {
+					slog.Warn("daemon: failed to sleep idle Agent sessions", "provider", provider, "error", err)
+				}
+				if slept > 0 {
+					slog.Info("daemon: slept idle Agent sessions", "provider", provider, "count", slept)
+				}
+
+				slept, err = sm.SleepIdleThinkingSessions(thinkingIdleBefore)
 				if err != nil {
 					slog.Warn("daemon: failed to sleep idle Thinking sessions", "provider", provider, "error", err)
 				}

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -170,7 +170,7 @@ func main() {
 	// Graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	go h.runThinkingSessionReaper(ctx)
+	go h.runSessionReaper(ctx)
 
 	go func() {
 		slog.Info("daemon server starting", "addr", srv.Addr)
@@ -354,7 +354,7 @@ func sendHeartbeat() {
 		MaxLoad:     10,
 		UptimeSec:   int64(time.Since(startTime).Seconds()),
 		ActiveTasks: taskMgr.ListActiveTasks(),
-		AgentIDs:    daemonH.activeSessionAgentIDs(),
+		AgentIDs:    daemonH.cachedSessionAgentIDs(),
 		SystemInfo:  collectSystemInfo(),
 		// Skills served on-demand via /internal/daemon/skills
 	}

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
 const credentials = { email: 'agent-result-delivery-e2e@solo.local', password: 'SoloE2E-2026!' };
+const daemonLogPath = join(process.cwd(), '..', 'daemon.log');
 
 interface AuthResponse {
   access_token: string;
@@ -46,6 +49,13 @@ interface ChannelSessionState {
   external_session_id: string;
   message_id: string;
   message_content: string;
+}
+
+interface AgentHeartbeatState {
+  agent_active: boolean;
+  computer_online: boolean;
+  heartbeat_has_agent: boolean;
+  heartbeat_epoch: number;
 }
 
 interface TaskRetryState {
@@ -194,6 +204,71 @@ function channelSessionState(triggerMessageID: string): ChannelSessionState {
        LIMIT 1
     ), '{"run_id":"","status":"","external_session_id":"","message_id":"","message_content":""}')
   `);
+}
+
+function triggerMessageID(channelID: string, content: string): string {
+  return databaseJSON<{ id: string }>(`
+    SELECT json_build_object('id', COALESCE((
+      SELECT id::text
+        FROM messages
+       WHERE channel_id = '${channelID}'
+         AND sender_type = 'user'
+         AND content = '${content}'
+       ORDER BY created_at DESC
+       LIMIT 1
+    ), ''))::text
+  `).id;
+}
+
+function agentHeartbeatState(agentID: string): AgentHeartbeatState {
+  return databaseJSON<AgentHeartbeatState>(`
+    SELECT json_build_object(
+      'agent_active', a.is_active,
+      'computer_online', EXISTS(SELECT 1 FROM computers c WHERE c.status = 'online'),
+      'heartbeat_has_agent', EXISTS(
+        SELECT 1 FROM computers c
+         WHERE c.status = 'online'
+           AND a.id = ANY(COALESCE(c.agent_ids, '{}'::uuid[]))
+      ),
+      'heartbeat_epoch', COALESCE((
+        SELECT MAX(EXTRACT(EPOCH FROM c.last_heartbeat))
+          FROM computers c
+         WHERE c.status = 'online'
+           AND a.id = ANY(COALESCE(c.agent_ids, '{}'::uuid[]))
+      ), 0)
+    )::text
+      FROM agents a
+     WHERE a.id = '${agentID}'
+  `);
+}
+
+function logLinesAfterRun(runID: string): string[] {
+  const lines = readFileSync(daemonLogPath, 'utf8').split('\n');
+  const completed = lines.findLastIndex((line) =>
+    line.includes('"msg":"task backend completed"') && line.includes(`"task_id":"${runID}"`));
+  return completed < 0 ? [] : lines.slice(completed + 1);
+}
+
+async function expectAgentSessionSleptAfterRun(runID: string, sessionKey: string, providerSessionID: string) {
+  await expect.poll(() => {
+    const lines = logLinesAfterRun(runID);
+    return lines.some((line) =>
+      line.includes('"msg":"session: sleeping idle Agent process"')
+      && line.includes(`"session_key":"${sessionKey}"`))
+      && lines.some((line) =>
+        line.includes('"msg":"claude: persistent session closed"')
+        && line.includes(`"session_id":"${providerSessionID}"`));
+  }, { timeout: 30000, intervals: [250, 500, 1000] }).toBe(true);
+}
+
+async function expectAgentSessionResumed(logOffset: number, sessionKey: string, providerSessionID: string) {
+  await expect.poll(() => {
+    const log = readFileSync(daemonLogPath, 'utf8').slice(logOffset);
+    return log.split('\n').some((line) =>
+      line.includes('"msg":"session: creating"')
+      && line.includes(`"session_key":"${sessionKey}"`)
+      && line.includes(`"resume":"${providerSessionID}"`));
+  }, { timeout: 30000, intervals: [250, 500, 1000] }).toBe(true);
 }
 
 function taskRetryState(taskID: string): TaskRetryState {
@@ -561,6 +636,97 @@ test.describe('real Agent result delivery contract', () => {
       const recalled = channelSessionState(recallMessage.id);
       await authenticatePage(page, auth);
       await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.locator(`[data-message-id="${recalled.message_id}"]`)).toContainText(`RECALLED ${secret}`);
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('sleeps an idle Channel Agent and resumes the same real provider Session', async ({ page, request }) => {
+    test.skip(process.env.SOLO_E2E_EXPECT_AGENT_IDLE_REAPER !== '1', 'requires a short-TTL daemon started through make rebuild');
+    test.setTimeout(360000);
+
+    const auth = await authenticate(request);
+    const suffix = `idle-${Date.now().toString(36)}`;
+    const secret = `IDLE_MEMORY_${suffix.toUpperCase()}`;
+    const rememberContent = `REMEMBER ${secret}`;
+    const recallContent = `RECALL ${suffix}`;
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `channel-idle-resume-e2e-${suffix}`,
+        description: 'Real Channel Agent idle sleep and wake E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Channel Idle Resume E2E ${suffix}`,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: [
+          'Always deliver replies with solo message send.',
+          'When introducing yourself, send exactly READY.',
+          'When a user message starts with REMEMBER followed by a value, retain it only in the current provider conversation and send exactly STORED.',
+          'When a user message starts with RECALL, send exactly RECALLED followed by the remembered value.',
+          'Never use message read, files, MEMORY.md, databases, or any other storage for REMEMBER or RECALL.',
+        ].join(' '),
+      });
+
+      await expect.poll(() => deliveryState(agent!.id).status, {
+        timeout: 180000, intervals: [500, 1000, 2000],
+      }).toBe('completed');
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      const composer = page.getByPlaceholder('Type a message...');
+      await expect(composer).toBeVisible();
+      await composer.fill(rememberContent);
+      await composer.press('Enter');
+
+      await expect.poll(() => triggerMessageID(channel!.id, rememberContent), {
+        timeout: 30000, intervals: [250, 500, 1000],
+      }).not.toBe('');
+      const rememberMessageID = triggerMessageID(channel.id, rememberContent);
+      await expect.poll(() => {
+        const state = channelSessionState(rememberMessageID);
+        return `${state.status}/${Boolean(state.external_session_id)}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('completed/true/STORED');
+      const first = channelSessionState(rememberMessageID);
+      await expect(page.locator(`[data-message-id="${first.message_id}"]`)).toContainText('STORED');
+
+      await expect.poll(() => {
+        const state = agentHeartbeatState(agent!.id);
+        return `${state.agent_active}/${state.computer_online}/${state.heartbeat_has_agent}`;
+      }, { timeout: 45000, intervals: [1000, 2000] }).toBe('true/true/true');
+      const heartbeatBeforeSleep = agentHeartbeatState(agent.id).heartbeat_epoch;
+      const sessionKey = `channel:${channel.id}:agent:${agent.id}`;
+
+      await expectAgentSessionSleptAfterRun(first.run_id, sessionKey, first.external_session_id);
+      await expect.poll(() => {
+        const state = agentHeartbeatState(agent!.id);
+        return state.agent_active
+          && state.computer_online
+          && state.heartbeat_has_agent
+          && state.heartbeat_epoch > heartbeatBeforeSleep;
+      }, { timeout: 45000, intervals: [1000, 2000] }).toBe(true);
+
+      const resumeLogOffset = readFileSync(daemonLogPath, 'utf8').length;
+      await composer.fill(recallContent);
+      await composer.press('Enter');
+      await expect.poll(() => triggerMessageID(channel!.id, recallContent), {
+        timeout: 30000, intervals: [250, 500, 1000],
+      }).not.toBe('');
+      const recallMessageID = triggerMessageID(channel.id, recallContent);
+      await expect.poll(() => {
+        const state = channelSessionState(recallMessageID);
+        return `${state.status}/${state.external_session_id}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${first.external_session_id}/RECALLED ${secret}`,
+      );
+
+      await expectAgentSessionResumed(resumeLogOffset, sessionKey, first.external_session_id);
+      const recalled = channelSessionState(recallMessageID);
       await expect(page.locator(`[data-message-id="${recalled.message_id}"]`)).toContainText(`RECALLED ${secret}`);
     } finally {
       if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);

--- a/internal/server/handler/computer.go
+++ b/internal/server/handler/computer.go
@@ -297,10 +297,10 @@ type ComputerAgentsResponse struct {
 // Returns agents persistently bound to this computer (via agents.runtime_id).
 // Only shows agents owned by the current user.
 //
-// Agent status is determined by heartbeat agent_ids (persistent session state):
-//   - "online"  — active persistent session on the daemon
-//   - "offline" — bound but no active session (or computer offline)
-//   - "running" — active session + currently executing a task
+// Agent status is determined by heartbeat agent_ids (persistent session cache):
+//   - "online"  — resumable persistent session on the daemon, awake or asleep
+//   - "offline" — bound but no cached session (or computer offline)
+//   - "running" — cached session + currently executing a task
 func (h *ComputerHandler) ListAgents(w http.ResponseWriter, r *http.Request) {
 	userID, ok := requireUserID(r)
 	if !ok {
@@ -325,7 +325,7 @@ func (h *ComputerHandler) ListAgents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Build lookup set from heartbeat agent_ids (persistent session state).
+	// Build lookup set from heartbeat agent_ids (resumable session cache).
 	sessionSet := make(map[string]struct{}, len(c.AgentIDs))
 	for _, id := range c.AgentIDs {
 		if id != "" {

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -14,9 +14,8 @@ import (
 const failedStartRetryInterval = 30 * time.Second
 
 // AgentSessionManager manages a pool of Agent and Thinking-node sessions.
-// Crash recovery is automatic via --resume, concurrent starts are rate-limited,
-// and callers may explicitly sleep idle Thinking sessions without affecting
-// ordinary Agent session lifetime.
+// Crash recovery and idle wake are automatic via provider resume, and
+// concurrent starts are rate-limited.
 type AgentSessionManager struct {
 	backend      PersistentBackend
 	workspaceMgr *WorkspaceManager
@@ -72,6 +71,12 @@ func (e *agentSessionEntry) updateSession(ps *PersistentSession) {
 	if sessionID != "" {
 		e.sessionID = sessionID
 	}
+	e.mu.Unlock()
+}
+
+func (e *agentSessionEntry) markActive() {
+	e.mu.Lock()
+	e.LastActive = time.Now()
 	e.mu.Unlock()
 }
 
@@ -203,9 +208,8 @@ func (m *AgentSessionManager) IsScopedActive(sessionKey string) bool {
 }
 
 // ActiveAgentIDs returns the IDs of all agents with an active (non-asleep,
-// process-alive) persistent session. This is used by the daemon heartbeat to
-// report which agents are "online" on this computer — distinct from the
-// task-level ActiveAgentIDs which only reports currently-executing tasks.
+// process-alive) persistent session. This is distinct from cached sessions and
+// from task-level ActiveAgentIDs, which only reports currently-executing tasks.
 func (m *AgentSessionManager) ActiveAgentIDs() []string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -215,6 +219,24 @@ func (m *AgentSessionManager) ActiveAgentIDs() []string {
 	for _, entry := range m.sessions {
 		_, asleep, _ := entry.snapshot()
 		if !asleep && m.isSessionAlive(entry) && !seen[entry.AgentID] {
+			seen[entry.AgentID] = true
+			ids = append(ids, entry.AgentID)
+		}
+	}
+	return ids
+}
+
+// CachedAgentIDs returns agents whose provider session is tracked by this
+// daemon, including sessions whose idle process has been released. Heartbeats
+// use this so an idle, resumable Agent is not reported as offline.
+func (m *AgentSessionManager) CachedAgentIDs() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	seen := make(map[string]bool)
+	var ids []string
+	for _, entry := range m.sessions {
+		if !seen[entry.AgentID] {
 			seen[entry.AgentID] = true
 			ids = append(ids, entry.AgentID)
 		}
@@ -242,10 +264,24 @@ func (m *AgentSessionManager) ForceCloseThinkingSession(nodeID string) error {
 // SleepIdleThinkingSessions gracefully releases idle node processes while
 // retaining their provider session IDs for the next --resume.
 func (m *AgentSessionManager) SleepIdleThinkingSessions(idleBefore time.Time) (int, error) {
+	return m.sleepIdleSessions(idleBefore, func(sessionKey string) bool {
+		return strings.HasPrefix(sessionKey, "thinking:")
+	}, "Thinking")
+}
+
+// SleepIdleAgentSessions gracefully releases idle Channel/DM Agent processes
+// while keeping their scoped provider sessions resumable.
+func (m *AgentSessionManager) SleepIdleAgentSessions(idleBefore time.Time) (int, error) {
+	return m.sleepIdleSessions(idleBefore, func(sessionKey string) bool {
+		return strings.HasPrefix(sessionKey, "agent:") || strings.HasPrefix(sessionKey, "channel:")
+	}, "Agent")
+}
+
+func (m *AgentSessionManager) sleepIdleSessions(idleBefore time.Time, matches func(string) bool, scope string) (int, error) {
 	m.mu.RLock()
 	keys := make([]string, 0)
 	for sessionKey := range m.sessions {
-		if strings.HasPrefix(sessionKey, "thinking:") {
+		if matches(sessionKey) {
 			keys = append(keys, sessionKey)
 		}
 	}
@@ -274,14 +310,18 @@ func (m *AgentSessionManager) SleepIdleThinkingSessions(idleBefore time.Time) (i
 			continue
 		}
 		ps := entry.Session
-		if ps.SessionID != "" {
-			entry.sessionID = ps.SessionID
+		resumeID := ps.SessionID
+		if state, ok := ps.state.(SessionStater); ok {
+			resumeID = firstNonEmpty(state.SessionID(), resumeID)
+		}
+		if resumeID != "" {
+			entry.sessionID = resumeID
 		}
 		entry.Session = nil
 		entry.asleep = true
 		entry.mu.Unlock()
 
-		m.logger.Info("session: sleeping idle Thinking process", "agent_id", entry.AgentID, "session_key", sessionKey)
+		m.logger.Info("session: sleeping idle "+scope+" process", "agent_id", entry.AgentID, "session_key", sessionKey)
 		if err := m.backend.Close(ps); err != nil && firstErr == nil {
 			firstErr = err
 		}
@@ -414,7 +454,10 @@ func (m *AgentSessionManager) deliverToSession(ctx context.Context, sessionKey s
 	}
 
 	entry.updateSession(ps)
-	holdTurnUntilResult(ps, release)
+	holdTurnUntilResult(ps, func() {
+		entry.markActive()
+		release()
+	})
 	releaseOnReturn = false
 	return ps, nil
 }
@@ -445,7 +488,10 @@ func (m *AgentSessionManager) createSession(ctx context.Context, sessionKey, age
 				return nil, fmt.Errorf("session backend returned a nil session for %s", sessionKey)
 			}
 			entry.updateSession(ps)
-			holdTurnUntilResult(ps, release)
+			holdTurnUntilResult(ps, func() {
+				entry.markActive()
+				release()
+			})
 			releaseOnReturn = false
 			return ps, nil
 		}
@@ -555,7 +601,10 @@ func (m *AgentSessionManager) createSession(ctx context.Context, sessionKey, age
 
 	state, _ := ps.state.(SessionStater)
 	go m.watchCrash(sessionKey, agentID, agentCfg, channelCtx, entry, state)
-	holdTurnUntilResult(ps, release)
+	holdTurnUntilResult(ps, func() {
+		entry.markActive()
+		release()
+	})
 	releaseOnReturn = false
 
 	// If the process died immediately (CLI broken/missing), record failure

--- a/pkg/agent/session_test.go
+++ b/pkg/agent/session_test.go
@@ -266,6 +266,63 @@ func TestSessionManagerSleepsOnlyIdleThinkingSessionsAndResumes(t *testing.T) {
 	}
 }
 
+func TestSessionManagerSleepsIdleAgentSessionAndResumes(t *testing.T) {
+	backend := &scopedRecordingBackend{}
+	mgr := NewAgentSessionManager(backend, NewWorkspaceManager(t.TempDir()), nil, slog.Default())
+	cfg := AgentConfig{AgentID: "agent-1", Name: "Agent", Provider: "claude"}
+	sessionKey := ChannelSessionKey("agent-1", "channel-1")
+
+	first, err := mgr.GetOrCreateScopedSession(context.Background(), sessionKey, "agent-1", cfg, ChannelContext{}, []Message{{Role: RoleUser, Content: "first"}}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("start Agent session: %v", err)
+	}
+	if result := <-first.Result; result == nil || result.Status != "completed" {
+		t.Fatalf("Agent result = %#v", result)
+	}
+	waitForScopedTurnRelease(t, mgr, sessionKey)
+
+	mgr.mu.RLock()
+	entry := mgr.sessions[sessionKey]
+	mgr.mu.RUnlock()
+	entry.mu.Lock()
+	entry.LastActive = time.Now().Add(-time.Hour)
+	entry.mu.Unlock()
+
+	slept, err := mgr.SleepIdleAgentSessions(time.Now().Add(-30 * time.Minute))
+	if err != nil {
+		t.Fatalf("sleep idle Agent sessions: %v", err)
+	}
+	if slept != 1 || mgr.IsScopedActive(sessionKey) {
+		t.Fatalf("slept = %d active = %v, want 1/false", slept, mgr.IsScopedActive(sessionKey))
+	}
+	if ids := mgr.ActiveAgentIDs(); len(ids) != 0 {
+		t.Fatalf("ActiveAgentIDs = %v, want no live process", ids)
+	}
+	if ids := mgr.CachedAgentIDs(); len(ids) != 1 || ids[0] != "agent-1" {
+		t.Fatalf("CachedAgentIDs = %v, want resumable agent-1", ids)
+	}
+
+	resumed, err := mgr.GetOrCreateScopedSession(context.Background(), sessionKey, "agent-1", cfg, ChannelContext{}, []Message{{Role: RoleUser, Content: "continue"}}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("resume Agent session: %v", err)
+	}
+	if result := <-resumed.Result; result == nil || result.Status != "completed" {
+		t.Fatalf("resumed result = %#v", result)
+	}
+	if resumed.SessionID != first.SessionID {
+		t.Fatalf("resumed SessionID = %q, want %q", resumed.SessionID, first.SessionID)
+	}
+
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if backend.closeCount != 1 || len(backend.startOptions) != 2 {
+		t.Fatalf("close/start counts = %d/%d, want 1/2", backend.closeCount, len(backend.startOptions))
+	}
+	if backend.startOptions[1].ResumeSessionID != first.SessionID {
+		t.Fatalf("resume ID = %q, want %q", backend.startOptions[1].ResumeSessionID, first.SessionID)
+	}
+}
+
 func TestSessionManagerUsesProtocolResumeWithoutInjectingCLIFlag(t *testing.T) {
 	backend := &scopedRecordingBackend{}
 	mgr := NewAgentSessionManager(backend, NewWorkspaceManager(t.TempDir()), nil, slog.Default())
@@ -360,6 +417,47 @@ func TestSessionManagerDoesNotSleepThinkingSessionWithActiveTurn(t *testing.T) {
 		t.Fatal("active Thinking turn was closed")
 	}
 	backend.finishStart()
+}
+
+func TestSessionManagerDoesNotSleepAgentSessionWithActiveTurn(t *testing.T) {
+	backend := newEarlyReturnBackend()
+	mgr := NewAgentSessionManager(backend, NewWorkspaceManager(t.TempDir()), nil, slog.Default())
+	sessionKey := ChannelSessionKey("agent-1", "channel-1")
+
+	_, err := mgr.GetOrCreateScopedSession(context.Background(), sessionKey, "agent-1", AgentConfig{
+		AgentID: "agent-1", Name: "Agent", Provider: "claude",
+	}, ChannelContext{}, []Message{{Role: RoleUser, Content: "working"}}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("start Agent session: %v", err)
+	}
+	mgr.mu.RLock()
+	entry := mgr.sessions[sessionKey]
+	mgr.mu.RUnlock()
+	old := time.Now().Add(-time.Hour)
+	entry.mu.Lock()
+	entry.LastActive = old
+	entry.mu.Unlock()
+
+	slept, err := mgr.SleepIdleAgentSessions(time.Now().Add(-30 * time.Minute))
+	if err != nil {
+		t.Fatalf("sleep idle Agent sessions: %v", err)
+	}
+	if slept != 0 || !mgr.IsScopedActive(sessionKey) {
+		t.Fatalf("slept = %d active = %v, want 0/true", slept, mgr.IsScopedActive(sessionKey))
+	}
+
+	backend.finishStart()
+	waitForScopedTurnRelease(t, mgr, sessionKey)
+	entry.mu.RLock()
+	lastActive := entry.LastActive
+	entry.mu.RUnlock()
+	if !lastActive.After(old) {
+		t.Fatalf("LastActive = %v, want turn completion after %v", lastActive, old)
+	}
+	slept, err = mgr.SleepIdleAgentSessions(time.Now().Add(-time.Minute))
+	if err != nil || slept != 0 {
+		t.Fatalf("freshly completed Agent sleep = %d, %v, want 0/nil", slept, err)
+	}
 }
 
 func waitForScopedTurnRelease(t *testing.T, mgr *AgentSessionManager, sessionKey string) {


### PR DESCRIPTION
## Summary

- release idle Channel and DM Agent provider processes while preserving resumable Session IDs
- keep sleeping Agents present in daemon heartbeats so they remain online and routable
- update last activity when a turn actually completes and never sleep an active turn
- add configurable Agent/Thinking idle TTLs and a shared sweep interval
- add real browser-to-PostgreSQL-to-Claude sleep/resume coverage

## Why

Ordinary persistent Agent sessions previously kept their provider CLI process alive indefinitely after use. This accumulated local processes and memory as Agents participated in more Channels. Solo already had the required sleep/resume primitives for Thinking sessions, so this extends the existing SessionManager instead of adding a parallel lifecycle system.

## Compatibility

- no database migration or new API
- Router, Thread, Task, DM, and visible UI behavior remain unchanged
- sleeping Agents remain enabled and routable
- existing Thinking idle lifecycle remains supported

## Validation

- `go test ./...`
- `go test -race ./pkg/agent`
- `npm run lint` (0 errors; existing warnings only)
- `make test-e2e-agent-idle-resume` — real frontend, API server, PostgreSQL, daemon, and local Claude runtime; 1 passed in 1.2m
