### PR TITLE
fix: refresh Agent credentials for template discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-server test-e2e-public-remote
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-agent-template-credential test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-server test-e2e-public-remote
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -41,6 +41,9 @@ rebuild: stop clean-pids build start ## Rebuild binaries from a clean .pids dir 
 
 test-e2e-agent-delivery: rebuild ## Rebuild and verify the real Agent result delivery contract
 	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts
+
+test-e2e-agent-template-credential: rebuild ## Verify template discovery across persistent Agent Runs
+	@cd frontend && CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "lists templates through the current Run" --workers=1
 
 test-e2e-budget-gate: export DAEMON_SERVER_URL := http://127.0.0.1:8080
 test-e2e-budget-gate: export SOLO_DAEMON_CREDENTIAL_FILE := /tmp/solo-budget-gate-e2e-credentials.json

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -368,7 +368,9 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 	_, token := h.taskManager.ExecutingCredential(req.AgentID, req.ChannelID, req.NodeID)
 	if token == "" {
-		writeJSON(w, http.StatusConflict, map[string]string{"error": "no executing Run credential for this Agent scope"})
+		writeJSON(w, http.StatusConflict, map[string]string{
+			"error": "this command must run during one active Agent turn; no unique current Run was found",
+		})
 		return
 	}
 
@@ -407,6 +409,8 @@ func (h *daemonHandler) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/members", req.ChannelID)
 	case "server_info":
 		serverPath = "/api/v1/server/info"
