### PR TITLE
fix: preserve managed daemon pairing across restarts

### DIFF
--- a/cmd/solo/daemon.go
+++ b/cmd/solo/daemon.go
@@ -143,6 +143,14 @@ func startManagedDaemon(extraEnv []string) error {
 	if err != nil {
 		return err
 	}
+	credentialPath, err = filepath.Abs(credentialPath)
+	if err != nil {
+		return err
+	}
+	// A managed Daemon belongs to Solo, not to the project directory where the
+	// user happened to invoke the CLI. Keep config.LoadDotenv in the child from
+	// loading an unrelated project .env and overriding the persisted pairing.
+	cmd.Dir = filepath.Dir(logPath)
 	cmd.Env = append(os.Environ(), "SOLO_DAEMON_CREDENTIAL_FILE="+credentialPath)
 	cmd.Env = append(cmd.Env, extraEnv...)
 	cmd.Stdin = nil
@@ -152,12 +160,13 @@ func startManagedDaemon(extraEnv []string) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
+	pid := cmd.Process.Pid
 	pidPath, err := daemonStatePath("daemon.pid")
 	if err != nil {
 		_ = cmd.Process.Kill()
 		return err
 	}
-	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(cmd.Process.Pid)+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
 		_ = cmd.Process.Kill()
 		return err
 	}
@@ -166,7 +175,7 @@ func startManagedDaemon(extraEnv []string) error {
 	if _, running := daemonPID(); !running {
 		return fmt.Errorf("failed to start; inspect %s", logPath)
 	}
-	fmt.Printf("Solo Daemon started (pid %d). Logs: %s\n", cmd.Process.Pid, logPath)
+	fmt.Printf("Solo Daemon started (pid %d). Logs: %s\n", pid, logPath)
 	return nil
 }
 

--- a/cmd/solo/daemon_test.go
+++ b/cmd/solo/daemon_test.go
@@ -4,7 +4,11 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestManagedDaemonConnectedRequiresReadyControlChannel(t *testing.T) {
@@ -32,5 +36,79 @@ func TestManagedDaemonConnectedRequiresReadyControlChannel(t *testing.T) {
 	ready = true
 	if !managedDaemonConnected() {
 		t.Fatal("Daemon did not report the ready remote control channel")
+	}
+}
+
+func TestStartManagedDaemonUsesSoloStateDirectory(t *testing.T) {
+	home := t.TempDir()
+	callerDir := t.TempDir()
+	observedCWD := filepath.Join(t.TempDir(), "cwd")
+	observedCredential := filepath.Join(t.TempDir(), "credential")
+	helper := filepath.Join(t.TempDir(), "solo-daemon")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\ntrap 'exit 0' TERM INT\npwd > \"$OBSERVED_CWD\"\nprintf '%s\\n' \"$SOLO_DAEMON_CREDENTIAL_FILE\" > \"$OBSERVED_CREDENTIAL\"\nwhile :; do sleep 1; done\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(callerDir, ".env"), []byte("DAEMON_SERVER_URL=http://wrong.example\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(callerDir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldCWD) })
+	t.Setenv("HOME", home)
+	t.Setenv("SOLO_DAEMON_BINARY", helper)
+	t.Setenv("OBSERVED_CWD", observedCWD)
+	t.Setenv("OBSERVED_CREDENTIAL", observedCredential)
+	t.Setenv("SOLO_DAEMON_CREDENTIAL_FILE", "relative-credentials.json")
+
+	if err := startManagedDaemon(nil); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if pid, running := daemonPID(); running {
+			if process, findErr := os.FindProcess(pid); findErr == nil {
+				_ = process.Kill()
+			}
+		}
+		if pidPath, pathErr := daemonStatePath("daemon.pid"); pathErr == nil {
+			_ = os.Remove(pidPath)
+		}
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	var raw []byte
+	for time.Now().Before(deadline) {
+		raw, err = os.ReadFile(observedCWD)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("read child working directory: %v", err)
+	}
+	want, err := filepath.EvalSymlinks(filepath.Join(home, ".solo", "daemon"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filepath.Clean(strings.TrimSpace(string(raw))); got != want {
+		t.Fatalf("child working directory = %q, want %q", got, want)
+	}
+	raw, err = os.ReadFile(observedCredential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvedCallerDir, err := filepath.EvalSymlinks(callerDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCredential := filepath.Join(resolvedCallerDir, "relative-credentials.json")
+	if got := strings.TrimSpace(string(raw)); got != wantCredential {
+		t.Fatalf("child credential path = %q, want %q", got, wantCredential)
 	}
 }


### PR DESCRIPTION
## Summary
- start CLI-managed Daemons from Solo's private state directory so a caller project `.env` cannot override the persisted production pairing
- preserve relative custom credential-file semantics by resolving the path before changing the child working directory
- retain the real child PID before releasing the process, fixing the `pid -1` startup message

## Validation
- `go test ./...`
- `bash scripts/test-release-install.sh`
- real Singapore E2E: paired this Mac to `https://soloagent.team`, reproduced restart from a repository containing a conflicting `.env`, then verified `control_connected=true` and the persisted production Computer ID
- real offline recovery: one queued PostgreSQL Run recovered with one delivery and one visible reply