### PR TITLE
Unify runtime metadata and daemon-owned detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-e2e-agent-delivery test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -66,6 +66,9 @@ test-e2e-m8: export AGENT_CASCADE_WINDOW=10s
 test-e2e-m8: export AGENT_CASCADE_COOLDOWN=5s
 test-e2e-m8: rebuild ## Rebuild and verify real M8 Agent behavior
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_M8=1 SOLO_E2E_REAL_AGENT_FRESHNESS=1 npx playwright test e2e/agent-message-flow.spec.ts e2e/send-freshness.spec.ts --workers=1
+
+test-e2e-m9: rebuild ## Rebuild and verify runtime metadata and daemon-owned CLI detection
+	@cd frontend && CI=1 SOLO_E2E_RUNTIME_DETECTION=1 npx playwright test e2e/runtime-detection.spec.ts --workers=1
 
 stop: ## Shut down all services
 	@bash scripts/stop-services.sh

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -114,6 +114,15 @@ func (h *daemonHandler) getSessionManager(providerType string) *agent.AgentSessi
 	return h.sessionManagers[providerType]
 }
 
+// DetectBackends reports CLI availability on the machine that runs agents.
+func (h *daemonHandler) DetectBackends(w http.ResponseWriter, _ *http.Request) {
+	results := agent.GlobalRegistry().Detect()
+	if results == nil {
+		results = []agent.BackendStatus{}
+	}
+	writeJSON(w, http.StatusOK, results)
+}
+
 // cachedSessionAgentIDs returns all Agent IDs with a cached persistent session,
 // including idle sessions whose provider process is asleep. A resumable Agent
 // remains online and routable while its local process is released.

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -149,6 +149,7 @@ func main() {
 	r.Route("/internal/daemon", func(r chi.Router) {
 		r.Post("/run", h.Run)            // Server dispatches agent tasks here
 		r.Post("/proxy", h.ProxyRequest) // Agent-to-server proxy
+		r.Get("/backends/detect", h.DetectBackends)
 		r.Post("/thinking/cleanup", h.CleanupThinkingSessions)
 		r.Route("/workspace", func(r chi.Router) {
 			r.Get("/list", h.HandleWorkspaceList)

--- a/frontend/components/agents/agent-form.tsx
+++ b/frontend/components/agents/agent-form.tsx
@@ -142,7 +142,11 @@ export function AgentForm({
   const selectedProvider = watch('model_provider') || '';
 
   // v1.4: dynamic CLI detection + backend metadata
-  const { results: detection, isLoading: detectionLoading } = useCliDetection();
+  const {
+    results: detection,
+    isLoading: detectionLoading,
+    error: detectionError,
+  } = useCliDetection();
   const { metas: backendMeta } = useBackendMeta();
 
   // Role template selection state (SOLO-210-F)
@@ -260,9 +264,14 @@ export function AgentForm({
         {detectionLoading && (
           <Skeleton className="h-10 w-full rounded-none" />
         )}
+        {detectionError && (
+          <p className="font-mono text-[11px] text-brutal-danger">
+            {t('cliCheckFailed')}
+          </p>
+        )}
 
         {/* Runtime dropdown — only show available runtimes */}
-        {!detectionLoading && (
+        {!detectionLoading && !detectionError && (
           <Controller
             name="model_provider"
             control={control}

--- a/frontend/components/agents/cli-detection.tsx
+++ b/frontend/components/agents/cli-detection.tsx
@@ -1,5 +1,5 @@
 // ============================================================================
-// CliDetection — shows which provider CLIs are installed on the server
+// CliDetection — shows which provider CLIs are installed on the runtime computer
 // Green dot = available, gray dot = not installed (with install hint)
 // ============================================================================
 

--- a/frontend/components/onboarding/wizard-card.tsx
+++ b/frontend/components/onboarding/wizard-card.tsx
@@ -15,7 +15,11 @@ interface WizardCardProps {
 }
 
 export function WizardCard({ channelId, onComplete }: WizardCardProps) {
-  const { results: cliResults, isLoaded: cliLoaded } = useCliDetection();
+  const {
+    results: cliResults,
+    isLoaded: cliLoaded,
+    error: cliError,
+  } = useCliDetection();
   const { computers, isLoading: computersLoading, claimComputer, refetch } = useComputers();
   const { createLucy, isCreating, error: createError } = useOnboarding();
 
@@ -157,6 +161,10 @@ export function WizardCard({ channelId, onComplete }: WizardCardProps) {
             </p>
             {!cliLoaded ? (
               <Spinner size="sm" />
+            ) : cliError ? (
+              <p className="font-mono text-xs text-brutal-danger">
+                Could not detect CLI status. Check that the runtime daemon is online.
+              </p>
             ) : hasAvailableRuntime ? (
               <Select
                 options={runtimeOptions}

--- a/frontend/e2e/runtime-detection.spec.ts
+++ b/frontend/e2e/runtime-detection.spec.ts
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process';
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const daemonBase = process.env.SOLO_E2E_DAEMON_URL ?? 'http://127.0.0.1:8081';
+const credentials = { email: 'runtime-detection-e2e@solo.local', password: 'SoloE2E-2026!' };
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+}
+
+interface BackendMeta {
+  type: string;
+  display_name: string;
+  requires_binary: string;
+  protocols: string[];
+}
+
+interface BackendStatus {
+  type: string;
+  display_name: string;
+  binary: string;
+  available: boolean;
+  version?: string;
+  error?: string;
+}
+
+async function authenticate(request: APIRequestContext): Promise<AuthResponse> {
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, { data: credentials });
+  if (login.ok()) return login.json();
+  const register = await request.post(`${apiBase}/api/v1/auth/register`, {
+    data: { ...credentials, display_name: 'Runtime Detection E2E' },
+  });
+  if (!register.ok()) {
+    throw new Error(`E2E authentication failed: ${register.status()} ${await register.text()}`);
+  }
+  return register.json();
+}
+
+async function authenticatePage(page: Page, auth: AuthResponse) {
+  await page.addInitScript(({ accessToken, refreshToken }) => {
+    localStorage.setItem('access_token', accessToken);
+    localStorage.setItem('refresh_token', refreshToken);
+    localStorage.setItem('solo.locale', 'en');
+  }, { accessToken: auth.access_token, refreshToken: auth.refresh_token });
+}
+
+function onlineComputerState(): { count: number; daemon_id: string } {
+  const output = execFileSync('docker', [
+    'exec',
+    process.env.SOLO_POSTGRES_CONTAINER ?? 'solo-postgres',
+    'psql',
+    '-U', process.env.POSTGRES_USER ?? 'solo',
+    '-d', process.env.POSTGRES_DB ?? 'solo',
+    '-tA',
+    '-c', `SELECT json_build_object(
+      'count', COUNT(*),
+      'daemon_id', COALESCE(MAX(daemon_id), '')
+    )::text FROM computers WHERE status = 'online' AND daemon_id IS NOT NULL`,
+  ], { encoding: 'utf8' }).trim();
+  return JSON.parse(output);
+}
+
+test.describe('M9 runtime boundaries', () => {
+  test.skip(process.env.SOLO_E2E_RUNTIME_DETECTION !== '1', 'requires the make-managed stack');
+
+  test('uses registry metadata and the real daemon probe in API and UI', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const headers = { authorization: `Bearer ${auth.access_token}` };
+    const suffix = Date.now().toString(36);
+
+    const metadataResponse = await request.get(`${apiBase}/api/v1/agent-backends`, { headers });
+    expect(metadataResponse.ok()).toBeTruthy();
+    const metadata = await metadataResponse.json() as BackendMeta[];
+    expect(metadata.find((item) => item.type === 'opencode')?.protocols).toEqual(['acp']);
+    expect(metadata.find((item) => item.type === 'openclaw')?.protocols).toEqual(['acp']);
+    expect(metadata.every((item) => item.type && item.display_name && item.requires_binary)).toBeTruthy();
+
+    const daemonResponse = await request.get(`${daemonBase}/internal/daemon/backends/detect`);
+    expect(daemonResponse.ok()).toBeTruthy();
+    const daemonResults = await daemonResponse.json() as BackendStatus[];
+
+    const serverResponse = await request.get(`${apiBase}/api/v1/agent-backends/detect`, { headers });
+    expect(serverResponse.ok()).toBeTruthy();
+    const serverResults = await serverResponse.json() as BackendStatus[];
+    const stableStatus = (items: BackendStatus[]) => items
+      .map(({ type, display_name, binary, available }) => ({ type, display_name, binary, available }))
+      .sort((a, b) => a.type.localeCompare(b.type));
+    expect(stableStatus(serverResults)).toEqual(stableStatus(daemonResults));
+
+    const channelResponse = await request.post(`${apiBase}/api/v1/channels`, {
+      headers,
+      data: { name: `runtime-detection-e2e-${suffix}` },
+    });
+    expect(channelResponse.ok()).toBeTruthy();
+    const channel = await channelResponse.json() as { id: string };
+
+    try {
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await page.getByRole('button', { name: 'Teams', exact: true }).click();
+      await page.getByRole('button', { name: 'Create first Agent' }).click();
+
+      const dialog = page.getByRole('dialog');
+      await dialog.getByRole('button', { name: 'Select Runtime...' }).click();
+      const visibleRuntime = serverResults.find((item) =>
+        ['openclaw', 'hermes', 'claude', 'opencode', 'codex'].includes(item.type),
+      );
+      expect(visibleRuntime).toBeDefined();
+      await expect(page.locator('[role="option"]').filter({ hasText: visibleRuntime!.display_name })).toBeVisible();
+
+      const persisted = onlineComputerState();
+      expect(persisted.count).toBeGreaterThanOrEqual(1);
+      expect(persisted.daemon_id).not.toBe('');
+    } finally {
+      const cleanup = await request.delete(`${apiBase}/api/v1/channels/${channel.id}`, { headers });
+      expect(cleanup.ok()).toBeTruthy();
+    }
+  });
+});

--- a/frontend/lib/hooks/use-cli-detection.ts
+++ b/frontend/lib/hooks/use-cli-detection.ts
@@ -1,6 +1,6 @@
 // ============================================================================
 // useCliDetection — fetches CLI availability from /api/v1/agent-backends/detect
-// Used to show which provider CLIs are installed on the server
+// Used to show which provider CLIs are installed on the runtime computer
 // v1.4: returns Record<string, AgentBackendDetectItem> keyed by type
 // ============================================================================
 
@@ -69,6 +69,7 @@ export function useCliDetection(): CliDetectionState {
         setError(
           err instanceof Error ? err.message : `${t('cliDetectionError')}`,
         );
+        setIsLoaded(true);
       })
       .finally(() => {
         if (mountedRef.current) setIsLoading(false);

--- a/internal/server/handler/agent.go
+++ b/internal/server/handler/agent.go
@@ -37,17 +37,21 @@ type AgentHandler struct {
 	httpClient    *http.Client    // for daemon cleanup callbacks
 	hub           realtime.Broadcaster
 	agentSvc      *service.AgentService
+	dm            *service.DaemonManager
 }
 
 // NewAgentHandler creates a new AgentHandler.
-func NewAgentHandler(pool *pgxpool.Pool, proxy workspace.Proxy, hub realtime.Broadcaster, agentSvc *service.AgentService) *AgentHandler {
+func NewAgentHandler(pool *pgxpool.Pool, dm *service.DaemonManager, hub realtime.Broadcaster, agentSvc *service.AgentService) *AgentHandler {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "."
 	}
 	workspaceRoot := filepath.Join(home, ".solo", "agents")
-	if proxy == nil {
+	var proxy workspace.Proxy
+	if dm == nil {
 		slog.Warn("agent handler: no workspace proxy configured, falling back to local filesystem only")
+	} else {
+		proxy = dm
 	}
 	return &AgentHandler{
 		pool:          pool,
@@ -56,6 +60,7 @@ func NewAgentHandler(pool *pgxpool.Pool, proxy workspace.Proxy, hub realtime.Bro
 		httpClient:    &http.Client{Timeout: 10 * time.Second},
 		hub:           hub,
 		agentSvc:      agentSvc,
+		dm:            dm,
 	}
 }
 
@@ -736,11 +741,19 @@ func (h *AgentHandler) AgentBackends(w http.ResponseWriter, r *http.Request) {
 
 // AgentBackendsDetect handles GET /api/v1/agent-backends/detect
 func (h *AgentHandler) AgentBackendsDetect(w http.ResponseWriter, r *http.Request) {
-	results := agent.GlobalRegistry().Detect()
-	if results == nil {
-		results = []agent.BackendStatus{}
+	if h.dm == nil {
+		writeError(w, http.StatusServiceUnavailable, "no runtime daemon available")
+		return
 	}
-	writeJSON(w, http.StatusOK, results)
+	results, err := h.dm.ProxyBackendDetect(r.Context())
+	if err != nil {
+		slog.Warn("agent backends: daemon detection failed", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "runtime detection unavailable")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(results)
 }
 
 // --- JSONB helpers ---

--- a/internal/server/service/daemon.go
+++ b/internal/server/service/daemon.go
@@ -411,6 +411,44 @@ func (dm *DaemonManager) SendTask(ctx context.Context, daemon *DaemonInfo, req i
 	return result.Bytes(), nil
 }
 
+// ProxyBackendDetect asks the single online daemon to inspect its own machine.
+// Multi-computer selection belongs in the public API once the UI can choose a computer.
+func (dm *DaemonManager) ProxyBackendDetect(ctx context.Context) ([]byte, error) {
+	var selected *DaemonInfo
+	for _, daemon := range dm.ListDaemons() {
+		if daemon.Status != DaemonStatusOnline {
+			continue
+		}
+		if selected != nil {
+			return nil, fmt.Errorf("multiple online daemons; computer selection is required")
+		}
+		selected = daemon
+	}
+	if selected == nil {
+		return nil, fmt.Errorf("no online daemon")
+	}
+
+	url := fmt.Sprintf("http://%s:%d/internal/daemon/backends/detect", selected.Host, selected.Port)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create backend detection request: %w", err)
+	}
+	resp, err := dm.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("detect backends on daemon: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read backend detection response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("daemon returned status %d: %s", resp.StatusCode, body)
+	}
+	return body, nil
+}
+
 // CleanupThinkingSessions broadcasts node process cleanup to every online
 // daemon. Runtime affinity is not durable, so the operation is intentionally
 // idempotent and fan-out based.

--- a/internal/server/service/daemon_lifecycle_test.go
+++ b/internal/server/service/daemon_lifecycle_test.go
@@ -2,11 +2,25 @@ package service
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+func TestProxyBackendDetectRequiresOneOnlineDaemon(t *testing.T) {
+	dm := NewDaemonManager(nil, nil)
+	if _, err := dm.ProxyBackendDetect(context.Background()); err == nil || !strings.Contains(err.Error(), "no online daemon") {
+		t.Fatalf("no-daemon error = %v", err)
+	}
+
+	dm.Register(&DaemonInfo{ID: "daemon-a", Status: DaemonStatusOnline})
+	dm.Register(&DaemonInfo{ID: "daemon-b", Status: DaemonStatusOnline})
+	if _, err := dm.ProxyBackendDetect(context.Background()); err == nil || !strings.Contains(err.Error(), "multiple online daemons") {
+		t.Fatalf("multi-daemon error = %v", err)
+	}
+}
 
 func TestPendingTaskTimeoutsUseCurrentLifecyclePhase(t *testing.T) {
 	now := time.Now().UTC()

--- a/pkg/agent/backend.go
+++ b/pkg/agent/backend.go
@@ -179,8 +179,7 @@ type PersistentSession struct {
 // SessionStater exposes session metadata and control to AgentSessionManager
 // without coupling to a specific backend's persistent state type.
 // Any PersistentBackend that wants to participate in the session pool,
-// crash recovery, and inbox notification must have its persistent state
-// implement this interface.
+// and crash recovery must have its persistent state implement this interface.
 type SessionStater interface {
 	// IsAlive returns true if the subprocess is still running.
 	IsAlive() bool
@@ -188,6 +187,4 @@ type SessionStater interface {
 	SessionID() string
 	// Done returns a channel that closes when the session is terminated.
 	Done() <-chan struct{}
-	// Notify writes a lightweight notification to the agent's stdin.
-	Notify(msg string) error
 }

--- a/pkg/agent/island.go
+++ b/pkg/agent/island.go
@@ -101,27 +101,25 @@ func InferActivityText(chunk OutputChunk) string {
 // function normalises that.
 // ============================================================================
 
-// Protocol-family classification, keyed by the backend type string
-// registered in builtin.go. Used as the dispatch for per-family
-// normalisations.
+// Protocol-family classification used as the dispatch for per-family
+// normalisations. BackendRegistry is the single source of protocol metadata.
 const (
-	familyStreamJSON = "stream-json" // claude, local, opencode, cursor, gemini, openclaw
-	familyJSONL      = "jsonl"       // copilot, pi
-	familyACP        = "acp"         // kimi, kiro, hermes
-	familyOther      = "other"       // codex (already emits canonical OutputChunk) + unknown
+	familyStreamJSON = "stream-json"
+	familyJSONL      = "jsonl" // copilot, pi
+	familyACP        = "acp"
+	familyOther      = "other" // codex already emits canonical OutputChunk
 )
 
 func backendFamily(provider string) string {
-	switch provider {
-	case "claude", "local", "opencode", "cursor", "gemini", "openclaw":
-		return familyStreamJSON
-	case "copilot", "pi":
-		return familyJSONL
-	case "kimi", "kiro", "hermes":
-		return familyACP
-	default:
+	meta, ok := GlobalRegistry().Meta(provider)
+	if !ok || len(meta.Protocols) == 0 {
 		return familyOther
 	}
+	switch meta.Protocols[0] {
+	case familyStreamJSON, familyJSONL, familyACP:
+		return meta.Protocols[0]
+	}
+	return familyOther
 }
 
 // NormalizeToolName canonicalises a raw tool name from a backend so the

--- a/pkg/agent/island_test.go
+++ b/pkg/agent/island_test.go
@@ -343,10 +343,10 @@ func TestBackendFamily(t *testing.T) {
 	}{
 		{"claude", familyStreamJSON},
 		{"local", familyStreamJSON},
-		{"opencode", familyStreamJSON},
+		{"opencode", familyACP},
 		{"cursor", familyStreamJSON},
 		{"gemini", familyStreamJSON},
-		{"openclaw", familyStreamJSON},
+		{"openclaw", familyACP},
 		{"copilot", familyJSONL},
 		{"pi", familyJSONL},
 		{"kimi", familyACP},

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -24,11 +24,19 @@ type BackendConfig struct {
 
 // AdapterMeta describes a registered backend adapter for discovery and UI.
 type AdapterMeta struct {
-	Type           string   // "claude", "codex", "opencode"...
-	DisplayName    string   // "Claude Code", "Codex CLI"
-	RequiresBinary string   // CLI binary name, e.g. "claude", "codex", "opencode"
-	DetectCommand  string   // e.g. "--version"
-	Protocols      []string // "stream-json", "json-rpc", "acp", "jsonl"
+	Type           string   `json:"type"`            // "claude", "codex", "opencode"...
+	DisplayName    string   `json:"display_name"`    // "Claude Code", "Codex CLI"
+	RequiresBinary string   `json:"requires_binary"` // CLI binary name, e.g. "claude", "codex", "opencode"
+	DetectCommand  string   `json:"-"`               // e.g. "--version"
+	Protocols      []string `json:"protocols"`       // "stream-json", "json-rpc", "acp", "jsonl"
+}
+
+// Meta returns the registered metadata for typ.
+func (r *BackendRegistry) Meta(typ string) (AdapterMeta, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	entry, ok := r.backends[typ]
+	return entry.Meta, ok
 }
 
 // BackendRegistry is a thread-safe registry of backend adapters.

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
@@ -145,6 +146,26 @@ func TestRegistry_ListMeta(t *testing.T) {
 		if !seen[want] {
 			t.Errorf("missing entry for type %q", want)
 		}
+	}
+}
+
+func TestRegistry_Meta(t *testing.T) {
+	reg := &BackendRegistry{backends: make(map[string]registryEntry)}
+	reg.Register(AdapterMeta{Type: "acp-agent", DisplayName: "ACP Agent", DetectCommand: "--version", Protocols: []string{"acp"}}, nil)
+
+	meta, ok := reg.Meta("acp-agent")
+	if !ok || len(meta.Protocols) != 1 || meta.Protocols[0] != "acp" {
+		t.Fatalf("Meta(acp-agent) = %+v, %v", meta, ok)
+	}
+	if _, ok := reg.Meta("missing"); ok {
+		t.Fatal("Meta(missing) unexpectedly found an entry")
+	}
+	wire, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(wire); !strings.Contains(got, `"type":"acp-agent"`) || strings.Contains(got, "DetectCommand") || strings.Contains(got, "detect_command") {
+		t.Fatalf("AdapterMeta JSON = %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make `BackendRegistry` the source of truth for runtime metadata and protocol-family classification
- correct OpenCode and OpenClaw activity handling to follow their registered ACP protocol
- move CLI installation/version detection to the runtime Daemon while preserving the public Server API
- surface runtime-detection failures in Agent creation and onboarding instead of leaving loading state stuck
- remove the unused `SessionStater.Notify` requirement without adding a capability matrix or database state
- add a real Frontend/API/PostgreSQL/Daemon M9 E2E target

## Why

The Server previously inspected its own filesystem even though Agent processes run on the Daemon's computer. Protocol metadata also existed in both the registry and a provider-name switch, allowing the two sources to drift.

## Validation

- `go test ./...`
- `go vet ./...`
- `npm run build`
- `npm run lint` — 0 errors; 50 existing warnings
- `make test-e2e-m9` — 1 passed using the real Frontend, Server, PostgreSQL, and Daemon