+	case "template_list":
+		serverPath = "/api/v1/templates"
 	case "message_read":
 		serverPath = fmt.Sprintf("/api/v1/channels/%s/messages", req.ChannelID)
 		if req.NodeID != "" {

--- a/cmd/daemon/handler_test.go
+++ b/cmd/daemon/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,6 +47,62 @@ func TestControlRPCReadsTranscriptFromLocalRuntime(t *testing.T) {
 	}
 	if len(entries) != 1 || entries[0].Text != "remote transcript works" || len(entries[0].Raw) != 0 {
 		t.Fatalf("entries = %#v", entries)
+	}
+}
+
+func TestProxyTemplateListUsesCurrentExecutingRunCredential(t *testing.T) {
+	const freshToken = "fresh-current-run-token"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/templates" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+freshToken {
+			t.Fatalf("authorization = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id":"dev-team"}]`)
+	}))
+	defer server.Close()
+
+	tm := newTaskManager()
+	tm.AddTask("task-current", &taskState{
+		TaskID:     "task-current",
+		RunID:      "run-current",
+		AgentID:    "agent-1",
+		ChannelID:  "channel-1",
+		Status:     taskStatusRunning,
+		AgentToken: freshToken,
+	})
+	h := newDaemonHandler(tm, nil, server.URL, "")
+
+	body := bytes.NewBufferString(`{"agent_id":"agent-1","action":"template_list"}`)
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", body)
+	req.RemoteAddr = "127.0.0.1:45678"
+	recorder := httptest.NewRecorder()
+	h.ProxyRequest(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"id":"dev-team"`) {
+		t.Fatalf("body = %s", recorder.Body.String())
+	}
+}
+
+func TestProxyWithoutExecutingRunExplainsRuntimeStateNotPermission(t *testing.T) {
+	h := newDaemonHandler(newTaskManager(), nil, "http://remote-server.invalid", "")
+	body := bytes.NewBufferString(`{"agent_id":"agent-1","action":"template_list"}`)
+	req := httptest.NewRequest(http.MethodPost, "/internal/daemon/proxy", body)
+	req.RemoteAddr = "127.0.0.1:45678"
+	recorder := httptest.NewRecorder()
+	h.ProxyRequest(recorder, req)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	response := strings.ToLower(recorder.Body.String())
+	if !strings.Contains(response, "active agent turn") || strings.Contains(response, "permission") {
+		t.Fatalf("body = %s", recorder.Body.String())
 	}
 }
 

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -138,7 +138,10 @@ func handleTemplate(args []string, baseURL, token string) {
 	jsonOutput := fs.Bool("json", false, "Print compact JSON")
 	fs.Parse(args[1:])
 
-	statusCode, body, err := doHTTP(http.MethodGet, baseURL+"/api/v1/templates", token, nil)
+	statusCode, body, err := proxyRequest("template_list", "", "", "", token, 0, "", "")
+	if err != nil && allowDirectFallback() {
+		statusCode, body, err = doHTTP(http.MethodGet, baseURL+"/api/v1/templates", token, nil)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
 		doExit(exitUsage)

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -1212,6 +1212,57 @@ func TestHandleChannelMembersMissingChannel(t *testing.T) {
 	}
 }
 
+func TestHandleTemplateListUsesDaemonRunCredential(t *testing.T) {
+	var request map[string]any
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/daemon/proxy" || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[{"id":"dev-team","name":"Development Team","description":"Build software","roles":["lead","engineer"]}]`)
+	}))
+	defer daemon.Close()
+
+	t.Setenv("SOLO_DAEMON_URL", daemon.URL)
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+	t.Setenv("SOLO_RUN_ID", "old-run-from-persistent-process")
+
+	code, stdout, stderr := captureAndRun(t, func() {
+		handleTemplate([]string{"list", "--json"}, "http://remote-server.invalid", "stale-process-token")
+	})
+	if code != exitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if request["action"] != "template_list" || request["agent_id"] != "agent-1" {
+		t.Fatalf("proxy request = %#v", request)
+	}
+	if !strings.Contains(stdout, `"id":"dev-team"`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+func TestHandleTemplateListFallsBackToDirectAPIForHumanCLI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer user-token" {
+			t.Fatalf("authorization = %q", got)
+		}
+		fmt.Fprint(w, `[{"id":"dev-team"}]`)
+	}))
+	defer server.Close()
+
+	t.Setenv("SOLO_DAEMON_URL", "")
+	t.Setenv("SOLO_AGENT_ID", "")
+	code, stdout, stderr := captureAndRun(t, func() {
+		handleTemplate([]string{"list", "--json"}, server.URL, "user-token")
+	})
+	if code != exitOK || !strings.Contains(stdout, `"id":"dev-team"`) {
+		t.Fatalf("exit = %d, stdout = %q, stderr = %q", code, stdout, stderr)
+	}
+}
+
 func TestHandleTeamFormSendsDeclarativePlan(t *testing.T) {
 	const channelID = "550e8400-e29b-41d4-a716-446655440099"
 	const sourceMessageID = "a1b2c3d4"

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -478,6 +478,121 @@ test.describe('real Agent result delivery contract', () => {
     }
   });
 
