### PR TITLE
Add WebSocket self-healing and message backfill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -55,6 +55,9 @@ test-e2e-agent-scope-router: rebuild ## Rebuild and verify the real Coordinator-
 
 test-e2e-send-freshness: rebuild ## Rebuild and verify three real Agents relay through send freshness holds
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_FRESHNESS=1 npx playwright test e2e/send-freshness.spec.ts --workers=1
+
+test-e2e-websocket-recovery: rebuild ## Rebuild and verify browser WebSocket recovery and message backfill
+	@cd frontend && CI=1 npx playwright test e2e/websocket-message-send.spec.ts e2e/websocket-recovery.spec.ts --workers=1
 
 stop: ## Shut down all services
 	@bash scripts/stop-services.sh

--- a/frontend/e2e/websocket-recovery.spec.ts
+++ b/frontend/e2e/websocket-recovery.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+  user: { id: string };
+}
+
+interface MessageResponse {
+  id: string;
+  content: string;
+  thread_id?: string;
+}
+
+interface MessageListResponse {
+  messages: MessageResponse[];
+  has_more: boolean;
+}
+
+async function register(request: APIRequestContext, label: string): Promise<AuthResponse> {
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const response = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: {
+      email: `ws-recovery-${label}-${suffix}@solo.local`,
+      password: 'SoloE2E-2026!',
+      display_name: `WS Recovery ${label}`,
+    },
+  });
+  if (!response.ok()) {
+    throw new Error(`E2E registration failed: ${response.status()} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function authenticatePage(page: Page, auth: AuthResponse): Promise<void> {
+  await page.addInitScript(({ accessToken, refreshToken }) => {
+    localStorage.setItem('access_token', accessToken);
+    localStorage.setItem('refresh_token', refreshToken);
+    localStorage.setItem('solo.locale', 'en');
+  }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+}
+
+function authorization(auth: AuthResponse): { authorization: string } {
+  return { authorization: `Bearer ${auth.access_token}` };
+}
+
+test('foreground and network recovery restore Channel and Thread messages', async ({ page, request, context }) => {
+  const auth = await register(request, 'channel');
+  const createdChannel = await request.post(`${apiBase}/api/v1/channels`, {
+    headers: authorization(auth),
+    data: { name: `ws-recovery-${Date.now()}`, description: 'WebSocket recovery E2E' },
+  });
+  expect(createdChannel.ok()).toBe(true);
+  const channel = await createdChannel.json() as { id: string };
+
+  try {
+    const rootContent = `WS_RECOVERY_ROOT_${Date.now()}`;
+    const rootResponse = await request.post(`${apiBase}/api/v1/channels/${channel.id}/messages`, {
+      headers: authorization(auth),
+      data: { content: rootContent },
+    });
+    expect(rootResponse.ok()).toBe(true);
+    const root = await rootResponse.json() as MessageResponse;
+
+    const seedContent = `WS_RECOVERY_THREAD_SEED_${Date.now()}`;
+    const seedResponse = await request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages/${root.id}/thread`,
+      { headers: authorization(auth), data: { content: seedContent } },
+    );
+    expect(seedResponse.ok()).toBe(true);
+    const seed = await seedResponse.json() as MessageResponse;
+
+    let socketCount = 0;
+    let pingCount = 0;
+    page.on('websocket', (socket) => {
+      if (!socket.url().includes('/api/v1/ws')) return;
+      socketCount++;
+      socket.on('framereceived', ({ payload }) => {
+        try {
+          if (JSON.parse(String(payload)).type === 'ping') pingCount++;
+        } catch {
+          // Ignore non-JSON frames.
+        }
+      });
+    });
+
+    await authenticatePage(page, auth);
+    await page.goto(`/dashboard?channel=${channel.id}`);
+    await expect(page.locator('#channel-conversation-panel')).toBeVisible();
+    await expect(page.getByText(rootContent, { exact: true })).toBeVisible();
+
+    const rootRow = page.locator(`[data-message-id="${root.id}"]`);
+    await rootRow.hover();
+    await rootRow.getByRole('button', { name: /^Reply to / }).click();
+    await expect(page.getByText(seedContent, { exact: true })).toBeVisible();
+
+    await expect.poll(() => pingCount, { timeout: 35_000 }).toBeGreaterThan(0);
+    const socketsBeforeForeground = socketCount;
+    await page.evaluate(() => document.dispatchEvent(new Event('visibilitychange')));
+    await expect.poll(() => socketCount).toBeGreaterThan(socketsBeforeForeground);
+
+    await context.setOffline(true);
+    await expect(
+      page.getByRole('alert').filter({ hasText: /Connection lost|Reconnecting/ }).first(),
+    ).toBeVisible();
+
+    const channelMissedContent = `WS_RECOVERY_CHANNEL_MISSED_${Date.now()}`;
+    const channelMissedResponse = await request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages`,
+      { headers: authorization(auth), data: { content: channelMissedContent } },
+    );
+    expect(channelMissedResponse.ok()).toBe(true);
+    const channelMissed = await channelMissedResponse.json() as MessageResponse;
+
+    const threadMissedContent = `WS_RECOVERY_THREAD_MISSED_${Date.now()}`;
+    const threadMissedResponse = await request.post(
+      `${apiBase}/api/v1/channels/${channel.id}/messages/${root.id}/thread`,
+      { headers: authorization(auth), data: { content: threadMissedContent } },
+    );
+    expect(threadMissedResponse.ok()).toBe(true);
+    const threadMissed = await threadMissedResponse.json() as MessageResponse;
+
+    await context.setOffline(false);
+    await expect(page.getByText(threadMissedContent, { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Close thread panel' }).click();
+    await expect(page.getByText(channelMissedContent, { exact: true })).toBeVisible();
+
+    const listedChannel = await request.get(
+      `${apiBase}/api/v1/channels/${channel.id}/messages?after=${root.id}&limit=50`,
+      { headers: authorization(auth) },
+    );
+    expect(listedChannel.ok()).toBe(true);
+    expect(await listedChannel.json() as MessageListResponse).toMatchObject({
+      messages: [{ id: channelMissed.id, content: channelMissedContent }],
+      has_more: false,
+    });
+
+    const listedThread = await request.get(
+      `${apiBase}/api/v1/channels/${channel.id}/messages/${root.id}/thread?after=${seed.id}&limit=50`,
+      { headers: authorization(auth) },
+    );
+    expect(listedThread.ok()).toBe(true);
+    expect(await listedThread.json() as MessageListResponse).toMatchObject({
+      messages: [{ id: threadMissed.id, content: threadMissedContent }],
+      has_more: false,
+    });
+  } finally {
+    await context.setOffline(false);
+    await request.delete(`${apiBase}/api/v1/channels/${channel.id}`, {
+      headers: authorization(auth),
+    });
+  }
+});
+
+test('network recovery restores missed DM messages', async ({ page, request, context }) => {
+  const auth = await register(request, 'dm-owner');
+  const peer = await register(request, 'dm-peer');
+  const createdDM = await request.post(`${apiBase}/api/v1/dm`, {
+    headers: authorization(auth),
+    data: { member_type: 'user', member_id: peer.user.id },
+  });
+  expect(createdDM.ok()).toBe(true);
+  const dm = await createdDM.json() as { id: string };
+
+  const seedContent = `WS_RECOVERY_DM_SEED_${Date.now()}`;
+  const seedResponse = await request.post(`${apiBase}/api/v1/dm/${dm.id}/messages`, {
+    headers: authorization(peer),
+    data: { content: seedContent },
+  });
+  expect(seedResponse.ok()).toBe(true);
+  const seed = await seedResponse.json() as MessageResponse;
+
+  await authenticatePage(page, auth);
+  await page.goto(`/dashboard?dm=${dm.id}`);
+  await expect(page.getByText(seedContent, { exact: true })).toBeVisible();
+
+  await context.setOffline(true);
+  await expect(
+    page.getByRole('alert').filter({ hasText: /Connection lost|Reconnecting/ }).first(),
+  ).toBeVisible();
+
+  const missedContent = `WS_RECOVERY_DM_MISSED_${Date.now()}`;
+  const missedResponse = await request.post(`${apiBase}/api/v1/dm/${dm.id}/messages`, {
+    headers: authorization(peer),
+    data: { content: missedContent },
+  });
+  expect(missedResponse.ok()).toBe(true);
+  const missed = await missedResponse.json() as MessageResponse;
+
+  await context.setOffline(false);
+  await expect(page.getByText(missedContent, { exact: true })).toBeVisible();
+
+  const listed = await request.get(
+    `${apiBase}/api/v1/dm/${dm.id}/messages?after=${seed.id}&limit=50`,
+    { headers: authorization(auth) },
+  );
+  expect(listed.ok()).toBe(true);
+  expect(await listed.json() as MessageListResponse).toMatchObject({
+    messages: [{ id: missed.id, content: missedContent }],
+    has_more: false,
+  });
+});

--- a/frontend/lib/hooks/use-dm.ts
+++ b/frontend/lib/hooks/use-dm.ts
@@ -242,26 +242,30 @@ export function useDM(dmId: string | null = null) {
 
       const lastMsg = [...currentMsgs].reverse().find((message) => message.status === 'sent');
       if (lastMsg?.id) {
-        apiClient
-          .get<DMMessageListResponse>(`/api/v1/dm/${did}/messages`, {
-            limit: '50',
-            after: lastMsg.id,
-          })
-          .then((res) => {
-            if (res.messages.length > 0) {
-              setMessages((prev) => {
-                const existingIds = new Set(prev.map((m) => m.id));
-                const newMsgs = res.messages
-                  .map(mapDMMessageResponse)
-                  .filter((m) => !existingIds.has(m.id));
-                if (newMsgs.length === 0) return prev;
-                return [...prev, ...newMsgs];
-              });
-            }
-          })
-          .catch(() => {
-            // Silently fail — messages will arrive via WS subscription
+        void (async () => {
+          const missed: DMMessageResponse[] = [];
+          let cursor = lastMsg.id;
+          for (;;) {
+            const res = await apiClient.get<DMMessageListResponse>(
+              `/api/v1/dm/${did}/messages`,
+              { limit: String(PAGE_SIZE), after: cursor },
+            );
+            if (dmIdRef.current !== did) return;
+            missed.push(...res.messages);
+            if (!res.has_more || res.messages.length === 0) break;
+            cursor = res.messages[res.messages.length - 1].id;
+          }
+          if (missed.length === 0) return;
+          setMessages((prev) => {
+            const existingIds = new Set(prev.map((m) => m.id));
+            const newMsgs = missed
+              .map(mapDMMessageResponse)
+              .filter((m) => !existingIds.has(m.id));
+            return newMsgs.length === 0 ? prev : [...prev, ...newMsgs];
           });
+        })().catch(() => {
+          // Silently fail — the next reconnect or refresh will retry from the same cursor.
+        });
       }
     }
   }, [isConnected]);

--- a/frontend/lib/hooks/use-messages.ts
+++ b/frontend/lib/hooks/use-messages.ts
@@ -195,28 +195,34 @@ export function useMessages(channelId: string | null, thinkingNodeId: string | n
       // to fetch messages that arrived during disconnection
       const lastMsg = [...currentMsgs].reverse().find((message) => message.status === 'sent');
       if (lastMsg?.id) {
-        apiClient
-          .get<MessageListResponse>(`/api/v1/channels/${cid}/messages`, {
-            limit: '50',
-            after: lastMsg.id,
-            ...(nodeID ? { thinking_node_id: nodeID } : {}),
-          })
-          .then((res) => {
+        void (async () => {
+          const missed: MessageResponse[] = [];
+          let cursor = lastMsg.id;
+          for (;;) {
+            const res = await apiClient.get<MessageListResponse>(
+              `/api/v1/channels/${cid}/messages`,
+              {
+                limit: String(PAGE_SIZE),
+                after: cursor,
+                ...(nodeID ? { thinking_node_id: nodeID } : {}),
+              },
+            );
             if (channelIdRef.current !== cid || thinkingNodeIdRef.current !== nodeID) return;
-            if (res.messages.length > 0) {
-              setMessages((prev) => {
-                const existingIds = new Set(prev.map((m) => m.id));
-                const newMsgs = res.messages
-                  .map(mapMessageResponse)
-                  .filter((m) => !existingIds.has(m.id));
-                if (newMsgs.length === 0) return prev;
-                return [...prev, ...newMsgs];
-              });
-            }
-          })
-          .catch(() => {
-            // Silently fail — messages will arrive via WS subscription
+            missed.push(...res.messages);
+            if (!res.has_more || res.messages.length === 0) break;
+            cursor = res.messages[res.messages.length - 1].id;
+          }
+          if (missed.length === 0) return;
+          setMessages((prev) => {
+            const existingIds = new Set(prev.map((m) => m.id));
+            const newMsgs = missed
+              .map(mapMessageResponse)
+              .filter((m) => !existingIds.has(m.id));
+            return newMsgs.length === 0 ? prev : [...prev, ...newMsgs];
           });
+        })().catch(() => {
+          // Silently fail — the next reconnect or refresh will retry from the same cursor.
+        });
       }
     }
   }, [isConnected]);

--- a/frontend/lib/hooks/use-thread.ts
+++ b/frontend/lib/hooks/use-thread.ts
@@ -64,6 +64,7 @@ function toWSMessage(r: ThreadReplyResponse): WSMessage {
     thread_parent_id: r.thread_id,
     attachments: r.attachments,
     created_at: r.created_at,
+    status: 'sent',
   };
 }
 
@@ -90,7 +91,7 @@ export interface UseThreadReturn {
 
 export function useThread(): UseThreadReturn {
   const { user } = useAuth();
-  const { subscribeThread, unsubscribeThread, onEvent } = useWebSocket();
+  const { subscribeThread, unsubscribeThread, onEvent, isConnected } = useWebSocket();
   const [messages, setMessages] = useState<WSMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -102,6 +103,9 @@ export function useThread(): UseThreadReturn {
   const threadIdRef = useRef<string | null>(null);
   threadIdRef.current = threadId;
   const loadingRef = useRef(false);
+  const messagesRef = useRef<WSMessage[]>([]);
+  messagesRef.current = messages;
+  const prevConnectedRef = useRef(false);
 
   // ---- 加载线程消息 ----
 
@@ -137,6 +141,44 @@ export function useThread(): UseThreadReturn {
     [],
   );
 
+  // ---- Fetch missed replies after reconnection ----
+
+  useEffect(() => {
+    const wasConnected = prevConnectedRef.current;
+    prevConnectedRef.current = isConnected;
+    if (!isConnected || wasConnected) return;
+
+    const cid = channelIdRef.current;
+    const mid = messageIdRef.current;
+    const lastMsg = [...messagesRef.current].reverse().find((message) => message.status === 'sent');
+    if (!cid || !mid || !lastMsg?.id) return;
+
+    void (async () => {
+      const missed: ThreadReplyResponse[] = [];
+      let cursor = lastMsg.id;
+      for (;;) {
+        const res = await apiClient.get<ThreadMessageListResponse>(
+          `/api/v1/channels/${cid}/messages/${mid}/thread`,
+          { limit: '50', after: cursor },
+        );
+        if (channelIdRef.current !== cid || messageIdRef.current !== mid) return;
+        missed.push(...res.messages);
+        if (!res.has_more || res.messages.length === 0) break;
+        cursor = res.messages[res.messages.length - 1].id;
+      }
+      if (missed.length === 0) return;
+      const recovered = missed.map(toWSMessage);
+      setMessages((prev) => {
+        const recoveredByID = new Map(recovered.map((message) => [message.id, message]));
+        const merged = prev.map((message) => recoveredByID.get(message.id) ?? message);
+        const existingIDs = new Set(prev.map((message) => message.id));
+        return [...merged, ...recovered.filter((message) => !existingIDs.has(message.id))];
+      });
+    })().catch(() => {
+      // Silently fail — the next reconnect or refresh will retry from the same cursor.
+    });
+  }, [isConnected]);
+
   // ---- WS 订阅生命周期 ----
   // 当获得实际的 thread_id 后，订阅该线程的实时事件
 
@@ -148,7 +190,6 @@ export function useThread(): UseThreadReturn {
     return () => {
       unsubscribeThread(tid);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId, subscribeThread, unsubscribeThread]);
 
   // ---- WS 事件监听：实时接收新线程消息 + 流式输出 ----
@@ -204,6 +245,7 @@ export function useThread(): UseThreadReturn {
           thread_parent_id: event.message.thread_id,
           attachments: event.message.attachments,
           created_at: event.message.created_at,
+          status: 'sent',
         };
         if (event.message.client_msg_id && acknowledgeReliableSend(event.message.client_msg_id, {
           message: newMsg,

--- a/frontend/lib/ws-client.ts
+++ b/frontend/lib/ws-client.ts
@@ -28,6 +28,7 @@ export interface WSClientConfig {
 const INITIAL_RECONNECT_DELAY = 1000; // 1s
 const MAX_RECONNECT_DELAY = 30000;    // 30s
 const BACKOFF_MULTIPLIER = 2;
+const INBOUND_WATCHDOG_MS = 70000;
 
 export class WSClient {
   private readonly config: WSClientConfig;
@@ -38,6 +39,7 @@ export class WSClient {
   private subscribedDMs: Set<string> = new Set();
   private reconnectDelay: number = INITIAL_RECONNECT_DELAY;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private watchdogTimer: ReturnType<typeof setTimeout> | null = null;
   private intentionalClose: boolean = false;
   private readonly handlers: Set<(event: WSServerEvent) => void> = new Set();
 
@@ -103,6 +105,7 @@ export class WSClient {
       this.setState('connected');
       this.config.onReconnectChange?.(false, 0);
       this.reconnectDelay = INITIAL_RECONNECT_DELAY;
+      this.resetWatchdog();
 
       // 重连后自动重新订阅之前的频道
       if (this.subscribedChannels.size > 0) {
@@ -127,6 +130,7 @@ export class WSClient {
     };
 
     this.ws.onclose = () => {
+      this.clearWatchdog();
       this.setState('disconnected');
       this.ws = null;
 
@@ -146,6 +150,7 @@ export class WSClient {
     };
 
     this.ws.onmessage = (event: MessageEvent) => {
+      this.resetWatchdog();
       this.handleMessage(event.data);
     };
   }
@@ -250,6 +255,7 @@ export class WSClient {
       // Backend Envelope: { "type": "...", "payload": {...} }
       // 将 payload 展开到顶层，形成扁平结构
       const parsed = JSON.parse(rawData);
+      if (parsed.type === 'ping') return;
       if (parsed.payload && typeof parsed.payload === 'object') {
         event = { type: parsed.type, ...parsed.payload } as WSServerEvent;
       } else {
@@ -295,7 +301,23 @@ export class WSClient {
     }
   }
 
+  private resetWatchdog(): void {
+    this.clearWatchdog();
+    this.watchdogTimer = setTimeout(() => {
+      this.watchdogTimer = null;
+      this.forceReconnect();
+    }, INBOUND_WATCHDOG_MS);
+  }
+
+  private clearWatchdog(): void {
+    if (this.watchdogTimer !== null) {
+      clearTimeout(this.watchdogTimer);
+      this.watchdogTimer = null;
+    }
+  }
+
   private cleanupSocket(): void {
+    this.clearWatchdog();
     if (this.ws) {
       // 清除回调以防止旧 socket 触发 onclose 导致意外重连
       this.ws.onopen = null;

--- a/frontend/lib/ws-context.tsx
+++ b/frontend/lib/ws-context.tsx
@@ -166,7 +166,10 @@ export function WSProvider({
 
   useEffect(() => {
     const onVisibility = () => {
-      if (document.visibilityState === 'visible') retryFailedReliableSends();
+      if (document.visibilityState === 'visible') {
+        retryFailedReliableSends();
+        forceReconnect();
+      }
     };
     const onPageShow = () => {
       retryFailedReliableSends();

--- a/frontend/lib/ws-types.ts
+++ b/frontend/lib/ws-types.ts
@@ -49,6 +49,7 @@ export interface WSMessage {
 export type WSServerEvent =
   | { type: 'connected'; user_id: string }
   | { type: 'error'; code: string; message: string }
+  | { type: 'ping' }
   // ---- 消息事件 ----
   | { type: 'message.new'; id: string; client_msg_id?: string; channel_id: string; sender_type: string; sender_id: string; sender_name?: string; sender_avatar?: string | null; content: string; content_type: string; metadata?: Record<string, unknown>; thread_id?: string; thinking_node_id?: string; created_at: string; attachments?: Attachment[]; task_number?: number; task_title?: string; task_status?: string; task_claimer_name?: string; task_claimer_deleted?: boolean; reply_count?: number; has_unread_thread?: boolean }
   | { type: 'message.updated'; id: string; channel_id: string; content: string; sender_type?: string; sender_id?: string; updated_at: string; task_number?: number; task_title?: string; task_status?: string; task_claimer_name?: string; task_claimer_deleted?: boolean; reply_count?: number }

--- a/internal/server/handler/dm.go
+++ b/internal/server/handler/dm.go
@@ -467,6 +467,17 @@ func (h *DMHandler) ListMessages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	after := r.URL.Query().Get("after")
+	if after != "" {
+		if _, err := uuid.Parse(after); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid cursor: must be a valid message ID")
+			return
+		}
+	}
+	if before != "" && after != "" {
+		writeError(w, http.StatusBadRequest, "before and after cannot be used together")
+		return
+	}
 
 	// Check user is a DM participant
 	var isParticipant bool
@@ -523,8 +534,17 @@ func (h *DMHandler) ListMessages(w http.ResponseWriter, r *http.Request) {
 		query += ` AND (m.created_at, m.id) < (SELECT c.created_at, c.id FROM messages c WHERE c.id = $2)`
 		args = append(args, before)
 	}
+	if after != "" {
+		query += ` AND (m.created_at, m.id) > (SELECT c.created_at, c.id FROM messages c WHERE c.id = $2)`
+		args = append(args, after)
+	}
 
-	query += ` ORDER BY m.created_at DESC, m.id DESC LIMIT $` + strconv.Itoa(len(args)+1)
+	if after != "" {
+		query += ` ORDER BY m.created_at ASC, m.id ASC`
+	} else {
+		query += ` ORDER BY m.created_at DESC, m.id DESC`
+	}
+	query += ` LIMIT $` + strconv.Itoa(len(args)+1)
 	args = append(args, limit+1)
 
 	rows, err := h.pool.Query(r.Context(), query, args...)
@@ -576,9 +596,11 @@ func (h *DMHandler) ListMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Reverse to chronological order (oldest first)
-	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
-		messages[i], messages[j] = messages[j], messages[i]
+	// Non-after queries arrive newest-first and need reversing for display.
+	if after == "" {
+		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+			messages[i], messages[j] = messages[j], messages[i]
+		}
 	}
 
 	writeJSON(w, http.StatusOK, MessageListResponse{

--- a/internal/server/handler/message.go
+++ b/internal/server/handler/message.go
@@ -832,6 +832,17 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	after := r.URL.Query().Get("after")
+	if after != "" {
+		if _, err := uuid.Parse(after); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid cursor: must be a valid message ID")
+			return
+		}
+	}
+	if before != "" && after != "" {
+		writeError(w, http.StatusBadRequest, "before and after cannot be used together")
+		return
+	}
 	thinkingNodeID := strings.TrimSpace(r.URL.Query().Get("thinking_node_id"))
 	if thinkingNodeID != "" {
 		if _, err := uuid.Parse(thinkingNodeID); err != nil {
@@ -925,8 +936,17 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		query += ` AND (m.created_at, m.id) < (SELECT c.created_at, c.id FROM messages c WHERE c.id = $` + strconv.Itoa(len(args)+1) + `)`
 		args = append(args, before)
 	}
+	if after != "" {
+		query += ` AND (m.created_at, m.id) > (SELECT c.created_at, c.id FROM messages c WHERE c.id = $` + strconv.Itoa(len(args)+1) + `)`
+		args = append(args, after)
+	}
 
-	query += ` ORDER BY m.created_at DESC, m.id DESC LIMIT $` + strconv.Itoa(len(args)+1)
+	if after != "" {
+		query += ` ORDER BY m.created_at ASC, m.id ASC`
+	} else {
+		query += ` ORDER BY m.created_at DESC, m.id DESC`
+	}
+	query += ` LIMIT $` + strconv.Itoa(len(args)+1)
 	args = append(args, limit+1) // Fetch one extra to determine has_more
 
 	rows, err := h.pool.Query(r.Context(), query, args...)
@@ -984,9 +1004,11 @@ func (h *MessageHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// The messages are in DESC order (newest first). Reverse to return ASC (oldest first)
-	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
-		messages[i], messages[j] = messages[j], messages[i]
+	// Non-after queries arrive newest-first and need reversing for display.
+	if after == "" {
+		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+			messages[i], messages[j] = messages[j], messages[i]
+		}
 	}
 
 	writeJSON(w, http.StatusOK, MessageListResponse{

--- a/internal/server/handler/thread.go
+++ b/internal/server/handler/thread.go
@@ -441,6 +441,17 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 			return
 		}
 	}
+	after := r.URL.Query().Get("after")
+	if after != "" {
+		if _, err := uuid.Parse(after); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid cursor: must be a valid message ID")
+			return
+		}
+	}
+	if before != "" && after != "" {
+		writeError(w, http.StatusBadRequest, "before and after cannot be used together")
+		return
+	}
 
 	// Verify user is a member of the channel and channel is not archived
 	var isArchived bool
@@ -521,8 +532,18 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 		args = append(args, before)
 		argIdx = 3
 	}
+	if after != "" {
+		query += ` AND (m.created_at, m.id) > (SELECT c.created_at, c.id FROM messages c WHERE c.id = $2)`
+		args = append(args, after)
+		argIdx = 3
+	}
 
-	query += ` ORDER BY m.created_at DESC, m.id DESC LIMIT $` + strconv.Itoa(argIdx)
+	if after != "" {
+		query += ` ORDER BY m.created_at ASC, m.id ASC`
+	} else {
+		query += ` ORDER BY m.created_at DESC, m.id DESC`
+	}
+	query += ` LIMIT $` + strconv.Itoa(argIdx)
 	args = append(args, limit+1)
 
 	rows, err := h.pool.Query(r.Context(), query, args...)
@@ -576,9 +597,11 @@ func (h *ThreadHandler) ListThreadMessages(w http.ResponseWriter, r *http.Reques
 		messages = messages[:limit]
 	}
 
-	// Reverse to ASC for natural reading order (oldest first)
-	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
-		messages[i], messages[j] = messages[j], messages[i]
+	// Non-after queries arrive newest-first and need reversing for display.
+	if after == "" {
+		for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+			messages[i], messages[j] = messages[j], messages[i]
+		}
 	}
 
 	writeJSON(w, http.StatusOK, ThreadMessageListResponse{

--- a/internal/server/ws/client.go
+++ b/internal/server/ws/client.go
@@ -17,8 +17,9 @@ const (
 	// Time allowed to read the next pong message from the peer.
 	pongWait = 60 * time.Second
 
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
+	// Send transport and application pings with this period. The text frame is
+	// observable by browser clients, unlike the WebSocket control frame.
+	pingPeriod = 30 * time.Second
 
 	// Maximum message size allowed from peer.
 	maxMessageSize = 100 * 1024 // 100KB
@@ -117,6 +118,9 @@ func (c *Client) WritePump() {
 
 		case <-ticker.C:
 			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
+			if err := c.conn.WriteMessage(websocket.TextMessage, Envelope(EventPing, struct{}{})); err != nil {
+				return
+			}
 			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}

--- a/internal/server/ws/message.go
+++ b/internal/server/ws/message.go
@@ -30,6 +30,7 @@ const (
 
 // Event types (server -> client)
 const (
+	EventPing              = "ping"
 	EventMessageNew        = "message.new"
 	EventMessageUpdated    = "message.updated"
 	EventMessageDeleted    = "message.deleted"


### PR DESCRIPTION
## Summary

- recover zombie browser WebSocket connections with a 30-second server keepalive, a 70-second inbound watchdog, and foreground/network recovery hooks
- restore Channel, Thread, and DM subscriptions and page through messages missed while disconnected
- complete the existing `after` cursor contract in all three message list handlers
- add real frontend/API/WebSocket/PostgreSQL recovery coverage while retaining the legacy WebSocket send regression

## Root cause

iOS/Safari and flaky network transitions can leave a browser WebSocket reporting `OPEN` after the underlying TCP connection has died. Solo could reconnect after `onclose`, but could not detect every zombie connection. Its Channel and DM hooks also sent an `after` cursor the server ignored, while Thread had no reconnect backfill.

## Impact

Returning to Solo now establishes a fresh connection, restores subscriptions, and reconciles durable messages from PostgreSQL. No schema migration or new dependency is required, and existing message sending behavior remains compatible.

## Validation

- `go test ./...`
- `npm run build`
- targeted ESLint: 0 errors (one pre-existing warning)
- `make test-e2e-websocket-recovery`: 3 passed, covering legacy WebSocket send plus Channel, Thread, and DM recovery
