### PR TITLE
RADAR-P0-04: 统一编码工具能力判断

### DIFF
--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -1016,8 +1016,7 @@ func (h *daemonHandler) processTaskWithBackend(ctx context.Context, req runTaskR
 	var session *agent.Session
 	var providerSessionID string
 	var transcriptPath string
-	if _, isPersistent := backend.(agent.PersistentBackend); isPersistent && h.getSessionManager(req.ModelConfig.Provider) != nil {
-		sm := h.getSessionManager(req.ModelConfig.Provider)
+	if sm := h.getSessionManager(req.ModelConfig.Provider); sm != nil {
 		sessionKey := agent.ChannelSessionKey(req.AgentID, req.ChannelID)
 		if req.NodeID != "" {
 			sessionKey = agent.ThinkingSessionKey(req.NodeID)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -103,9 +103,13 @@ func main() {
 	// v1.4: Initialize persistent agent session managers for all registered types.
 	var sessionManagers []*agent.AgentSessionManager
 	for _, meta := range agent.GlobalRegistry().ListMeta() {
+		if meta.Capabilities.PersistentConversation != agent.CapabilitySupported {
+			continue
+		}
 		psBackend, err := agent.NewPersistentBackend(meta.Type)
 		if err != nil {
-			continue // not all types support persistent sessions
+			slog.Error("backend declares persistent conversation but cannot initialize it", "provider", meta.Type, "error", err)
+			continue
 		}
 		workspaceMgr = agent.NewWorkspaceManager("")
 		memoryMgr := agent.NewMemoryManager("")

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -36,6 +36,7 @@ interface DeliveryState {
   input_tokens: number;
   output_tokens: number;
   failure_code: string;
+  external_session_id: string;
 }
 
 interface RecoveryState {
@@ -150,10 +151,15 @@ function deliveryState(agentID: string): DeliveryState {
            WHERE e.run_id = r.id AND e.type = 'error'
            ORDER BY e.seq DESC
            LIMIT 1
+        ), ''),
+        'external_session_id', COALESCE((
+          SELECT s.external_session_id
+            FROM agent_sessions s
+           WHERE s.id = r.session_id
         ), '')
       )::text
       FROM latest r
-    ), '{"run_id":"","daemon_id":"","bound_daemon_id":"","status":"","contract":"","message_id":"","visible_event":false,"input_tokens":0,"output_tokens":0,"failure_code":""}')
+    ), '{"run_id":"","daemon_id":"","bound_daemon_id":"","status":"","contract":"","message_id":"","visible_event":false,"input_tokens":0,"output_tokens":0,"failure_code":"","external_session_id":""}')
   `);
 }
 
@@ -416,7 +422,7 @@ test.describe('real Agent result delivery contract', () => {
     await localComputer?.release(request);
   });
 
-  test('persists and renders a run-linked visible result before completing', async ({ page, request }) => {
+  test('persists a run-linked result and reuses the declared persistent runtime', async ({ page, request }) => {
     const auth = await authenticate(request);
     const suffix = Date.now().toString(36);
     let channel: Entity | null = null;
@@ -432,7 +438,7 @@ test.describe('real Agent result delivery contract', () => {
         computer_id: localComputer.id,
         model_provider: 'claude',
         model_name: 'sonnet',
-        system_prompt: 'When asked to introduce yourself, use solo message send to post the introduction to the current channel. Do not merely print it.',
+        system_prompt: 'Always use solo message send for visible replies. When asked to introduce yourself, post the introduction. When the user says SECOND, send exactly SECOND_OK. Do not merely print replies.',
       });
 
       await expect.poll(() => {
@@ -442,13 +448,30 @@ test.describe('real Agent result delivery contract', () => {
 
       const state = deliveryState(agent.id);
       expect(state.input_tokens + state.output_tokens).toBeGreaterThan(0);
+      expect(state.external_session_id).not.toBe('');
       expect(state.daemon_id).not.toBe('');
       expect(state.daemon_id).toBe(state.bound_daemon_id);
+
+      const secondMessage = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: 'SECOND' },
+      );
+      await expect.poll(() => {
+        const second = channelSessionState(secondMessage.id);
+        return `${second.status}/${second.external_session_id}/${second.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${state.external_session_id}/SECOND_OK`,
+      );
+      const second = channelSessionState(secondMessage.id);
 
       await authenticatePage(page, auth);
       await page.goto(`/dashboard?channel=${channel.id}`);
       const persistedMessage = page.locator(`[data-message-id="${state.message_id}"]`);
       await expect(persistedMessage).toBeVisible();
+      await expect(page.locator(`[data-message-id="${second.message_id}"]`)).toContainText('SECOND_OK');
     } finally {
       if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
       if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);

--- a/frontend/e2e/runtime-detection.spec.ts
+++ b/frontend/e2e/runtime-detection.spec.ts
@@ -17,6 +17,18 @@ interface BackendMeta {
   display_name: string;
   requires_binary: string;
   protocols: string[];
+  capabilities: BackendCapabilities;
+}
+
+type CapabilityStatus = 'supported' | 'unsupported' | 'unknown';
+
+interface BackendCapabilities {
+  persistent_conversation: CapabilityStatus;
+  resume_conversation: CapabilityStatus;
+  busy_message_delivery: CapabilityStatus;
+  safe_stop: CapabilityStatus;
+  interactive_input: CapabilityStatus;
+  token_usage: CapabilityStatus;
 }
 
 interface BackendStatus {
@@ -79,6 +91,25 @@ test.describe('M9 runtime boundaries', () => {
     expect(metadata.find((item) => item.type === 'opencode')?.protocols).toEqual(['acp']);
     expect(metadata.find((item) => item.type === 'openclaw')?.protocols).toEqual(['acp']);
     expect(metadata.every((item) => item.type && item.display_name && item.requires_binary)).toBeTruthy();
+    const capabilityKeys: (keyof BackendCapabilities)[] = [
+      'persistent_conversation',
+      'resume_conversation',
+      'busy_message_delivery',
+      'safe_stop',
+      'interactive_input',
+      'token_usage',
+    ];
+    expect(metadata.every((item) => capabilityKeys.every((key) =>
+      ['supported', 'unsupported', 'unknown'].includes(item.capabilities[key]),
+    ))).toBeTruthy();
+    expect(metadata.find((item) => item.type === 'codex')?.capabilities).toMatchObject({
+      persistent_conversation: 'supported',
+      resume_conversation: 'supported',
+      busy_message_delivery: 'unsupported',
+      safe_stop: 'supported',
+      interactive_input: 'unsupported',
+      token_usage: 'supported',
+    });
 
     const daemonResponse = await request.get(`${daemonBase}/internal/daemon/backends/detect`);
     expect(daemonResponse.ok()).toBeTruthy();
@@ -111,10 +142,24 @@ test.describe('M9 runtime boundaries', () => {
       await page.getByRole('option').filter({ hasText: computerLease.name }).click();
       await dialog.getByRole('button', { name: 'Select Runtime...' }).click();
       const visibleRuntime = serverResults.find((item) =>
-        ['openclaw', 'hermes', 'claude', 'opencode', 'codex'].includes(item.type),
+        item.available && ['codex', 'claude', 'opencode', 'hermes', 'openclaw'].includes(item.type),
       );
       expect(visibleRuntime).toBeDefined();
-      await expect(page.locator('[role="option"]').filter({ hasText: visibleRuntime!.display_name })).toBeVisible();
+      const runtimeOption = page.locator('[role="option"]').filter({ hasText: visibleRuntime!.display_name });
+      await expect(runtimeOption).toBeVisible();
+      await runtimeOption.click();
+
+      const agentName = `Runtime Agent ${suffix}`;
+      await dialog.getByLabel('Name *').fill(agentName);
+      await dialog.getByRole('button', { name: 'Create Agent', exact: true }).click();
+      await expect(dialog).toBeHidden();
+
+      const agentNode = page.locator('.relationship-agent-node').filter({ hasText: agentName });
+      await expect(agentNode).toBeVisible();
+      await agentNode.click();
+      await expect(page.getByRole('heading', { name: /Runtime Config/ })).toBeVisible();
+      await expect(page.getByText('Runtime Capabilities', { exact: true })).toHaveCount(0);
+      await expect(page.locator('[data-capability]')).toHaveCount(0);
 
       const persisted = onlineComputerState();
       expect(persisted.count).toBeGreaterThanOrEqual(1);

--- a/pkg/agent/builtins.go
+++ b/pkg/agent/builtins.go
@@ -5,6 +5,28 @@ import (
 	"os"
 )
 
+func persistentCapabilities(safeStop CapabilityStatus) BackendCapabilities {
+	return BackendCapabilities{
+		PersistentConversation: CapabilitySupported,
+		ResumeConversation:     CapabilitySupported,
+		BusyMessageDelivery:    CapabilityUnsupported,
+		SafeStop:               safeStop,
+		InteractiveInput:       CapabilityUnsupported,
+		TokenUsage:             CapabilitySupported,
+	}
+}
+
+func oneShotCapabilities() BackendCapabilities {
+	return BackendCapabilities{
+		PersistentConversation: CapabilityUnsupported,
+		ResumeConversation:     CapabilityUnsupported,
+		BusyMessageDelivery:    CapabilityUnsupported,
+		SafeStop:               CapabilitySupported,
+		InteractiveInput:       CapabilityUnsupported,
+		TokenUsage:             CapabilitySupported,
+	}
+}
+
 // init registers all built-in backend adapters into the global registry
 // when the agent package is imported. Each adapter carries its metadata
 // (display name, binary requirements, protocols) and a factory function
@@ -23,6 +45,7 @@ func init() {
 		RequiresBinary: "codex",
 		DetectCommand:  "--version",
 		Protocols:      []string{"json-rpc"},
+		Capabilities:   persistentCapabilities(CapabilitySupported),
 	}, codexFactory)
 
 	// ── opencode — OpenCode CLI via ACP ─────────────────────────────
@@ -32,6 +55,7 @@ func init() {
 		RequiresBinary: "opencode",
 		DetectCommand:  "--version",
 		Protocols:      []string{"acp"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}, opencodeFactory)
 
 	// ── cursor — Cursor Agent CLI via stream-json ───────────────────
@@ -41,6 +65,7 @@ func init() {
 		RequiresBinary: "cursor-agent",
 		DetectCommand:  "--version",
 		Protocols:      []string{"stream-json"},
+		Capabilities:   oneShotCapabilities(),
 	}, cursorFactory)
 
 	// ── gemini — Google Gemini CLI via stream-json ──────────────────
@@ -50,6 +75,7 @@ func init() {
 		RequiresBinary: "gemini",
 		DetectCommand:  "--version",
 		Protocols:      []string{"stream-json"},
+		Capabilities:   oneShotCapabilities(),
 	}, geminiFactory)
 
 	// ── kimi — Kimi CLI via ACP ─────────────────────────────────────
@@ -59,6 +85,7 @@ func init() {
 		RequiresBinary: "kimi",
 		DetectCommand:  "--version",
 		Protocols:      []string{"acp"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}, kimiFactory)
 
 	// ── kiro — Kiro CLI via ACP ─────────────────────────────────────
@@ -68,6 +95,7 @@ func init() {
 		RequiresBinary: "kiro-cli",
 		DetectCommand:  "--version",
 		Protocols:      []string{"acp"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}, kiroFactory)
 
 	// ── copilot — GitHub Copilot CLI via JSONL ──────────────────────
@@ -77,6 +105,7 @@ func init() {
 		RequiresBinary: "copilot",
 		DetectCommand:  "--version",
 		Protocols:      []string{"jsonl"},
+		Capabilities:   oneShotCapabilities(),
 	}, copilotFactory)
 
 	// ── openclaw — OpenClaw Agent CLI via ACP ───────────────────────
@@ -86,6 +115,7 @@ func init() {
 		RequiresBinary: "openclaw",
 		DetectCommand:  "--version",
 		Protocols:      []string{"acp"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}, openclawFactory)
 
 	// ── hermes — Hermes CLI via ACP ─────────────────────────────────
@@ -95,6 +125,7 @@ func init() {
 		RequiresBinary: "hermes",
 		DetectCommand:  "--version",
 		Protocols:      []string{"acp"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}, hermesFactory)
 
 	// ── pi — Pi CLI via JSONL ───────────────────────────────────────
@@ -104,6 +135,7 @@ func init() {
 		RequiresBinary: "pi",
 		DetectCommand:  "--version",
 		Protocols:      []string{"jsonl"},
+		Capabilities:   oneShotCapabilities(),
 	}, piFactory)
 }
 
@@ -116,6 +148,7 @@ func claudeMeta(typ, displayName string) AdapterMeta {
 		RequiresBinary: "claude",
 		DetectCommand:  "--version",
 		Protocols:      []string{"stream-json"},
+		Capabilities:   persistentCapabilities(CapabilityUnsupported),
 	}
 }
 

--- a/pkg/agent/builtins_test.go
+++ b/pkg/agent/builtins_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBuiltins_AllTypesCreatable(t *testing.T) {
 	types := []string{
-		"claude", "codex", "opencode", "cursor",
+		"claude", "local", "codex", "opencode", "cursor",
 		"gemini", "kimi", "kiro", "copilot", "openclaw", "hermes", "pi",
 	}
 
@@ -24,8 +24,12 @@ func TestBuiltins_AllTypesCreatable(t *testing.T) {
 			t.Errorf("Create(%q): nil backend", typ)
 			continue
 		}
-		if got := b.Name(); got != typ {
-			t.Errorf("Create(%q): Name() = %q, want %q", typ, got, typ)
+		wantName := typ
+		if typ == "local" {
+			wantName = "claude"
+		}
+		if got := b.Name(); got != wantName {
+			t.Errorf("Create(%q): Name() = %q, want %q", typ, got, wantName)
 		}
 	}
 }
@@ -34,13 +38,13 @@ func TestBuiltins_AllTypesCreatable(t *testing.T) {
 
 func TestBuiltins_ListMeta(t *testing.T) {
 	expected := []string{
-		"claude", "codex", "opencode", "cursor",
+		"claude", "local", "codex", "opencode", "cursor",
 		"gemini", "kimi", "kiro", "copilot", "openclaw", "hermes", "pi",
 	}
 
 	metas := GlobalRegistry().ListMeta()
-	if len(metas) < 11 {
-		t.Errorf("ListMeta: expected >= 11 entries, got %d", len(metas))
+	if len(metas) < 12 {
+		t.Errorf("ListMeta: expected >= 12 entries, got %d", len(metas))
 	}
 
 	typeSet := make(map[string]bool, len(metas))
@@ -57,6 +61,68 @@ func TestBuiltins_ListMeta(t *testing.T) {
 	for _, want := range expected {
 		if !typeSet[want] {
 			t.Errorf("ListMeta: missing type %q", want)
+		}
+	}
+}
+
+func TestBuiltinsCapabilitiesAreCompleteAndMatchPersistentInterface(t *testing.T) {
+	valid := map[CapabilityStatus]bool{
+		CapabilitySupported:   true,
+		CapabilityUnsupported: true,
+	}
+	for _, meta := range GlobalRegistry().ListMeta() {
+		statuses := map[string]CapabilityStatus{
+			"persistent_conversation": meta.Capabilities.PersistentConversation,
+			"resume_conversation":     meta.Capabilities.ResumeConversation,
+			"busy_message_delivery":   meta.Capabilities.BusyMessageDelivery,
+			"safe_stop":               meta.Capabilities.SafeStop,
+			"interactive_input":       meta.Capabilities.InteractiveInput,
+			"token_usage":             meta.Capabilities.TokenUsage,
+		}
+		for name, status := range statuses {
+			if !valid[status] {
+				t.Errorf("%s capability %s = %q, want an explicit supported/unsupported value", meta.Type, name, status)
+			}
+		}
+
+		backend, err := GlobalRegistry().Create(meta.Type, BackendConfig{ProviderType: meta.Type})
+		if err != nil {
+			t.Fatalf("Create(%q): %v", meta.Type, err)
+		}
+		_, implementsPersistent := backend.(PersistentBackend)
+		declaresPersistent := meta.Capabilities.PersistentConversation == CapabilitySupported
+		if implementsPersistent != declaresPersistent {
+			t.Errorf("%s persistent declaration = %v, interface implementation = %v", meta.Type, declaresPersistent, implementsPersistent)
+		}
+		if meta.Capabilities.ResumeConversation == CapabilitySupported && !declaresPersistent {
+			t.Errorf("%s declares resume without persistent conversation", meta.Type)
+		}
+	}
+}
+
+func TestBuiltinsCapabilityMatrix(t *testing.T) {
+	want := map[string]BackendCapabilities{
+		"claude":   persistentCapabilities(CapabilityUnsupported),
+		"local":    persistentCapabilities(CapabilityUnsupported),
+		"codex":    persistentCapabilities(CapabilitySupported),
+		"opencode": persistentCapabilities(CapabilityUnsupported),
+		"kimi":     persistentCapabilities(CapabilityUnsupported),
+		"kiro":     persistentCapabilities(CapabilityUnsupported),
+		"openclaw": persistentCapabilities(CapabilityUnsupported),
+		"hermes":   persistentCapabilities(CapabilityUnsupported),
+		"cursor":   oneShotCapabilities(),
+		"gemini":   oneShotCapabilities(),
+		"copilot":  oneShotCapabilities(),
+		"pi":       oneShotCapabilities(),
+	}
+	for typ, expected := range want {
+		meta, ok := GlobalRegistry().Meta(typ)
+		if !ok {
+			t.Errorf("missing metadata for %s", typ)
+			continue
+		}
+		if meta.Capabilities != expected {
+			t.Errorf("%s capabilities = %+v, want %+v", typ, meta.Capabilities, expected)
 		}
 	}
 }
@@ -142,8 +208,8 @@ func TestBuiltins_NewPersistentBackend(t *testing.T) {
 		if pb != nil {
 			t.Errorf("NewPersistentBackend(%q): expected nil backend on error", typ)
 		}
-		if err != nil && !strings.Contains(err.Error(), "persistent backend not supported") {
-			t.Errorf("NewPersistentBackend(%q): error missing 'persistent backend not supported': %v", typ, err)
+		if err != nil && !strings.Contains(err.Error(), "persistent conversation not supported") {
+			t.Errorf("NewPersistentBackend(%q): error missing capability reason: %v", typ, err)
 		}
 	}
 

--- a/pkg/agent/factory.go
+++ b/pkg/agent/factory.go
@@ -67,18 +67,23 @@ func newClaudeBackendFromEnv() *ClaudeBackend {
 }
 
 // NewPersistentBackend creates a PersistentBackend for the given provider type.
-// It delegates to the global BackendRegistry and checks whether the created
-// Backend satisfies the PersistentBackend interface.
-//
-// Supported: claude, codex, opencode, hermes, kimi, kiro, openclaw.
+// The registry capability is the product contract; the interface assertion is
+// a second guard against an adapter declaring support it does not implement.
 func NewPersistentBackend(providerType string) (PersistentBackend, error) {
+	meta, ok := GlobalRegistry().Meta(providerType)
+	if !ok {
+		return nil, fmt.Errorf("unknown backend type: %q", providerType)
+	}
+	if meta.Capabilities.PersistentConversation != CapabilitySupported {
+		return nil, fmt.Errorf("persistent conversation not supported for provider %q", providerType)
+	}
 	backend, err := GlobalRegistry().Create(providerType, BackendConfig{ProviderType: providerType})
 	if err != nil {
 		return nil, err
 	}
 	pb, ok := backend.(PersistentBackend)
 	if !ok {
-		return nil, fmt.Errorf("persistent backend not supported for provider %q (supported: claude, local, codex, opencode, hermes, kimi, kiro, openclaw)", providerType)
+		return nil, fmt.Errorf("backend %q declares persistent conversation but does not implement it", providerType)
 	}
 	return pb, nil
 }

--- a/pkg/agent/registry.go
+++ b/pkg/agent/registry.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -22,13 +23,57 @@ type BackendConfig struct {
 	Logger       *slog.Logger
 }
 
+// CapabilityStatus describes whether a backend capability is available
+// through Solo's integration. The zero value is normalized to unknown so
+// adapters compiled before the capability table remain safe and visible.
+type CapabilityStatus string
+
+const (
+	CapabilitySupported   CapabilityStatus = "supported"
+	CapabilityUnsupported CapabilityStatus = "unsupported"
+	CapabilityUnknown     CapabilityStatus = "unknown"
+)
+
+// BackendCapabilities is the runtime contract for one backend adapter.
+// It describes Solo's integration rather than every feature the underlying
+// CLI may expose on its own.
+type BackendCapabilities struct {
+	PersistentConversation CapabilityStatus `json:"persistent_conversation"`
+	ResumeConversation     CapabilityStatus `json:"resume_conversation"`
+	BusyMessageDelivery    CapabilityStatus `json:"busy_message_delivery"`
+	SafeStop               CapabilityStatus `json:"safe_stop"`
+	InteractiveInput       CapabilityStatus `json:"interactive_input"`
+	TokenUsage             CapabilityStatus `json:"token_usage"`
+}
+
+func normalizeCapabilityStatus(status CapabilityStatus) CapabilityStatus {
+	switch status {
+	case CapabilitySupported, CapabilityUnsupported, CapabilityUnknown:
+		return status
+	default:
+		return CapabilityUnknown
+	}
+}
+
+func (c BackendCapabilities) normalized() BackendCapabilities {
+	return BackendCapabilities{
+		PersistentConversation: normalizeCapabilityStatus(c.PersistentConversation),
+		ResumeConversation:     normalizeCapabilityStatus(c.ResumeConversation),
+		BusyMessageDelivery:    normalizeCapabilityStatus(c.BusyMessageDelivery),
+		SafeStop:               normalizeCapabilityStatus(c.SafeStop),
+		InteractiveInput:       normalizeCapabilityStatus(c.InteractiveInput),
+		TokenUsage:             normalizeCapabilityStatus(c.TokenUsage),
+	}
+}
+
 // AdapterMeta describes a registered backend adapter for discovery and UI.
 type AdapterMeta struct {
-	Type           string   `json:"type"`            // "claude", "codex", "opencode"...
-	DisplayName    string   `json:"display_name"`    // "Claude Code", "Codex CLI"
-	RequiresBinary string   `json:"requires_binary"` // CLI binary name, e.g. "claude", "codex", "opencode"
-	DetectCommand  string   `json:"-"`               // e.g. "--version"
-	Protocols      []string `json:"protocols"`       // "stream-json", "json-rpc", "acp", "jsonl"
+	Type           string              `json:"type"`            // "claude", "codex", "opencode"...
+	DisplayName    string              `json:"display_name"`    // "Claude Code", "Codex CLI"
+	RequiresBinary string              `json:"requires_binary"` // CLI binary name, e.g. "claude", "codex", "opencode"
+	DetectCommand  string              `json:"-"`               // e.g. "--version"
+	Protocols      []string            `json:"protocols"`       // "stream-json", "json-rpc", "acp", "jsonl"
+	Capabilities   BackendCapabilities `json:"capabilities"`
 }
 
 // Meta returns the registered metadata for typ.
@@ -63,6 +108,7 @@ func GlobalRegistry() *BackendRegistry { return globalRegistry }
 // Register adds a backend adapter to the registry. It overwrites any
 // existing entry with the same meta.Type. Safe for concurrent use.
 func (r *BackendRegistry) Register(meta AdapterMeta, factory BackendFactory) {
+	meta.Capabilities = meta.Capabilities.normalized()
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.backends[meta.Type] = registryEntry{Factory: factory, Meta: meta}
@@ -137,5 +183,6 @@ func (r *BackendRegistry) ListMeta() []AdapterMeta {
 	for _, e := range r.backends {
 		metas = append(metas, e.Meta)
 	}
+	sort.Slice(metas, func(i, j int) bool { return metas[i].Type < metas[j].Type })
 	return metas
 }

--- a/pkg/agent/registry_test.go
+++ b/pkg/agent/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -147,11 +148,44 @@ func TestRegistry_ListMeta(t *testing.T) {
 			t.Errorf("missing entry for type %q", want)
 		}
 	}
+	if got := []string{metas[0].Type, metas[1].Type, metas[2].Type}; !slices.Equal(got, []string{"a", "b", "c"}) {
+		t.Fatalf("ListMeta order = %v, want stable type order", got)
+	}
+}
+
+func TestRegistryNormalizesMissingAndInvalidCapabilities(t *testing.T) {
+	reg := &BackendRegistry{backends: make(map[string]registryEntry)}
+	reg.Register(AdapterMeta{
+		Type: "future",
+		Capabilities: BackendCapabilities{
+			SafeStop: CapabilityStatus("invalid"),
+		},
+	}, nil)
+
+	meta, ok := reg.Meta("future")
+	if !ok {
+		t.Fatal("Meta(future) not found")
+	}
+	for name, status := range map[string]CapabilityStatus{
+		"persistent_conversation": meta.Capabilities.PersistentConversation,
+		"resume_conversation":     meta.Capabilities.ResumeConversation,
+		"busy_message_delivery":   meta.Capabilities.BusyMessageDelivery,
+		"safe_stop":               meta.Capabilities.SafeStop,
+		"interactive_input":       meta.Capabilities.InteractiveInput,
+		"token_usage":             meta.Capabilities.TokenUsage,
+	} {
+		if status != CapabilityUnknown {
+			t.Errorf("%s = %q, want unknown", name, status)
+		}
+	}
 }
 
 func TestRegistry_Meta(t *testing.T) {
 	reg := &BackendRegistry{backends: make(map[string]registryEntry)}
-	reg.Register(AdapterMeta{Type: "acp-agent", DisplayName: "ACP Agent", DetectCommand: "--version", Protocols: []string{"acp"}}, nil)
+	reg.Register(AdapterMeta{
+		Type: "acp-agent", DisplayName: "ACP Agent", DetectCommand: "--version", Protocols: []string{"acp"},
+		Capabilities: BackendCapabilities{PersistentConversation: CapabilitySupported},
+	}, nil)
 
 	meta, ok := reg.Meta("acp-agent")
 	if !ok || len(meta.Protocols) != 1 || meta.Protocols[0] != "acp" {
@@ -164,7 +198,9 @@ func TestRegistry_Meta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := string(wire); !strings.Contains(got, `"type":"acp-agent"`) || strings.Contains(got, "DetectCommand") || strings.Contains(got, "detect_command") {
+	if got := string(wire); !strings.Contains(got, `"type":"acp-agent"`) ||
+		!strings.Contains(got, `"persistent_conversation":"supported"`) ||
+		strings.Contains(got, "DetectCommand") || strings.Contains(got, "detect_command") {
 		t.Fatalf("AdapterMeta JSON = %s", got)
 	}
 }


### PR DESCRIPTION
## 改了什么

- 为所有内置编码工具增加统一的后端能力声明，覆盖持续对话、恢复、忙碌时收消息、安全停止、运行中输入和 Token 用量。
- 本机运行程序只为明确支持持续对话的工具建立并复用长期会话；声明与实际实现不一致时安全跳过并记录错误。
- 补充统一能力表、接口输出和真实会话复用测试。
- 不增加页面入口、字段或能力卡片，现有 Agent 运行设置保持不变。

## 为什么做

此前不同编码工具的能力判断分散在多处。统一声明后，新增或调整工具时可以在一个地方明确边界，避免不支持的工具被错误地当成可以连续对话。

对现有用户的日常使用基本没有变化；主要收益是降低以后接入新工具时出现上下文丢失或错误复用的风险。

## 验证

- `go test ./...`
- `npm run lint`：0 个错误，48 个已有警告
- `npm run build`
- 真实浏览器 + API + 本机运行程序 + PostgreSQL：创建并打开真实 Agent，确认现有运行设置正常且没有常驻能力卡片
- 真实 Claude Agent 连续两轮对话：确认复用同一段外部会话，页面结果、运行记录和 Token 用量均写入真实数据库
- `git diff --check origin/master...HEAD`

## 已知边界

- 当前只有“持续对话”参与实际运行判断。
- 其余五项是统一声明和一致性约束，本 PR 不宣称实现忙碌时插话、运行中审批等新功能。