+  test('lists templates through the current Run across a persistent Agent Session', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `template-proxy-e2e-${suffix}`,
+        description: 'Persistent Agent template credential E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Template Proxy E2E ${suffix}`,
+        computer_id: localComputer.id,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: [
+          'Always deliver replies with solo message send.',
+          'When introducing yourself, run solo template list --json first. If it succeeds, send exactly TEMPLATE_LIST_FIRST_OK.',
+          'When the user says LIST_AGAIN, run solo template list --json again. If it succeeds, send exactly TEMPLATE_LIST_SECOND_OK.',
+          'Do not guess or memorize the catalog. Do not send an OK result unless the command returned a non-empty JSON template array.',
+        ].join(' '),
+      });
+
+      await expect.poll(() => {
+        const state = deliveryState(agent!.id);
+        return `${state.status}/${state.message_id ? 'visible' : 'missing'}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('completed/visible');
+      const first = deliveryState(agent.id);
+      expect(first.external_session_id).not.toBe('');
+
+      const secondTrigger = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: 'LIST_AGAIN' },
+      );
+      await expect.poll(() => {
+        const state = channelSessionState(secondTrigger.id);
+        return `${state.status}/${state.external_session_id}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${first.external_session_id}/TEMPLATE_LIST_SECOND_OK`,
+      );
+
+      const second = channelSessionState(secondTrigger.id);
+      const persisted = databaseJSON<{
+        runs: number;
+        completed: number;
+        sessions: number;
+        visible_messages: number;
+        transcript_path: string;
+      }>(`
+        SELECT json_build_object(
+          'runs', COUNT(*),
+          'completed', COUNT(*) FILTER (WHERE r.status = 'completed'),
+          'sessions', COUNT(DISTINCT r.session_id),
+          'visible_messages', COUNT(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM messages m WHERE m.metadata->>'agent_run_id' = r.id::text
+          )),
+          'transcript_path', COALESCE(MAX(r.transcript_path), '')
+        )::text
+          FROM agent_runs r
+         WHERE r.agent_id = '${agent.id}'
+      `);
+      expect(persisted).toMatchObject({ runs: 2, completed: 2, sessions: 1, visible_messages: 2 });
+      expect(persisted.transcript_path).not.toBe('');
+
+      const transcriptEntries = readFileSync(persisted.transcript_path, 'utf8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as {
+          message?: { content?: Array<{
+            type?: string;
+            id?: string;
+            tool_use_id?: string;
+            is_error?: boolean;
+            content?: string;
+            name?: string;
+            input?: { command?: string };
+          }> };
+        });
+      const templateToolIDs = new Set(transcriptEntries.flatMap((entry) => (
+        entry.message?.content ?? []
+      )).filter((content) => (
+        content.type === 'tool_use'
+        && content.name === 'Bash'
+        && content.input?.command === 'solo template list --json'
+        && content.id
+      )).map((content) => content.id!));
+      const successfulTemplateResults = transcriptEntries.flatMap((entry) => (
+        entry.message?.content ?? []
+      )).filter((content) => {
+        if (content.type !== 'tool_result' || !content.tool_use_id || content.is_error) return false;
+        if (!templateToolIDs.has(content.tool_use_id) || typeof content.content !== 'string') return false;
+        try {
+          const templates = JSON.parse(content.content) as unknown;
+          return Array.isArray(templates) && templates.length > 0;
+        } catch {
+          return false;
+        }
+      });
+      expect(templateToolIDs.size).toBe(2);
+      expect(successfulTemplateResults).toHaveLength(2);
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.locator(`[data-message-id="${first.message_id}"]`)).toContainText('TEMPLATE_LIST_FIRST_OK');
+      await expect(page.locator(`[data-message-id="${second.message_id}"]`)).toContainText('TEMPLATE_LIST_SECOND_OK');
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
   test('routes an unmentioned Channel message only to the unique Coordinator', async ({ page, request }) => {
     const auth = await authenticate(request);
     const suffix = Date.now().toString(36);


### PR DESCRIPTION
## What changed

- Route `solo template list` through the local Daemon during Agent turns so persistent provider sessions receive the credential for the current Run.
- Preserve direct Server access for normal human CLI usage when no Daemon URL is configured.
- Replace the misleading permission error with an explicit “no unique active Run” diagnostic.
- Add unit coverage plus a real Claude persistent-session E2E that executes template discovery successfully across two Runs and verifies the visible messages and persisted Run/session state.

## Why

The provider process persists across Runs, but a Run credential is valid only while that Run is active. The process therefore retained the previous Run's token and a later direct template request returned 401. Agents such as Lucy interpreted that transport/auth lifecycle problem as a user permission restriction.

The Daemon already knows which Run is currently executing, so it is the correct place to supply the current credential without exposing machine credentials or weakening Run isolation.

## User impact

An Agent running on a connected computer can discover the official template list on later turns without being blocked by a stale credential or reporting a false permission limitation.

## Validation

- `go test ./...`
- `cd frontend && npm run lint` (0 errors; existing warnings only)
- `cd frontend && npx tsc --noEmit`
- `make test-e2e-agent-template-credential ENV_FILE=...` — real frontend, API server, PostgreSQL, Daemon, Solo CLI, and Claude provider; 1 passed
