### PR TITLE
fix: allow multiple legacy remote daemons to connect

### DIFF
--- a/internal/server/service/computer_auth.go
+++ b/internal/server/service/computer_auth.go
@@ -196,7 +196,11 @@ func (s *ComputerService) RevokeCredential(ctx context.Context, computerID, user
 	return nil
 }
 
-func (s *ComputerService) MarkConnected(ctx context.Context, computerID, daemonID, daemonVersion string, protocolVersion int, inventory json.RawMessage, sysinfo ComputerSystemInfo, agentIDs []string) error {
+func (s *ComputerService) MarkConnected(ctx context.Context, computerID, reportedDaemonID, daemonVersion string, protocolVersion int, inventory json.RawMessage, sysinfo ComputerSystemInfo, agentIDs []string) error {
+	// The authenticated Computer is the remote routing identity. Older clients
+	// all report "daemon-01", so persisting that client label would make the
+	// second paired Computer violate the global daemon_id uniqueness constraint.
+	canonicalDaemonID := computerID
 	if len(inventory) == 0 || !json.Valid(inventory) {
 		inventory = json.RawMessage("[]")
 	}
@@ -216,7 +220,7 @@ func (s *ComputerService) MarkConnected(ctx context.Context, computerID, daemonI
 		`UPDATE computers
 		    SET daemon_id = NULL, daemon_url = NULL, status = 'offline', updated_at = now()
 		  WHERE daemon_id = $1 AND id <> $2 AND credential_hash IS NULL`,
-		daemonID, computerID,
+		reportedDaemonID, computerID,
 	); err != nil {
 		return fmt.Errorf("mark computer connected: release legacy registration: %w", err)
 	}
@@ -228,7 +232,7 @@ func (s *ComputerService) MarkConnected(ctx context.Context, computerID, daemonI
 		        runtime_inventory = $5, os = $6, hostname = $7, ip = $8,
 		        agent_ids = $9, last_heartbeat = now(), last_connected_at = now(), updated_at = now()
 		  WHERE id = $1 AND credential_hash IS NOT NULL AND credential_revoked_at IS NULL`,
-		computerID, daemonID, daemonVersion, protocolVersion, inventory,
+		computerID, canonicalDaemonID, daemonVersion, protocolVersion, inventory,
 		sysinfo.OS, sysinfo.Hostname, sysinfo.IP, activeAgentIDs,
 	)
 	if err != nil {

--- a/internal/server/service/computer_test.go
+++ b/internal/server/service/computer_test.go
@@ -93,8 +93,62 @@ func TestMarkConnectedSupersedesLegacyDaemonRegistration(t *testing.T) {
 	).Scan(&targetDaemonID, &legacyDaemonID, &legacyStatus); err != nil {
 		t.Fatal(err)
 	}
-	if targetDaemonID == nil || *targetDaemonID != daemonID || legacyDaemonID != nil || legacyStatus != "offline" {
+	if targetDaemonID == nil || *targetDaemonID != target.Computer.ID || legacyDaemonID != nil || legacyStatus != "offline" {
 		t.Fatalf("target daemon = %v, legacy daemon/status = %v/%s", targetDaemonID, legacyDaemonID, legacyStatus)
+	}
+}
+
+func TestMarkConnectedCanonicalizesSharedReportedDaemonIDs(t *testing.T) {
+	pool := taskSubmitTestPool(t)
+	ctx := context.Background()
+	ownerID := taskSubmitUser(t, pool)
+	svc := NewComputerService(pool)
+
+	first, err := svc.CreateComputerWithEnrollment(ctx, ownerID, "first-mac")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := svc.CreateComputerWithEnrollment(ctx, ownerID, "second-mac")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, enrollment := range []*ComputerEnrollment{first, second} {
+		if _, err := svc.ExchangeEnrollment(ctx, enrollment.Computer.ID, enrollment.Token); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM computers WHERE id IN ($1, $2)`, first.Computer.ID, second.Computer.ID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	for _, enrollment := range []*ComputerEnrollment{first, second} {
+		if err := svc.MarkConnected(ctx, enrollment.Computer.ID, "daemon-01", "test", ComputerProtocolVersion, nil, ComputerSystemInfo{}, nil); err != nil {
+			t.Fatalf("MarkConnected(%s): %v", enrollment.Computer.Name, err)
+		}
+	}
+
+	rows, err := pool.Query(ctx, `SELECT id::text, daemon_id FROM computers WHERE id IN ($1, $2)`, first.Computer.ID, second.Computer.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	seen := 0
+	for rows.Next() {
+		var computerID, daemonID string
+		if err := rows.Scan(&computerID, &daemonID); err != nil {
+			t.Fatal(err)
+		}
+		if daemonID != computerID {
+			t.Fatalf("Computer %s daemon_id = %q", computerID, daemonID)
+		}
+		seen++
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if seen != 2 {
+		t.Fatalf("connected Computers = %d, want 2", seen)
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat the authenticated Computer UUID as the canonical identity for reverse-control Daemons
- keep the client-reported legacy ID only for superseding an unauthenticated local registration
- let multiple existing v1.0.0 clients that all report `daemon-01` connect to the same public Server without re-enrollment

## Validation
- real PostgreSQL regression: two paired Computers both report `daemon-01` and persist distinct canonical IDs
- existing legacy-registration takeover behavior remains covered
- `go test ./internal/server/service -count=1`
- `go test ./...`

## Production finding
Singapore logs showed a second paired Computer repeatedly rejected by `idx_computers_daemon_id_unique` while the first production Computer was online.