### PR TITLE
Bind Agent runs to their computer daemon

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -160,7 +160,7 @@ func main() {
 
 	// SSE requires long-lived connections — no write timeout.
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%s", port),
+		Addr:         net.JoinHostPort("127.0.0.1", port),
 		Handler:      r,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 0, // 0 = no timeout (needed for SSE streaming)

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -25,6 +25,8 @@ interface TaskEntity {
 
 interface DeliveryState {
   run_id: string;
+  daemon_id: string;
+  bound_daemon_id: string;
   status: string;
   contract: string;
   message_id: string;
@@ -106,6 +108,13 @@ function deliveryState(agentID: string): DeliveryState {
     SELECT COALESCE((
       SELECT json_build_object(
         'run_id', r.id::text,
+        'daemon_id', COALESCE(r.daemon_id, ''),
+        'bound_daemon_id', COALESCE((
+          SELECT c.daemon_id
+            FROM agents a
+            JOIN computers c ON c.id::text = a.runtime_id
+           WHERE a.id = r.agent_id
+        ), ''),
         'status', r.status,
         'contract', COALESCE((
           SELECT e.payload->>'result_contract'
@@ -136,7 +145,7 @@ function deliveryState(agentID: string): DeliveryState {
         ), '')
       )::text
       FROM latest r
-    ), '{"run_id":"","status":"","contract":"","message_id":"","visible_event":false,"input_tokens":0,"output_tokens":0,"failure_code":""}')
+    ), '{"run_id":"","daemon_id":"","bound_daemon_id":"","status":"","contract":"","message_id":"","visible_event":false,"input_tokens":0,"output_tokens":0,"failure_code":""}')
   `);
 }
 
@@ -385,6 +394,8 @@ test.describe('real Agent result delivery contract', () => {
 
       const state = deliveryState(agent.id);
       expect(state.input_tokens + state.output_tokens).toBeGreaterThan(0);
+      expect(state.daemon_id).not.toBe('');
+      expect(state.daemon_id).toBe(state.bound_daemon_id);
 
       await authenticatePage(page, auth);
       await page.goto(`/dashboard?channel=${channel.id}`);

--- a/internal/server/handler/agent.go
+++ b/internal/server/handler/agent.go
@@ -590,14 +590,13 @@ func (h *AgentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Disconnect from any computer that had this agent in its connected list.
-	// Capture the daemon URL before array_remove strips this agent from
-	// agent_ids — once we leave the transaction, no computer row references
-	// this agent, and we need the URL to tell the daemon to drop the session,
-	// workspace, and memory.
+	// Capture the bound daemon before disconnecting the Agent.
 	var daemonURL string
 	err = tx.QueryRow(r.Context(),
-		`SELECT COALESCE(daemon_url, '') FROM computers WHERE $1::uuid = ANY(agent_ids) LIMIT 1`,
+		`SELECT COALESCE(c.daemon_url, '')
+		   FROM agents a
+		   LEFT JOIN computers c ON c.id::text = a.runtime_id
+		  WHERE a.id = $1`,
 		agentID,
 	).Scan(&daemonURL)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
@@ -639,9 +638,7 @@ func (h *AgentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 }
 
 // notifyDaemonCleanup asks the given daemon to drop the agent's session,
-// workspace, and memory. daemonURL is captured inside the Delete transaction
-// before array_remove strips the agent from computers.agent_ids — querying
-// afterwards would always return no rows.
+// workspace, and memory. daemonURL is captured inside the Delete transaction.
 //
 // Best-effort: errors are logged, never surfaced to the user — the soft-delete
 // already succeeded.

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -226,10 +226,9 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 		newChain := append([]string(nil), agentChain...)
 		newChain = append(newChain, ag.ID)
 
-		// Select a daemon that supports this agent's model provider
-		daemon := s.dm.SelectDaemon("llm")
-		if daemon == nil {
-			slog.Warn("no available daemon for agent task", "agent_id", ag.ID)
+		daemon, err := s.dm.ResolveDaemonForAgent(ctx, ag.ID, "llm")
+		if err != nil {
+			slog.Warn("no available daemon for agent task", "agent_id", ag.ID, "error", err)
 			s.broadcastAgentError("", channelID, ag.ID, ag.Name, agentErrorNoAvailableDaemon)
 			continue
 		}
@@ -381,8 +380,8 @@ func (s *AgentService) triggerAgentResponseInNode(ctx context.Context, channelID
 			continue
 		}
 		newChain := append(append([]string(nil), agentChain...), ag.ID)
-		daemon := s.dm.SelectDaemon("llm")
-		if daemon == nil {
+		daemon, err := s.dm.ResolveDaemonForAgent(ctx, ag.ID, "llm")
+		if err != nil {
 			s.broadcastAgentError("", channelID, ag.ID, ag.Name, agentErrorNoAvailableDaemon)
 			if handoffRun {
 				return errors.New("no available local Agent daemon")
@@ -632,6 +631,7 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 		var err error
 		run, err = runSvc.StartRun(ctx, StartRunInput{
 			AgentID:          ag.ID,
+			DaemonID:         daemon.ID,
 			TriggerType:      triggerType,
 			TriggerMessageID: taskReq.TriggerMessageID,
 			ChannelID:        taskReq.ChannelID,
@@ -1215,13 +1215,13 @@ func (s *AgentService) StartAgentRunWatchdogLoop(ctx context.Context) {
 	}
 }
 
-// ReconcileDaemonRuns converges PostgreSQL Run state with the one local
-// daemon's in-memory task list after either process restarts.
+// ReconcileDaemonRuns converges PostgreSQL Run state with this daemon's
+// in-memory task list after either process restarts.
 func (s *AgentService) ReconcileDaemonRuns(ctx context.Context, daemon *DaemonInfo, taskIDs []string) {
 	if daemon == nil {
 		return
 	}
-	runs, err := NewAgentRunService(s.pool).ListActiveRuns(ctx)
+	runs, err := NewAgentRunService(s.pool).ListActiveRunsByDaemon(ctx, daemon.ID)
 	if err != nil {
 		slog.Warn("failed to list active runs for daemon reconciliation", "daemon_id", daemon.ID, "error", err)
 		return
@@ -1479,7 +1479,15 @@ func (s *AgentService) timeoutStaleQueuedAgentRun(ctx context.Context, runSvc *A
 
 func (s *AgentService) finishTimedOutAgentRun(ctx context.Context, runSvc *AgentRunService, run *AgentRun, activity string) error {
 	retryable := false
-	if daemon := s.dm.SelectDaemon("llm"); daemon != nil {
+	var daemon *DaemonInfo
+	if daemonID, err := runSvc.GetRunDaemonID(ctx, run.ID); err == nil && daemonID != "" {
+		if candidate, ok := s.dm.GetDaemon(daemonID); ok && candidate.Status == DaemonStatusOnline {
+			daemon = candidate
+		}
+	} else if err == nil {
+		daemon, _ = s.dm.ResolveDaemonForAgent(ctx, run.AgentID, "")
+	}
+	if daemon != nil {
 		if err := s.dm.CancelTask(ctx, daemon, run.ID); err != nil {
 			slog.Warn("failed to stop timed out daemon task", "run_id", run.ID, "error", err)
 		} else {
@@ -1969,8 +1977,8 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 		newChain := append([]string(nil), agentChain...)
 		newChain = append(newChain, ag.ID)
 
-		daemon := s.dm.SelectDaemon("llm")
-		if daemon == nil {
+		daemon, err := s.dm.ResolveDaemonForAgent(ctx, ag.ID, "llm")
+		if err != nil {
 			slog.Warn("no available daemon for thread agent task", "agent_id", ag.ID)
 			s.broadcastAgentError(threadID, channelID, ag.ID, ag.Name, agentErrorNoAvailableDaemon)
 			continue
@@ -2143,9 +2151,8 @@ func (s *AgentService) TriggerAgentForTask(ctx context.Context, channelID, taskI
 		)
 	}
 
-	// Select daemon
-	daemon := s.dm.SelectDaemon("llm")
-	if daemon == nil {
+	daemon, err := s.dm.ResolveDaemonForAgent(ctx, ag.ID, "llm")
+	if err != nil {
 		slog.Warn("no available daemon for task agent trigger", "agent_id", ag.ID, "task_id", taskID)
 		s.broadcastAgentError(threadID, channelID, ag.ID, ag.Name, agentErrorNoAvailableDaemon)
 		return false
@@ -2268,8 +2275,8 @@ func (s *AgentService) TriggerAgentForArtifact(ctx context.Context, task *Task, 
 		}
 	}
 
-	daemon := s.dm.SelectDaemon("llm")
-	if daemon == nil {
+	daemon, err := s.dm.ResolveDaemonForAgent(ctx, ag.ID, "llm")
+	if err != nil {
 		return fmt.Errorf("no available daemon for artifact agent trigger")
 	}
 

--- a/internal/server/service/agent_helpers.go
+++ b/internal/server/service/agent_helpers.go
@@ -54,9 +54,9 @@ func (s *AgentService) TriggerAgentGreeting(ctx context.Context, channelID, agen
 		channelID,
 	).Scan(&channelName)
 
-	daemon := s.dm.SelectDaemon("llm")
-	if daemon == nil {
-		slog.Warn("TriggerAgentGreeting: no available daemon", "agent_id", agentID)
+	daemon, err := s.dm.ResolveDaemonForAgent(ctx, agentID, "llm")
+	if err != nil {
+		slog.Warn("TriggerAgentGreeting: no available daemon", "agent_id", agentID, "error", err)
 		return
 	}
 

--- a/internal/server/service/agent_p0_test.go
+++ b/internal/server/service/agent_p0_test.go
@@ -349,8 +349,10 @@ func TestDaemonReconcileFailsTrackedRunMissingFromNewProcess(t *testing.T) {
 	})
 
 	runSvc := NewAgentRunService(pool)
+	daemonID := "daemon-" + agentID[:8]
 	run, err := runSvc.StartRun(ctx, StartRunInput{
 		AgentID:      agentID,
+		DaemonID:     daemonID,
 		TriggerType:  AgentRunTriggerMessage,
 		ChannelID:    channelID,
 		Status:       AgentRunStatusThinking,
@@ -359,10 +361,20 @@ func TestDaemonReconcileFailsTrackedRunMissingFromNewProcess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartRun: %v", err)
 	}
+	foreignRun, err := runSvc.StartRun(ctx, StartRunInput{
+		AgentID:      agentID,
+		DaemonID:     "another-daemon",
+		TriggerType:  AgentRunTriggerMessage,
+		ChannelID:    channelID,
+		Status:       AgentRunStatusThinking,
+		ActivityText: agentActivityAccepted,
+	})
+	if err != nil {
+		t.Fatalf("StartRun on another daemon: %v", err)
+	}
 
 	rec := newRecordingBroadcaster()
 	dm := NewDaemonManager(pool, rec)
-	daemonID := "daemon-" + agentID[:8]
 	daemon := &DaemonInfo{ID: daemonID, Host: "127.0.0.1", Port: 1, Capabilities: []string{"agent"}}
 	dm.Register(daemon)
 	dm.TrackTask(run.ID, daemonID, agentID)
@@ -377,6 +389,12 @@ func TestDaemonReconcileFailsTrackedRunMissingFromNewProcess(t *testing.T) {
 	}
 	if status != string(AgentRunStatusFailed) {
 		t.Fatalf("status = %q, want failed", status)
+	}
+	if err := pool.QueryRow(ctx, `SELECT status FROM agent_runs WHERE id = $1`, foreignRun.ID).Scan(&status); err != nil {
+		t.Fatalf("query foreign run: %v", err)
+	}
+	if status != string(AgentRunStatusThinking) {
+		t.Fatalf("foreign run status = %q, want thinking", status)
 	}
 	if !rec.hasBroadcastEvent("agent.run.finished", agentActivityDaemonLost) {
 		t.Fatalf("reconcile daemon-lost finish not broadcast: %q", rec.broadcastMessages)

--- a/internal/server/service/agent_retry.go
+++ b/internal/server/service/agent_retry.go
@@ -211,7 +211,7 @@ func (s *AgentService) retryTaskRun(ctx context.Context, failed retryableTaskRun
 		}
 		return err
 	}
-	if s.dm.SelectDaemon("llm") == nil {
+	if _, err := s.dm.ResolveDaemonForAgent(ctx, nextAgentID, "llm"); err != nil {
 		return nil
 	}
 

--- a/internal/server/service/agent_run.go
+++ b/internal/server/service/agent_run.go
@@ -157,6 +157,7 @@ type UpdateSessionMetadataInput struct {
 
 type StartRunInput struct {
 	AgentID          string
+	DaemonID         string
 	SessionID        string
 	TriggerType      string
 	TriggerMessageID string
@@ -305,9 +306,9 @@ func (s *AgentRunService) StartRun(ctx context.Context, input StartRunInput) (*A
 	}
 	return scanAgentRun(s.pool.QueryRow(ctx,
 		`INSERT INTO agent_runs (
-		   id, agent_id, session_id, trigger_type, trigger_message_id, channel_id, thread_id, thinking_node_id,
+		   id, agent_id, daemon_id, session_id, trigger_type, trigger_message_id, channel_id, thread_id, thinking_node_id,
 		   status, activity_text, tool_name, tool_input_summary, source, usage_json, freshness_seen_seq
-		 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+		 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		 RETURNING id::text, agent_id::text,
 		       COALESCE((SELECT name FROM agents WHERE id = agent_runs.agent_id), ''),
 		       COALESCE(session_id::text, ''), trigger_type,
@@ -315,7 +316,7 @@ func (s *AgentRunService) StartRun(ctx context.Context, input StartRunInput) (*A
 		       COALESCE(thread_id::text, ''), COALESCE(thinking_node_id::text, ''), status, activity_text, COALESCE(tool_name, ''),
 		       COALESCE(tool_input_summary, ''), COALESCE(source, ''), COALESCE(transcript_path, ''), usage_json,
 		       started_at, backend_started_at, updated_at, finished_at`,
-		uuid.NewString(), input.AgentID, nullableUUID(input.SessionID), input.TriggerType,
+		uuid.NewString(), input.AgentID, nullableStr(input.DaemonID), nullableUUID(input.SessionID), input.TriggerType,
 		nullableUUID(input.TriggerMessageID), nullableUUID(input.ChannelID), nullableUUID(input.ThreadID), nullableUUID(input.ThinkingNodeID),
 		string(input.Status), input.ActivityText, nullableStr(input.ToolName),
 		nullableStr(input.ToolInputSummary), nullableStr(input.Source), usage, nullableInt64(input.FreshnessSeenSeq),
@@ -548,6 +549,19 @@ func (s *AgentRunService) ListActiveRuns(ctx context.Context) ([]AgentRun, error
 			string(AgentRunStatusWaitingApproval),
 		},
 	))
+}
+
+func (s *AgentRunService) ListActiveRunsByDaemon(ctx context.Context, daemonID string) ([]AgentRun, error) {
+	return scanAgentRuns(s.pool.Query(ctx, baseAgentRunSelect()+`
+		 WHERE r.status = ANY($1) AND r.daemon_id = $2
+		 ORDER BY r.updated_at DESC
+		 LIMIT 100`, activeAgentRunStatuses(), daemonID))
+}
+
+func (s *AgentRunService) GetRunDaemonID(ctx context.Context, runID string) (string, error) {
+	var daemonID string
+	err := s.pool.QueryRow(ctx, `SELECT COALESCE(daemon_id, '') FROM agent_runs WHERE id = $1`, runID).Scan(&daemonID)
+	return daemonID, err
 }
 
 // ResolveExecutingThinkingNode returns the node scope of the single Agent turn

--- a/internal/server/service/agent_run_test.go
+++ b/internal/server/service/agent_run_test.go
@@ -61,6 +61,7 @@ func TestAgentRunServiceLifecycle(t *testing.T) {
 
 	run, err := svc.StartRun(ctx, StartRunInput{
 		AgentID:          agentID,
+		DaemonID:         "daemon-agent-run-test",
 		TriggerType:      AgentRunTriggerMessage,
 		TriggerMessageID: messageID,
 		ChannelID:        channelID,
@@ -77,6 +78,14 @@ func TestAgentRunServiceLifecycle(t *testing.T) {
 	}
 	if run.SessionID != "" {
 		t.Fatalf("run session_id = %q, want empty before provider session is known", run.SessionID)
+	}
+	daemonID, err := svc.GetRunDaemonID(ctx, run.ID)
+	if err != nil || daemonID != "daemon-agent-run-test" {
+		t.Fatalf("run daemon_id = %q, %v", daemonID, err)
+	}
+	activeOnDaemon, err := svc.ListActiveRunsByDaemon(ctx, daemonID)
+	if err != nil || !agentRunListContains(activeOnDaemon, run.ID) {
+		t.Fatalf("active runs for daemon = %#v, %v", activeOnDaemon, err)
 	}
 	run, err = svc.BindRunSession(ctx, BindRunSessionInput{
 		RunID:     run.ID,

--- a/internal/server/service/daemon.go
+++ b/internal/server/service/daemon.go
@@ -310,6 +310,74 @@ func (dm *DaemonManager) SelectDaemon(capability string) *DaemonInfo {
 	return best
 }
 
+// ResolveDaemonForAgent returns the daemon owned by the Agent's persisted
+// computer binding. Legacy unbound Agents remain supported only when there is
+// exactly one usable daemon, so adding a second computer cannot silently move
+// their work.
+func (dm *DaemonManager) ResolveDaemonForAgent(ctx context.Context, agentID, capability string) (*DaemonInfo, error) {
+	if dm.pool == nil {
+		if daemon := dm.SelectDaemon(capability); daemon != nil {
+			return daemon, nil
+		}
+		return nil, fmt.Errorf("no available daemon for agent %s", agentID)
+	}
+
+	var runtimeID, daemonID string
+	err := dm.pool.QueryRow(ctx, `
+		SELECT COALESCE(a.runtime_id, ''), COALESCE(c.daemon_id, '')
+		  FROM agents a
+		  LEFT JOIN computers c ON c.id::text = a.runtime_id
+		 WHERE a.id = $1`, agentID,
+	).Scan(&runtimeID, &daemonID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve agent computer: %w", err)
+	}
+	if runtimeID != "" {
+		if daemonID == "" {
+			return nil, fmt.Errorf("agent %s is bound to computer %s without a daemon", agentID, runtimeID)
+		}
+		daemon, ok := dm.GetDaemon(daemonID)
+		if !ok || !daemonUsable(daemon, capability) {
+			return nil, fmt.Errorf("agent %s daemon %s is unavailable", agentID, daemonID)
+		}
+		return daemon, nil
+	}
+
+	var only *DaemonInfo
+	for _, daemon := range dm.ListDaemons() {
+		if !daemonUsable(daemon, capability) {
+			continue
+		}
+		if only != nil {
+			return nil, fmt.Errorf("agent %s has no computer binding and multiple daemons are available", agentID)
+		}
+		only = daemon
+	}
+	if only == nil {
+		return nil, fmt.Errorf("no available daemon for agent %s", agentID)
+	}
+	if _, err := dm.pool.Exec(ctx, `
+		UPDATE agents a
+		   SET runtime_id = c.id::text, updated_at = now()
+		  FROM computers c
+		 WHERE a.id = $1
+		   AND a.runtime_id IS NULL
+		   AND c.daemon_id = $2`, agentID, only.ID); err != nil {
+		return nil, fmt.Errorf("persist agent computer binding: %w", err)
+	}
+	return only, nil
+}
+
+func daemonUsable(daemon *DaemonInfo, capability string) bool {
+	if daemon == nil || daemon.Status != DaemonStatusOnline {
+		return false
+	}
+	if capability == "" {
+		return true
+	}
+	return daemon.CurrentLoad < int32(daemon.MaxConcurrent) && hasCapability(daemon.Capabilities, capability)
+}
+
 // SendTask dispatches a task to a specific daemon via HTTP.
 func (dm *DaemonManager) SendTask(ctx context.Context, daemon *DaemonInfo, req interface{}) ([]byte, error) {
 	url := fmt.Sprintf("http://%s:%d/internal/daemon/run", daemon.Host, daemon.Port)
@@ -385,35 +453,36 @@ func (dm *DaemonManager) CleanupThinkingSessions(ctx context.Context, nodeIDs []
 }
 
 // CleanupAgents force-closes every scoped runtime session for the supplied
-// Agents and removes their local runtime state. It is idempotent and fans out
-// because runtime affinity is not durable.
+// Agents and removes their local runtime state from their bound daemon.
 func (dm *DaemonManager) CleanupAgents(ctx context.Context, agentIDs []string) error {
 	var firstErr error
-	for _, daemon := range dm.ListDaemons() {
-		if daemon.Status != DaemonStatusOnline {
+	for _, agentID := range agentIDs {
+		daemon, err := dm.ResolveDaemonForAgent(ctx, agentID, "")
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
-		for _, agentID := range agentIDs {
-			url := fmt.Sprintf("http://%s:%d/internal/daemon/agents/%s/cleanup", daemon.Host, daemon.Port, agentID)
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
-			if err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
+		url := fmt.Sprintf("http://%s:%d/internal/daemon/agents/%s/cleanup", daemon.Host, daemon.Port, agentID)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
 			}
-			resp, err := dm.httpClient.Do(req)
-			if err != nil {
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
+			continue
+		}
+		resp, err := dm.httpClient.Do(req)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
 			}
-			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64*1024))
-			resp.Body.Close()
-			if resp.StatusCode != http.StatusNoContent && firstErr == nil {
-				firstErr = fmt.Errorf("daemon %s returned status %d while cleaning agent %s", daemon.ID, resp.StatusCode, agentID)
-			}
+			continue
+		}
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 64*1024))
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNoContent && firstErr == nil {
+			firstErr = fmt.Errorf("daemon %s returned status %d while cleaning agent %s", daemon.ID, resp.StatusCode, agentID)
 		}
 	}
 	return firstErr
@@ -555,24 +624,13 @@ func (dm *DaemonManager) CancelTask(ctx context.Context, daemon *DaemonInfo, tas
 
 // ---- workspace.Proxy implementation ----
 
-// FindDaemonForAgent finds an online daemon that can serve workspace files.
-// TODO: implement agent-to-daemon affinity when persistent agent-daemon
-// assignment is available. Currently returns the first online daemon,
-// which is correct for single-daemon deployments.
+// FindDaemonForAgent finds the Agent's bound online daemon for workspace files.
 func (dm *DaemonManager) FindDaemonForAgent(ctx context.Context, agentID string) (*workspace.Daemon, bool) {
-	dm.mu.RLock()
-	defer dm.mu.RUnlock()
-
-	for _, d := range dm.daemons {
-		if d.Status != DaemonStatusOnline {
-			continue
-		}
-		return &workspace.Daemon{
-			Host: d.Host,
-			Port: d.Port,
-		}, true
+	daemon, err := dm.ResolveDaemonForAgent(ctx, agentID, "")
+	if err != nil {
+		return nil, false
 	}
-	return nil, false
+	return &workspace.Daemon{Host: daemon.Host, Port: daemon.Port}, true
 }
 
 // ProxyWorkspaceList sends a workspace list request to a daemon.

--- a/internal/server/service/daemon_lifecycle_test.go
+++ b/internal/server/service/daemon_lifecycle_test.go
@@ -1,8 +1,11 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestPendingTaskTimeoutsUseCurrentLifecyclePhase(t *testing.T) {
@@ -40,5 +43,65 @@ func TestPendingTaskTimeoutsUseCurrentLifecyclePhase(t *testing.T) {
 	}
 	if _, ok := dm.pendingTasks["fresh-queue"]; !ok {
 		t.Fatal("fresh queued task was removed by execution timeout")
+	}
+}
+
+func TestResolveDaemonForAgentUsesComputerBinding(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	computerA, computerB := uuid.NewString(), uuid.NewString()
+	var homeChannelID string
+	if err := pool.QueryRow(ctx, `SELECT home_channel_id::text FROM agents WHERE id = $1`, agentID).Scan(&homeChannelID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM computers WHERE id = ANY($1::uuid[])`, []string{computerA, computerB})
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, homeChannelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO computers (id, name, owner_id, daemon_id, status)
+		VALUES ($1, 'computer-a', $3, 'daemon-a', 'online'),
+		       ($2, 'computer-b', $3, 'daemon-b', 'online')`, computerA, computerB, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE agents SET runtime_id = $2 WHERE id = $1`, agentID, computerA); err != nil {
+		t.Fatal(err)
+	}
+
+	dm := NewDaemonManager(pool, nil)
+	dm.Register(&DaemonInfo{ID: "daemon-a", Capabilities: []string{"llm"}, MaxConcurrent: 1})
+	dm.Register(&DaemonInfo{ID: "daemon-b", Capabilities: []string{"llm"}, MaxConcurrent: 1})
+	daemon, err := dm.ResolveDaemonForAgent(ctx, agentID, "llm")
+	if err != nil || daemon.ID != "daemon-a" {
+		t.Fatalf("bound daemon = %#v, %v; want daemon-a", daemon, err)
+	}
+
+	dm.Unregister("daemon-a")
+	if _, err := dm.ResolveDaemonForAgent(ctx, agentID, "llm"); err == nil {
+		t.Fatal("offline bound daemon fell back to another computer")
+	}
+	dm.Register(&DaemonInfo{ID: "daemon-a", Capabilities: []string{"llm"}, MaxConcurrent: 1})
+	if _, err := pool.Exec(ctx, `UPDATE agents SET runtime_id = NULL WHERE id = $1`, agentID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := dm.ResolveDaemonForAgent(ctx, agentID, "llm"); err == nil {
+		t.Fatal("unbound agent selected randomly from multiple daemons")
+	}
+	dm.Unregister("daemon-b")
+	daemon, err = dm.ResolveDaemonForAgent(ctx, agentID, "llm")
+	if err != nil || daemon.ID != "daemon-a" {
+		t.Fatalf("single-daemon legacy fallback = %#v, %v; want daemon-a", daemon, err)
+	}
+	var runtimeID string
+	if err := pool.QueryRow(ctx, `SELECT COALESCE(runtime_id, '') FROM agents WHERE id = $1`, agentID).Scan(&runtimeID); err != nil {
+		t.Fatal(err)
+	}
+	if runtimeID != computerA {
+		t.Fatalf("persisted runtime_id = %q, want %q", runtimeID, computerA)
 	}
 }

--- a/migrations/000038_add_agent_run_daemon_affinity.down.sql
+++ b/migrations/000038_add_agent_run_daemon_affinity.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX idx_agent_runs_daemon_active;
+ALTER TABLE agent_runs DROP COLUMN daemon_id;

--- a/migrations/000038_add_agent_run_daemon_affinity.up.sql
+++ b/migrations/000038_add_agent_run_daemon_affinity.up.sql
@@ -1,0 +1,18 @@
+ALTER TABLE agent_runs ADD COLUMN daemon_id TEXT;
+
+UPDATE agent_runs r
+   SET daemon_id = c.daemon_id
+  FROM agents a
+  JOIN computers c ON c.id::text = a.runtime_id
+ WHERE r.agent_id = a.id
+   AND r.daemon_id IS NULL
+   AND c.daemon_id IS NOT NULL;
+
+UPDATE agent_runs
+   SET daemon_id = (SELECT daemon_id FROM computers WHERE daemon_id IS NOT NULL LIMIT 1)
+ WHERE daemon_id IS NULL
+   AND (SELECT count(*) FROM computers WHERE daemon_id IS NOT NULL) = 1;
+
+CREATE INDEX idx_agent_runs_daemon_active
+    ON agent_runs(daemon_id, updated_at DESC)
+    WHERE finished_at IS NULL;


### PR DESCRIPTION
## What changed

- Resolve Agent execution through its persisted `runtime_id -> computers.daemon_id` binding.
- Keep legacy single-Daemon compatibility by persisting the only available computer on first use, while rejecting ambiguous multi-Daemon fallback.
- Persist `daemon_id` on Agent runs so reconciliation and timeout cancellation target the exact Daemon.
- Route Channel, Thread, Task, Thinking, Artifact, Greeting, Workspace, Skills, cleanup, and retry paths through the same affinity boundary.
- Bind the local Daemon HTTP listener to loopback only.

## Why

Solo currently runs on one local computer, but execution paths selected the first or least-loaded Daemon independently. Once more than one Daemon exists, that can run an Agent against the wrong workspace/session, cancel the wrong process, or mark another Daemon's Run as lost. This PR lays the persistence and routing foundation without adding remote transport, scheduling, or offline queues.

## Compatibility

- Existing bound Agents keep their computer.
- An unbound Agent with exactly one usable Daemon is automatically and persistently bound to it.
- An unbound Agent with multiple usable Daemons fails closed instead of choosing randomly.
- Existing Run rows are backfilled from Agent bindings, with a single-computer fallback.

## Validation

- `go test ./...`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- Real make-managed Playwright E2E with frontend, API server, PostgreSQL, Daemon, and local Claude runtime
  - verified the visible Agent message in the UI
  - verified `agent_runs.daemon_id` equals the Agent computer's `daemon_id`
  - the existing three-attempt Task retry E2E also passed on isolated rerun after one transient Claude stall
