### PR TITLE
Coalesce busy Agent message wakes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-agent-message-coalescing test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -41,6 +41,9 @@ rebuild: stop clean-pids build start ## Rebuild binaries from a clean .pids dir 
 
 test-e2e-agent-delivery: ## Rebuild and verify the real Agent result delivery contract
 	@bash scripts/run-local-e2e.sh agent-delivery env CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts
+
+test-e2e-agent-message-coalescing: ## Rebuild and verify persisted busy-message coalescing with a real Agent
+	@bash scripts/run-local-e2e.sh agent-message-coalescing env CI=1 npx playwright test e2e/agent-message-coalescing.spec.ts --workers=1
 
 test-e2e-agent-template-credential: ## Verify template discovery across persistent Agent Runs
 	@bash scripts/run-local-e2e.sh agent-template-credential env CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "lists templates through the current Run" --workers=1

--- a/docs/design/agent-message-wake-coalescing.md
+++ b/docs/design/agent-message-wake-coalescing.md
@@ -1,0 +1,78 @@
+# Agent Message Wake Coalescing
+
+Status: implementation design
+Scope: persisted Channel and Thread messages that may wake an Agent. Thinking-node, scheduled, greeting, and task Runs keep their existing explicit dispatch paths.
+
+## 1. Product behavior
+
+- A public ordinary Channel is mention-only for Agents. Persisting and broadcasting an unmentioned message still succeeds, but it does not create an Agent Run.
+- DM and Lucy messages remain conversational and may wake an Agent without `@`.
+- Private ordinary Channels retain the existing coordinator/small-team/recent-Agent routing fallback.
+- One Agent executes at most one message-triggered Run per Channel at a time. This matches the runtime Session key, which is shared by the Channel and its Threads.
+- Messages arriving while that Run is active are not overwritten. Each message remains an immutable `messages` row. The pending wake records the first and latest unconsumed sequence for each Channel or Thread scope, and the next Run receives every persisted message in that range in sequence order.
+- An explicit mention, DM, or Lucy turn requires a user-visible result. An automatic private-Channel fallback may finish silently and is not retried solely because no visible message was sent.
+- A Channel-level Run may deliver its visible result either to the Channel root or to a Thread under that same Channel. The reply stays attributed to the originating Run; otherwise the terminal checker would mistake a valid Thread reply for a missing result and enqueue a reminder loop. Thread and Thinking-node Runs remain bound to their exact scope.
+
+## 2. Domain model, ownership, and lifecycle
+
+`agent_message_wake_slots` is the server-owned single-flight lease for `(agent_id, channel_id)`. Its `active_run_id` points at the currently executing message Run. The row is created lazily and contains no user-authored content.
+
+`agent_pending_message_wakes` is server-owned delivery state. A row is unique per `(agent_id, channel_id, scope_key)`, where `scope_key` is `channel` or `thread:<thread_id>`. It stores `first_message_seq`, `latest_message_seq`, and whether any merged trigger requires a visible result. The authoritative content remains in `messages`.
+
+Lifecycle:
+
+1. Routing selects a target Agent after a message is persisted.
+2. A transaction locks the Agent/Channel wake slot.
+3. If no message Run is active, the same transaction creates and budget-reserves a Run and assigns it to the slot.
+4. If a Run is active, the transaction upserts the scope's pending interval using `LEAST(first_seq)` and `GREATEST(latest_seq)`; visibility requirements are combined with logical OR.
+5. When the active Run reaches a terminal state, a transaction releases that exact Run, claims the oldest pending scope, creates and reserves its next Run, deletes only the claimed pending row, and assigns the new Run to the slot.
+6. Messages that arrive after the claim block on the same slot lock and form a new pending interval, so they cannot be lost or accidentally included in the already claimed Run.
+
+## 3. Data flow
+
+For an immediate Run, the existing persisted trigger message is its turn input. For a coalesced Run, the server loads all non-deleted messages from the claimed Channel/Thread scope whose sequence is inside the pending interval, orders them by sequence, and converts them to the same runtime message format used by a normal wake. Gaps caused by messages in another Thread are ignored by the scope filter.
+
+The latest message in the claimed range is the Run's audit `trigger_message_id`; the full range is its runtime input. Mention names are rebuilt from the loaded rows. Existing recent/cold-start context continues to be supplied where the runtime already expects it.
+
+The browser and WebSocket protocol do not gain optimistic pending state. Users see their independently persisted messages immediately and see at most one active Agent turn indicator for the Agent/Channel Session.
+
+## 4. Persistence and atomicity
+
+The two wake tables reference Agents, Channels, Runs, and Threads with cascading or nulling foreign keys appropriate to their ownership. Pending range constraints require positive sequence numbers and `first_message_seq <= latest_message_seq`.
+
+Run creation is factored into a transaction-aware primitive so Run insertion, token-budget reservation, and wake-slot assignment commit together. The slot row, not an in-memory mutex, serializes multiple API server processes.
+
+The claimed sequence range and visible-result requirement are also persisted on the Run. For remote Computers, the complete dispatch payload is stored in that same transaction, closing the Server-crash gap between claim and Daemon notification. A legacy Daemon that confirms it never received a claimed Run requeues that Run's persisted range before marking the Run lost.
+
+No message bodies are copied into the pending table, and no pending update deletes or rewrites a message.
+
+## 5. Failure recovery
+
+- A transaction failure leaves either the old active/pending state or the new state, never a half-claimed interval.
+- If dispatch fails after a Run is created, the existing Run failure path terminates it and advances the queue.
+- The Agent Run watchdog reconciles wake slots on every pass. A slot pointing to a terminal/missing Run is repaired, while a still-unfinished Run is preserved for normal daemon recovery.
+- On upgrade, a newly created slot also checks existing unfinished message Runs before starting another. Existing duplicate Runs drain first; pending work starts only after the last unfinished legacy Run terminates.
+- If the newest range message was deleted before claim, the server loads the remaining persisted messages. If none remain, it drops that empty pending interval and continues to the next one.
+- Daemon disconnection does not discard pending ranges. A claimed Run follows the existing daemon-lost/timeout recovery and terminal handling.
+
+## 6. API and frontend compatibility
+
+No public HTTP or WebSocket schema changes. Existing message-send responses, reliable-send deduplication, Channel membership, Workspace scoping, and frontend state remain unchanged. Run/event payloads continue using the latest persisted trigger message ID.
+
+Thinking nodes remain isolated and are not coalesced by this flow because their node Session, handoff, and debounce semantics are separate. Explicit tasks, schedules, and onboarding greetings are not converted into message ranges.
+
+## 7. Migration
+
+The migration only creates empty delivery-state tables and indexes. Existing messages and Runs are not rewritten. Lazy slot reconciliation provides rolling compatibility with unfinished pre-migration Runs. The down migration drops the delivery state without touching messages or Run history.
+
+## 8. Validation
+
+Validation uses the make-managed frontend, API server, PostgreSQL, and real Daemon/Agent runtime without route, service, database, or provider mocks. It must prove:
+
+1. Several messages sent while one real Agent Run is active persist as distinct rows and produce one pending range.
+2. The terminal transition atomically starts exactly one next Run containing all of those messages in sequence order.
+3. A message arriving after the claim forms a separate pending range.
+4. Public unmentioned messages create no Run or pending wake, while an explicit mention does.
+5. DM/Lucy and explicit mentions retain the visible-result contract; automatic private fallback does not generate missing-visible-result reminder loops.
+6. A Channel Run replying into its trigger message's Thread is attributed to that Run and does not generate a result reminder.
+7. Browser-visible messages, Run indicators, terminal results, and database Run/wake/message state agree.

--- a/frontend/e2e/agent-message-coalescing.spec.ts
+++ b/frontend/e2e/agent-message-coalescing.spec.ts
@@ -1,0 +1,285 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { registerVerified } from './support/auth';
+
+const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
+const publicWorkspaceID = '00000000-0000-0000-0000-000000000001';
+
+interface AuthResponse {
+  access_token: string;
+  refresh_token: string;
+  workspace_id: string;
+}
+
+interface Entity {
+  id: string;
+  name: string;
+}
+
+interface Computer extends Entity {
+  daemon_id: string;
+  status: string;
+  pairing_status: string;
+  my_role?: string;
+}
+
+interface Workspace extends Entity {
+  is_personal: boolean;
+}
+
+interface PendingState {
+  rows: number;
+  first_seq: number;
+  latest_seq: number;
+  messages: number;
+  runs: number;
+}
+
+interface FinalState {
+  messages: number;
+  runs: number;
+  first_trigger_runs: number;
+  second_trigger_runs: number;
+  completed: number;
+  pending: number;
+  coalesced: boolean;
+  wake_count: number;
+  replies: number;
+  linked_replies: number;
+  reminders: number;
+}
+
+function databaseJSON<T>(query: string): T {
+  const output = execFileSync('docker', [
+    'exec', process.env.SOLO_POSTGRES_CONTAINER ?? 'solo-postgres',
+    'psql', '-U', process.env.POSTGRES_USER ?? 'solo', '-d', process.env.POSTGRES_DB ?? 'solo',
+    '-tA', '-c', query,
+  ], { encoding: 'utf8' }).trim();
+  return JSON.parse(output) as T;
+}
+
+async function register(request: APIRequestContext): Promise<AuthResponse> {
+  const email = 'coalesce-agent-wakes@solo.local';
+  const password = 'SoloCoalesce-2026!';
+  const login = await request.post(`${apiBase}/api/v1/auth/login`, { data: { email, password } });
+  if (login.ok()) return login.json();
+  const response = await registerVerified(request, apiBase, {
+    data: {
+      email,
+      password,
+      display_name: 'Coalesce E2E',
+    },
+  });
+  if (!response.ok()) throw new Error(`register: ${response.status()} ${await response.text()}`);
+  return response.json();
+}
+
+async function call<T>(
+  request: APIRequestContext,
+  auth: AuthResponse,
+  method: 'get' | 'post' | 'delete',
+  path: string,
+  workspaceID?: string,
+  data?: unknown,
+): Promise<T> {
+  const options = {
+    headers: {
+      authorization: `Bearer ${auth.access_token}`,
+      ...(workspaceID ? { 'X-Workspace-ID': workspaceID } : {}),
+    },
+    ...(data === undefined ? {} : { data }),
+  };
+  const response = method === 'get'
+    ? await request.get(`${apiBase}${path}`, options)
+    : method === 'post'
+      ? await request.post(`${apiBase}${path}`, options)
+      : await request.delete(`${apiBase}${path}`, options);
+  if (!response.ok()) throw new Error(`${method.toUpperCase()} ${path}: ${response.status()} ${await response.text()}`);
+  if (response.status() === 204) return undefined as T;
+  return response.json();
+}
+
+async function authenticatePage(page: Page, auth: AuthResponse, workspaceID: string) {
+  await page.addInitScript(({ accessToken, refreshToken, activeWorkspaceID }) => {
+    localStorage.setItem('access_token', accessToken);
+    localStorage.setItem('refresh_token', refreshToken);
+    localStorage.setItem('solo_active_workspace_id', activeWorkspaceID);
+    localStorage.setItem('solo.locale', 'en');
+  }, {
+    accessToken: auth.access_token,
+    refreshToken: auth.refresh_token,
+    activeWorkspaceID: workspaceID,
+  });
+}
+
+async function sendMessage(request: APIRequestContext, auth: AuthResponse, workspaceID: string, channelID: string, content: string): Promise<string> {
+  const message = await call<{ id: string }>(request, auth, 'post', `/api/v1/channels/${channelID}/messages`, workspaceID, { content });
+  return message.id;
+}
+
+function runActive(agentID: string, triggerID = ''): boolean {
+  return databaseJSON<boolean>(`
+    SELECT EXISTS(
+      SELECT 1 FROM agent_runs
+       WHERE agent_id='${agentID}' AND finished_at IS NULL
+         AND ('${triggerID}'='' OR trigger_message_id='${triggerID}')
+    )::text
+  `);
+}
+
+test('merges every busy message and keeps public chatter mention-only', async ({ page, request }) => {
+  test.setTimeout(420_000);
+  const auth = await register(request);
+  const workspaces = await call<Workspace[]>(request, auth, 'get', '/api/v1/workspaces');
+  const privateWorkspaceID = workspaces.find((workspace) => workspace.is_personal)?.id;
+  expect(privateWorkspaceID, 'personal Workspace').toBeTruthy();
+  const suffix = Date.now().toString(36);
+  const daemonID = process.env.SOLO_E2E_DAEMON_ID ?? 'daemon-e2e-coalesce';
+  const computers = await call<Computer[]>(request, auth, 'get', '/api/v1/computers');
+  const computer = computers.find((item) => item.daemon_id === daemonID && item.status === 'online');
+  expect(computer, `online ${daemonID} Computer`).toBeTruthy();
+  if (!computer!.my_role) {
+    await call(request, auth, 'post', `/api/v1/computers/${computer!.id}/claim`);
+  }
+
+  const block = `COALESCE_BLOCK_${suffix}`;
+  const one = `COALESCE_ONE_${suffix}`;
+  const two = `COALESCE_TWO_${suffix}`;
+  const blockReply = `COALESCE_BLOCK_ACK_${suffix.toUpperCase()}`;
+  const batchReply = `COALESCE_BATCH_ACK_${suffix.toUpperCase()}`;
+  const publicPlain = `PUBLIC_PLAIN_${suffix}`;
+  const publicMention = `PUBLIC_MENTION_${suffix}`;
+  const publicReply = `PUBLIC_ACK_${suffix.toUpperCase()}`;
+  let privateChannel: Entity | undefined;
+  let privateAgent: Entity | undefined;
+  let publicAgent: Entity | undefined;
+
+  try {
+    privateChannel = await call<Entity>(request, auth, 'post', '/api/v1/channels', privateWorkspaceID, {
+      name: `coalesce-${suffix}`,
+      description: 'real Agent busy-message coalescing E2E',
+    });
+    privateAgent = await call<Entity>(request, auth, 'post', `/api/v1/channels/${privateChannel.id}/agents`, privateWorkspaceID, {
+      name: `Coalesce${suffix}`,
+      computer_id: computer!.id,
+      model_provider: 'claude',
+      model_name: 'sonnet',
+      system_prompt: [
+        'Use solo message send with the exact target from the incoming message.',
+        'When introducing yourself, send exactly COALESCE_READY.',
+        `For a message containing ${block}, run the foreground Bash command sleep 12 and wait, then send exactly ${blockReply}.`,
+        `When one turn contains both ${one} and ${two}, send exactly ${batchReply}.`,
+        'Send one visible message and no explanation.',
+      ].join(' '),
+    });
+    await expect.poll(() => databaseJSON<boolean>(`
+      SELECT EXISTS(SELECT 1 FROM agent_runs WHERE agent_id='${privateAgent!.id}' AND trigger_message_id IS NULL AND status='completed')::text
+    `), { timeout: 180_000, intervals: [500, 1000, 2000] }).toBe(true);
+
+    const blockID = await sendMessage(request, auth, privateWorkspaceID!, privateChannel.id, `@${privateAgent.name} ${block}`);
+    await expect.poll(() => runActive(privateAgent!.id, blockID), {
+      timeout: 90_000, intervals: [250, 500, 1000],
+    }).toBe(true);
+    const oneID = await sendMessage(request, auth, privateWorkspaceID!, privateChannel.id, `@${privateAgent.name} ${one}`);
+    const twoID = await sendMessage(request, auth, privateWorkspaceID!, privateChannel.id, `@${privateAgent.name} ${two}`);
+
+    await expect.poll(() => databaseJSON<PendingState>(`
+      WITH target_messages AS (
+        SELECT seq FROM messages WHERE id IN ('${oneID}','${twoID}')
+      )
+      SELECT json_build_object(
+        'rows', (SELECT count(*) FROM agent_pending_message_wakes WHERE agent_id='${privateAgent!.id}' AND channel_id='${privateChannel!.id}'),
+        'first_seq', COALESCE((SELECT first_message_seq FROM agent_pending_message_wakes WHERE agent_id='${privateAgent!.id}' AND channel_id='${privateChannel!.id}'),0),
+        'latest_seq', COALESCE((SELECT latest_message_seq FROM agent_pending_message_wakes WHERE agent_id='${privateAgent!.id}' AND channel_id='${privateChannel!.id}'),0),
+        'messages', (SELECT count(*) FROM target_messages),
+        'runs', (SELECT count(*) FROM agent_runs WHERE agent_id='${privateAgent!.id}' AND trigger_message_id IN ('${blockID}','${oneID}','${twoID}'))
+      )::text
+    `), { timeout: 20_000, intervals: [100, 250, 500] }).toMatchObject({ rows: 1, messages: 2, runs: 1 });
+
+    await expect.poll(() => databaseJSON<FinalState>(`
+      WITH target_runs AS (
+        SELECT * FROM agent_runs
+         WHERE agent_id='${privateAgent!.id}'
+           AND trigger_message_id IN ('${blockID}','${oneID}','${twoID}')
+      ), coalesced_run AS (
+        SELECT * FROM target_runs WHERE trigger_message_id='${twoID}' LIMIT 1
+      ), started AS (
+        SELECT payload FROM agent_run_events
+         WHERE run_id=(SELECT id FROM coalesced_run) AND type='run_started'
+         ORDER BY seq LIMIT 1
+      )
+      SELECT json_build_object(
+        'messages', (SELECT count(*) FROM messages WHERE id IN ('${blockID}','${oneID}','${twoID}')),
+        'runs', (SELECT count(*) FROM target_runs),
+        'first_trigger_runs', (SELECT count(*) FROM target_runs WHERE trigger_message_id='${oneID}'),
+        'second_trigger_runs', (SELECT count(*) FROM target_runs WHERE trigger_message_id='${twoID}'),
+        'completed', (SELECT count(*) FROM target_runs WHERE status='completed'),
+        'pending', (SELECT count(*) FROM agent_pending_message_wakes WHERE agent_id='${privateAgent!.id}' AND channel_id='${privateChannel!.id}'),
+        'coalesced', COALESCE((SELECT (payload->>'coalesced')::boolean FROM started),false),
+        'wake_count', COALESCE((SELECT (payload->>'wake_message_count')::int FROM started),0),
+        'replies', (SELECT count(*) FROM messages WHERE sender_id='${privateAgent!.id}' AND content IN ('${blockReply}','${batchReply}')),
+        'linked_replies', (SELECT count(*) FROM messages m JOIN target_runs r ON m.metadata->>'agent_run_id'=r.id::text WHERE m.sender_id='${privateAgent!.id}' AND m.content IN ('${blockReply}','${batchReply}')),
+        'reminders', (SELECT count(*) FROM agent_run_events WHERE run_id IN (SELECT id FROM target_runs) AND type='result_reminder')
+      )::text
+    `), { timeout: 300_000, intervals: [500, 1000, 2000] }).toEqual({
+      messages: 3,
+      runs: 2,
+      first_trigger_runs: 0,
+      second_trigger_runs: 1,
+      completed: 2,
+      pending: 0,
+      coalesced: true,
+      wake_count: 2,
+      replies: 2,
+      linked_replies: 2,
+      reminders: 0,
+    });
+
+    await authenticatePage(page, auth, privateWorkspaceID!);
+    await page.goto(`/dashboard?channel=${privateChannel.id}`);
+    await page.reload();
+    for (const text of [block, one, two, batchReply]) {
+      await expect(page.getByText(new RegExp(text), { exact: false }).first()).toBeVisible();
+    }
+    const blockRoot = page.locator(`[data-message-id="${blockID}"]`);
+    await blockRoot.hover();
+    await blockRoot.getByRole('button', { name: /^Reply to / }).click();
+    await expect(page.getByText(blockReply, { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Close thread panel' }).click();
+
+    const publicGeneral = databaseJSON<Entity>(`
+      SELECT json_build_object('id',id::text,'name',name)::text
+        FROM channels
+       WHERE workspace_id='${publicWorkspaceID}' AND type='channel' AND is_archived=false
+       ORDER BY created_at LIMIT 1
+    `);
+    publicAgent = await call<Entity>(request, auth, 'post', `/api/v1/channels/${publicGeneral.id}/agents`, publicWorkspaceID, {
+      name: `Public${suffix}`,
+      computer_id: computer!.id,
+      model_provider: 'claude',
+      model_name: 'sonnet',
+      system_prompt: [
+        'Use solo message send with the exact incoming target.',
+        'When introducing yourself, send exactly PUBLIC_READY.',
+        `For a message containing ${publicMention}, send exactly ${publicReply}.`,
+        'Send one visible message and no explanation.',
+      ].join(' '),
+    });
+    await expect.poll(() => databaseJSON<boolean>(`
+      SELECT EXISTS(SELECT 1 FROM agent_runs WHERE agent_id='${publicAgent!.id}' AND trigger_message_id IS NULL AND status='completed')::text
+    `), { timeout: 180_000, intervals: [500, 1000, 2000] }).toBe(true);
+    const plainID = await sendMessage(request, auth, publicWorkspaceID, publicGeneral.id, publicPlain);
+    await new Promise((resolve) => setTimeout(resolve, 2500));
+    expect(databaseJSON<number>(`SELECT count(*)::text FROM agent_runs WHERE agent_id='${publicAgent.id}' AND trigger_message_id='${plainID}'`)).toBe(0);
+    const mentionedID = await sendMessage(request, auth, publicWorkspaceID, publicGeneral.id, `@${publicAgent.name} ${publicMention}`);
+    await expect.poll(() => databaseJSON<number>(`
+      SELECT count(*)::text FROM agent_runs r
+       WHERE r.agent_id='${publicAgent!.id}' AND r.trigger_message_id='${mentionedID}' AND r.status='completed'
+         AND EXISTS(SELECT 1 FROM messages m WHERE m.metadata->>'agent_run_id'=r.id::text AND m.content='${publicReply}')
+    `), { timeout: 240_000, intervals: [500, 1000, 2000] }).toBe(1);
+  } finally {
+    if (publicAgent) await call(request, auth, 'delete', `/api/v1/agents/${publicAgent.id}`, publicWorkspaceID).catch(() => undefined);
+    if (privateAgent) await call(request, auth, 'delete', `/api/v1/agents/${privateAgent.id}`, privateWorkspaceID).catch(() => undefined);
+    if (privateChannel) await call(request, auth, 'delete', `/api/v1/channels/${privateChannel.id}`, privateWorkspaceID).catch(() => undefined);
+  }
+});

--- a/internal/server/service/agent.go
+++ b/internal/server/service/agent.go
@@ -199,6 +199,15 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 	if !shouldTriggerAgentForSender(senderType, mentionedAgentIDs) {
 		return
 	}
+	policy, err := s.getChannelWakePolicy(ctx, channelID)
+	if err != nil {
+		slog.Error("failed to load Channel Agent wake policy", "channel_id", channelID, "error", err)
+		return
+	}
+	if len(mentionedAgentIDs) == 0 && !hasMentions && policy.suppressesUnmentionedAgentWake() {
+		slog.Info("public Channel Agent wake suppressed", "channel_id", channelID, "message_id", messageID)
+		return
+	}
 	// If the message was sent by an agent, only proceed if it @mentions other agents.
 	// Agents don't respond to themselves or to non-mentioned agent messages.
 
@@ -217,7 +226,7 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 	if senderType == "agent" {
 		excludeAgentID = senderID
 	}
-	targetAgents, _ := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
+	targetAgents, decision := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
 		Scope:             wakeScopeChannel,
 		ChannelID:         channelID,
 		TriggerMessageID:  messageID,
@@ -245,8 +254,11 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 	// Query for open tasks in the channel to provide task context to agents
 	taskContext := s.getChannelOpenTasksSummary(ctx, channelID)
 
-	// Each persisted message gets its own Run. Duplicate client sends are
-	// coalesced before persistence by the reliable-send layer.
+	resultContract := agentResultContractNone
+	if policy.requiresVisibleResult(decision.Reason) {
+		resultContract = agentResultContractVisibleMessage
+	}
+
 	for _, ag := range targetAgents {
 		// SOLO-228-B: Validate agent trigger chain to prevent infinite loops.
 		if agentChain != nil {
@@ -291,12 +303,11 @@ func (s *AgentService) TriggerAgentResponse(ctx context.Context, channelID, mess
 			TaskContext:    taskContext,
 			AgentChain:     newChain,
 			MentionedNames: mentionedNames,
-			ResultContract: agentResultContractVisibleMessage,
+			ResultContract: resultContract,
 			ModelSeenSeq:   highestMessageSeq(contextMessages),
 		}
 
-		// Dispatch via streaming SSE and handle events
-		go s.handleStreamingAgentTask(context.Background(), daemon, taskReq, ag)
+		s.dispatchOrQueueMessageWake(ctx, daemon, taskReq, ag)
 	}
 }
 
@@ -649,8 +660,9 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 		triggerType = AgentRunTriggerTask
 	}
 	newRun := existingRun == nil
+	startingRun := newRun || taskReq.PrestartedRun
 	run := existingRun
-	if newRun && taskReq.NodeID == "" && taskReq.ResumeSessionID == "" && !taskReq.ForceFreshSession {
+	if startingRun && taskReq.NodeID == "" && taskReq.ResumeSessionID == "" && !taskReq.ForceFreshSession {
 		err := s.pool.QueryRow(ctx, `
 			SELECT sess.external_session_id
 			  FROM agent_runs r
@@ -710,7 +722,7 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 	s.dm.TrackTask(taskReq.TaskID, daemon.ID, ag.ID)
 	s.dm.AttachTaskRun(taskReq.TaskID, run.ID)
 	defer s.dm.RemoveTask(taskReq.TaskID)
-	if newRun && taskReq.OriginTaskID != "" {
+	if startingRun && taskReq.OriginTaskID != "" {
 		if err := runSvc.LinkTask(ctx, LinkRunTaskInput{RunID: run.ID, TaskID: taskReq.OriginTaskID, Role: AgentRunTaskRolePrimary, Confidence: 1}); err != nil {
 			slog.Warn("failed to link agent run task", "run_id", run.ID, "task_id", taskReq.OriginTaskID, "error", err)
 		} else {
@@ -721,7 +733,7 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 			})
 		}
 	}
-	if newRun {
+	if startingRun {
 		s.broadcastAgentRun(taskReq.ChannelID, "agent.run.started", runPayload(run, ag.ID, agentName, taskReq.OriginTaskID))
 		if taskReq.TriggerMessageID != "" {
 			s.appendAndBroadcastRunEvent(ctx, runSvc, run, ag.ID, agentName, AgentRunEventUserMessageReceived, "用户消息触发 run", "", map[string]any{
@@ -735,6 +747,12 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 			"trigger_message_id": taskReq.TriggerMessageID,
 			"task_id":            taskReq.OriginTaskID,
 			"result_contract":    resultContract,
+		}
+		if taskReq.WakeFirstMessageSeq > 0 {
+			runStartedPayload["wake_first_message_seq"] = taskReq.WakeFirstMessageSeq
+			runStartedPayload["wake_latest_message_seq"] = taskReq.WakeLatestMessageSeq
+			runStartedPayload["wake_message_count"] = taskReq.WakeMessageCount
+			runStartedPayload["coalesced"] = taskReq.WakeMessageCount > 1
 		}
 		if taskReq.Recovery != nil {
 			runStartedPayload["recovery"] = taskReq.Recovery
@@ -846,6 +864,8 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 					}
 					reminderReq.InitialGreeting = ""
 					reminderReq.ResultReminderAttempt = true
+					reminderReq.PrestartedRun = false
+					reminderReq.RemotePrequeued = false
 					reminderReq.AccumulatedInputTokens = inputTokens
 					reminderReq.AccumulatedOutputTokens = outputTokens
 					reminderReq.AccumulatedCacheReadTokens = cacheReadTokens
@@ -860,6 +880,12 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 				failureCode = agentFailureMissingVisibleResult
 				retryable = true
 				s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, agentErrorMissingVisibleResult)
+			}
+		}
+		if (status == AgentRunStatusFailed || status == AgentRunStatusTimeout) && run.BackendStartedAt == nil {
+			if err := s.requeueUndeliveredMessageWake(ctx, run); err != nil {
+				slog.Warn("failed to requeue undelivered Agent messages", "run_id", run.ID, "error", err)
+				return
 			}
 		}
 		activityText := finalStateActivityText(status)
@@ -902,6 +928,13 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 		}
 		s.appendAndBroadcastRunEvent(ctx, runSvc, finished, ag.ID, agentName, eventType, activityText, "", eventPayload)
 		s.broadcastAgentRun(taskReq.ChannelID, "agent.run.finished", runPayload(finished, ag.ID, agentName, taskReq.OriginTaskID))
+		if finished.TriggerType == AgentRunTriggerMessage && finished.TriggerMessageID != "" && finished.ThinkingNodeID == "" {
+			go func() {
+				if err := s.advancePendingMessageWake(context.Background(), finished.AgentID, finished.ChannelID); err != nil {
+					slog.Warn("failed to advance pending Agent messages", "agent_id", finished.AgentID, "channel_id", finished.ChannelID, "error", err)
+				}
+			}()
+		}
 	}
 
 	// Send via SSE streaming
@@ -915,7 +948,12 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 			return
 		}
 	}
-	if newRun || taskReq.ResultReminderAttempt {
+	if taskReq.RemotePrequeued && daemon.ComputerID != "" {
+		eventCh, err = s.dm.SubscribeTask(streamCtx, daemon, taskReq.TaskID)
+		if err == nil {
+			s.dm.NotifyRun(daemon.ComputerID, run.ID)
+		}
+	} else if startingRun || taskReq.ResultReminderAttempt {
 		eventCh, err = s.dm.StreamTask(streamCtx, daemon, taskReq)
 	} else {
 		eventCh, err = s.dm.SubscribeTask(streamCtx, daemon, taskReq.TaskID)
@@ -929,7 +967,7 @@ func (s *AgentService) runStreamingAgentTask(ctx context.Context, daemon *Daemon
 		)
 		s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, agentName, err.Error())
 		retryable = true
-		if newRun {
+		if startingRun {
 			failureCode = agentFailureProviderTransient
 		} else {
 			failureCode = agentFailureDaemonLost
@@ -1418,6 +1456,15 @@ func (s *AgentService) ReconcileRemoteRuns(ctx context.Context, daemon *DaemonIn
 		if taskReq.TaskID == "" {
 			taskReq.TaskID = run.ID
 		}
+		taskReq.RemotePrequeued = true
+		if err := s.pool.QueryRow(ctx, `
+			SELECT NOT EXISTS (
+				SELECT 1 FROM agent_run_events WHERE run_id = $1 AND type = $2
+			)`, run.ID, AgentRunEventRunStarted,
+		).Scan(&taskReq.PrestartedRun); err != nil {
+			slog.Warn("failed to inspect remote Run start event", "run_id", run.ID, "error", err)
+			continue
+		}
 		if s.dm.IsTaskTracked(taskReq.TaskID) {
 			continue
 		}
@@ -1487,6 +1534,11 @@ func (s *AgentService) loadRecoveredRun(ctx context.Context, run *AgentRun) (dae
 }
 
 func (s *AgentService) finishDaemonLostRun(ctx context.Context, run *AgentRun) error {
+	if run.BackendStartedAt == nil {
+		if err := s.requeueUndeliveredMessageWake(ctx, run); err != nil {
+			return fmt.Errorf("requeue undelivered Agent messages: %w", err)
+		}
+	}
 	runSvc := NewAgentRunService(s.pool)
 	finished, err := runSvc.FinishRun(ctx, FinishRunInput{
 		RunID:        run.ID,
@@ -1506,6 +1558,11 @@ func (s *AgentService) finishDaemonLostRun(ctx context.Context, run *AgentRun) e
 	})
 	s.broadcastAgentError(finished.ThreadID, finished.ChannelID, finished.AgentID, finished.AgentName, agentActivityDaemonLost)
 	s.broadcastAgentRun(finished.ChannelID, "agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, ""))
+	if finished.TriggerType == AgentRunTriggerMessage && finished.TriggerMessageID != "" && finished.ThinkingNodeID == "" {
+		if err := s.advancePendingMessageWake(ctx, finished.AgentID, finished.ChannelID); err != nil {
+			slog.Warn("failed to advance pending Agent messages after daemon loss", "run_id", finished.ID, "error", err)
+		}
+	}
 	return nil
 }
 
@@ -1550,7 +1607,10 @@ func (s *AgentService) CheckAgentRunWatchdogs(ctx context.Context, now time.Time
 			return err
 		}
 	}
-	return s.retryFailedTaskRuns(ctx)
+	if err := s.retryFailedTaskRuns(ctx); err != nil {
+		return err
+	}
+	return s.drainPendingMessageWakes(ctx)
 }
 
 func (s *AgentService) listStaleQueuedRuns(ctx context.Context, before time.Time) ([]AgentRun, error) {
@@ -1662,6 +1722,11 @@ func (s *AgentService) timeoutStaleQueuedAgentRun(ctx context.Context, runSvc *A
 }
 
 func (s *AgentService) finishTimedOutAgentRun(ctx context.Context, runSvc *AgentRunService, run *AgentRun, activity string) error {
+	if run.BackendStartedAt == nil {
+		if err := s.requeueUndeliveredMessageWake(ctx, run); err != nil {
+			return fmt.Errorf("requeue timed-out Agent messages: %w", err)
+		}
+	}
 	retryable := false
 	var daemon *DaemonInfo
 	if daemonID, err := runSvc.GetRunDaemonID(ctx, run.ID); err == nil && daemonID != "" {
@@ -1695,6 +1760,11 @@ func (s *AgentService) finishTimedOutAgentRun(ctx context.Context, runSvc *Agent
 		"retryable":    retryable,
 	})
 	s.broadcastAgentRun(finished.ChannelID, "agent.run.finished", runPayload(finished, finished.AgentID, finished.AgentName, ""))
+	if finished.TriggerType == AgentRunTriggerMessage && finished.TriggerMessageID != "" && finished.ThinkingNodeID == "" {
+		if err := s.advancePendingMessageWake(ctx, finished.AgentID, finished.ChannelID); err != nil {
+			slog.Warn("failed to advance pending Agent messages after timeout", "run_id", finished.ID, "error", err)
+		}
+	}
 	return nil
 }
 
@@ -2039,6 +2109,15 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 	if !shouldTriggerAgentForSender(senderType, mentionedAgentIDs) {
 		return
 	}
+	policy, err := s.getChannelWakePolicy(ctx, channelID)
+	if err != nil {
+		slog.Error("failed to load Thread Agent wake policy", "channel_id", channelID, "thread_id", threadID, "error", err)
+		return
+	}
+	if len(mentionedAgentIDs) == 0 && !hasMentions && policy.suppressesUnmentionedAgentWake() {
+		slog.Info("public Thread Agent wake suppressed", "channel_id", channelID, "thread_id", threadID, "message_id", messageID)
+		return
+	}
 
 	agents, err := s.getChannelActiveAgents(ctx, channelID)
 	if err != nil {
@@ -2050,7 +2129,7 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 	if senderType == "agent" {
 		excludeAgentID = senderID
 	}
-	targetAgents, _ := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
+	targetAgents, decision := s.routeWakeTargets(ctx, agents, wakeRouteRequest{
 		Scope:             wakeScopeThread,
 		ChannelID:         channelID,
 		ThreadID:          threadID,
@@ -2149,6 +2228,10 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 
 	// Resolve @mentioned agent names for context awareness.
 	threadMentionedNames := s.resolveMentionedNames(ctx, mentionedAgentIDs)
+	resultContract := agentResultContractNone
+	if policy.requiresVisibleResult(decision.Reason) {
+		resultContract = agentResultContractVisibleMessage
+	}
 
 	for _, ag := range targetAgents {
 		// SOLO-228-B: Validate agent trigger chain to prevent infinite loops.
@@ -2187,12 +2270,11 @@ func (s *AgentService) TriggerAgentResponseInThread(ctx context.Context, channel
 			TaskContext:    taskContext,
 			AgentChain:     newChain,
 			MentionedNames: threadMentionedNames,
-			ResultContract: agentResultContractVisibleMessage,
+			ResultContract: resultContract,
 			ModelSeenSeq:   highestMessageSeq(turnMessages),
 		}
 
-		// Use streaming for thread as well
-		go s.handleStreamingAgentTask(context.Background(), daemon, taskReq, ag)
+		s.dispatchOrQueueMessageWake(ctx, daemon, taskReq, ag)
 	}
 }
 
@@ -2598,6 +2680,7 @@ func (s *AgentService) getMessagesForNode(ctx context.Context, channelID, nodeID
 		`SELECT m.id, m.seq, m.sender_type, m.sender_id, m.content, m.created_at, COALESCE(m.attachment_ids, '{}') as attachment_ids
 		 FROM messages m
 			 WHERE m.channel_id = $1 AND m.thread_id IS NULL
+			   AND m.is_deleted = false
 			   AND (($3 = '' AND m.thinking_node_id IS NULL) OR m.thinking_node_id = NULLIF($3, '')::uuid)
 			   AND ($4 = '' OR m.id = NULLIF($4, '')::uuid)
 			 ORDER BY m.created_at DESC, m.id DESC
@@ -2826,6 +2909,11 @@ type daemonTaskRequest struct {
 	AccumulatedOutputTokens     int               `json:"-"`
 	AccumulatedCacheReadTokens  int               `json:"-"`
 	AccumulatedCacheWriteTokens int               `json:"-"`
+	PrestartedRun               bool              `json:"-"`
+	WakeFirstMessageSeq         int64             `json:"-"`
+	WakeLatestMessageSeq        int64             `json:"-"`
+	WakeMessageCount            int               `json:"-"`
+	RemotePrequeued             bool              `json:"-"`
 }
 
 func highestMessageSeq(messages []agent.Message) int64 {

--- a/internal/server/service/agent_message_wake.go
+++ b/internal/server/service/agent_message_wake.go
@@ -1,0 +1,712 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/solo-ai/solo/pkg/agent"
+	"github.com/solo-ai/solo/pkg/metrics"
+)
+
+type channelWakePolicy struct {
+	ChannelType         string
+	WorkspaceVisibility string
+}
+
+func (p channelWakePolicy) suppressesUnmentionedAgentWake() bool {
+	return p.ChannelType == "channel" && p.WorkspaceVisibility == "public"
+}
+
+func (p channelWakePolicy) requiresVisibleResult(reason wakeRouteReason) bool {
+	return reason == wakeReasonExplicitMention || p.ChannelType == "dm" || p.ChannelType == "lucy"
+}
+
+func (s *AgentService) getChannelWakePolicy(ctx context.Context, channelID string) (channelWakePolicy, error) {
+	var policy channelWakePolicy
+	err := s.pool.QueryRow(ctx, `
+		SELECT c.type, w.visibility
+		  FROM channels c
+		  JOIN workspaces w ON w.id = c.workspace_id
+		 WHERE c.id = $1 AND c.is_archived = false AND w.deleted_at IS NULL`, channelID,
+	).Scan(&policy.ChannelType, &policy.WorkspaceVisibility)
+	return policy, err
+}
+
+type pendingMessageWake struct {
+	AgentID              string
+	ChannelID            string
+	ThreadID             string
+	ScopeKey             string
+	FirstMessageSeq      int64
+	LatestMessageSeq     int64
+	RequiresVisibleReply bool
+	TriggerMessageID     string
+}
+
+func messageWakeScopeKey(threadID string) string {
+	if threadID == "" {
+		return "channel"
+	}
+	return "thread:" + threadID
+}
+
+func positiveMessageSeqRange(messages []agent.Message) (int64, int64) {
+	var first, latest int64
+	for _, message := range messages {
+		if message.Seq <= 0 {
+			continue
+		}
+		if first == 0 || message.Seq < first {
+			first = message.Seq
+		}
+		if message.Seq > latest {
+			latest = message.Seq
+		}
+	}
+	return first, latest
+}
+
+func positiveMessageSeqCount(messages []agent.Message) int {
+	count := 0
+	for _, message := range messages {
+		if message.Seq > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+// dispatchOrQueueMessageWake is the only dispatch entry for persisted Channel,
+// Thread, DM, and Lucy messages. The database slot closes the gap between the
+// routing goroutine and Run creation across multiple Server processes.
+func (s *AgentService) dispatchOrQueueMessageWake(ctx context.Context, daemon *DaemonInfo, taskReq daemonTaskRequest, ag agentChannelInfo) {
+	firstSeq, latestSeq := positiveMessageSeqRange(taskReq.Messages)
+	if latestSeq == 0 && taskReq.TriggerMessageID != "" {
+		if err := s.pool.QueryRow(ctx, `SELECT seq FROM messages WHERE id = $1`, taskReq.TriggerMessageID).Scan(&latestSeq); err != nil {
+			slog.Warn("failed to load message sequence for Agent wake", "message_id", taskReq.TriggerMessageID, "error", err)
+			return
+		}
+		firstSeq = latestSeq
+	}
+	if firstSeq == 0 || latestSeq == 0 {
+		slog.Warn("refusing Agent message wake without a persisted sequence", "agent_id", ag.ID, "channel_id", taskReq.ChannelID)
+		return
+	}
+	taskReq.WakeFirstMessageSeq = firstSeq
+	taskReq.WakeLatestMessageSeq = latestSeq
+	taskReq.WakeMessageCount = positiveMessageSeqCount(taskReq.Messages)
+
+	run, queued, err := s.claimMessageWake(ctx, daemon, taskReq, ag, firstSeq, latestSeq)
+	if err != nil {
+		slog.Warn("failed to claim Agent message wake", "agent_id", ag.ID, "channel_id", taskReq.ChannelID, "error", err)
+		errorCode := err.Error()
+		var budgetErr *BudgetStartError
+		if errors.As(err, &budgetErr) {
+			errorCode = budgetErr.Code()
+		}
+		s.broadcastAgentError(taskReq.ThreadID, taskReq.ChannelID, ag.ID, ag.Name, errorCode)
+		return
+	}
+	if queued {
+		slog.Info("coalesced Agent message wake",
+			"agent_id", ag.ID,
+			"channel_id", taskReq.ChannelID,
+			"thread_id", taskReq.ThreadID,
+			"first_message_seq", firstSeq,
+			"latest_message_seq", latestSeq,
+		)
+		go func() {
+			if err := s.advancePendingMessageWake(context.Background(), ag.ID, taskReq.ChannelID); err != nil {
+				slog.Debug("pending Agent messages remain queued", "agent_id", ag.ID, "channel_id", taskReq.ChannelID, "error", err)
+			}
+		}()
+		return
+	}
+
+	taskReq.PrestartedRun = true
+	taskReq.RemotePrequeued = daemon.ComputerID != ""
+	go s.runStreamingAgentTask(context.Background(), daemon, taskReq, ag, run)
+}
+
+func (s *AgentService) claimMessageWake(ctx context.Context, daemon *DaemonInfo, taskReq daemonTaskRequest, ag agentChannelInfo, firstSeq, latestSeq int64) (*AgentRun, bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	defer tx.Rollback(ctx)
+
+	if err := lockMessageWakeSlot(ctx, tx, ag.ID, taskReq.ChannelID); err != nil {
+		return nil, false, err
+	}
+	activeRunID, err := findActiveMessageRunTx(ctx, tx, ag.ID, taskReq.ChannelID)
+	if err != nil {
+		return nil, false, err
+	}
+	if activeRunID != "" {
+		if _, err := tx.Exec(ctx, `
+			UPDATE agent_message_wake_slots
+			   SET active_run_id = $3, updated_at = now()
+			 WHERE agent_id = $1 AND channel_id = $2`, ag.ID, taskReq.ChannelID, activeRunID); err != nil {
+			return nil, false, err
+		}
+		if err := upsertPendingMessageWakeTx(ctx, tx, pendingMessageWake{
+			AgentID:              ag.ID,
+			ChannelID:            taskReq.ChannelID,
+			ThreadID:             taskReq.ThreadID,
+			ScopeKey:             messageWakeScopeKey(taskReq.ThreadID),
+			FirstMessageSeq:      firstSeq,
+			LatestMessageSeq:     latestSeq,
+			RequiresVisibleReply: taskReq.ResultContract == agentResultContractVisibleMessage,
+		}); err != nil {
+			return nil, false, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, err
+		}
+		return nil, true, nil
+	}
+	var pendingExists bool
+	if err := tx.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM agent_pending_message_wakes
+			 WHERE agent_id = $1 AND channel_id = $2
+		)`, ag.ID, taskReq.ChannelID).Scan(&pendingExists); err != nil {
+		return nil, false, err
+	}
+	if pendingExists {
+		if err := upsertPendingMessageWakeTx(ctx, tx, pendingMessageWake{
+			AgentID:              ag.ID,
+			ChannelID:            taskReq.ChannelID,
+			ThreadID:             taskReq.ThreadID,
+			ScopeKey:             messageWakeScopeKey(taskReq.ThreadID),
+			FirstMessageSeq:      firstSeq,
+			LatestMessageSeq:     latestSeq,
+			RequiresVisibleReply: taskReq.ResultContract == agentResultContractVisibleMessage,
+		}); err != nil {
+			return nil, false, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return nil, false, err
+		}
+		return nil, true, nil
+	}
+
+	activityText := "等待执行"
+	if daemon.ComputerID != "" && daemon.Status != DaemonStatusOnline {
+		activityText = agentActivityWaitingComputer
+	}
+	runSvc := NewAgentRunService(s.pool)
+	run, err := runSvc.startRunTx(ctx, tx, StartRunInput{
+		AgentID:          ag.ID,
+		DaemonID:         daemon.ID,
+		TriggerType:      AgentRunTriggerMessage,
+		TriggerMessageID: taskReq.TriggerMessageID,
+		ChannelID:        taskReq.ChannelID,
+		ThreadID:         taskReq.ThreadID,
+		Status:           AgentRunStatusQueued,
+		ActivityText:     activityText,
+		Source:           taskReq.ModelConfig.Provider,
+		FreshnessSeenSeq: latestSeq,
+		WakeFirstSeq:     firstSeq,
+		WakeLatestSeq:    latestSeq,
+		WakeVisible:      taskReq.ResultContract == agentResultContractVisibleMessage,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE agent_message_wake_slots
+		   SET active_run_id = $3, updated_at = now()
+		 WHERE agent_id = $1 AND channel_id = $2`, ag.ID, taskReq.ChannelID, run.ID); err != nil {
+		return nil, false, err
+	}
+	if err := s.persistRemoteMessageRunTx(ctx, tx, daemon, run, taskReq, ag); err != nil {
+		return nil, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, false, err
+	}
+	if daemon.ComputerID != "" {
+		metrics.Global.IncRemoteRunsQueued()
+	}
+	if err := runSvc.hydrateAgentRunTokenUsage(ctx, run); err != nil {
+		slog.Warn("message Run created but token usage could not be reloaded", "run_id", run.ID, "error", err)
+	}
+	return run, false, nil
+}
+
+func lockMessageWakeSlot(ctx context.Context, tx pgx.Tx, agentID, channelID string) error {
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_message_wake_slots (agent_id, channel_id)
+		VALUES ($1, $2)
+		ON CONFLICT (agent_id, channel_id) DO NOTHING`, agentID, channelID); err != nil {
+		return err
+	}
+	var ignored string
+	return tx.QueryRow(ctx, `
+		SELECT COALESCE(active_run_id::text, '')
+		  FROM agent_message_wake_slots
+		 WHERE agent_id = $1 AND channel_id = $2
+		 FOR UPDATE`, agentID, channelID).Scan(&ignored)
+}
+
+func findActiveMessageRunTx(ctx context.Context, tx pgx.Tx, agentID, channelID string) (string, error) {
+	var runID string
+	err := tx.QueryRow(ctx, `
+		SELECT id::text
+		  FROM agent_runs
+		 WHERE agent_id = $1
+		   AND channel_id = $2
+		   AND trigger_type = $3
+		   AND trigger_message_id IS NOT NULL
+		   AND thinking_node_id IS NULL
+		   AND finished_at IS NULL
+		 ORDER BY started_at ASC, id ASC
+		 LIMIT 1`, agentID, channelID, AgentRunTriggerMessage).Scan(&runID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	return runID, err
+}
+
+func upsertPendingMessageWakeTx(ctx context.Context, tx pgx.Tx, wake pendingMessageWake) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO agent_pending_message_wakes (
+			agent_id, channel_id, scope_key, thread_id, first_message_seq,
+			latest_message_seq, requires_visible_result
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (agent_id, channel_id, scope_key)
+		DO UPDATE SET
+			first_message_seq = LEAST(agent_pending_message_wakes.first_message_seq, EXCLUDED.first_message_seq),
+			latest_message_seq = GREATEST(agent_pending_message_wakes.latest_message_seq, EXCLUDED.latest_message_seq),
+			requires_visible_result = agent_pending_message_wakes.requires_visible_result OR EXCLUDED.requires_visible_result,
+			updated_at = now()`,
+		wake.AgentID, wake.ChannelID, wake.ScopeKey, nullableUUID(wake.ThreadID),
+		wake.FirstMessageSeq, wake.LatestMessageSeq, wake.RequiresVisibleReply,
+	)
+	return err
+}
+
+// advancePendingMessageWake repairs the slot after any terminal path and, when
+// possible, atomically claims the oldest pending scope as the next Run.
+func (s *AgentService) advancePendingMessageWake(ctx context.Context, agentID, channelID string) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if err := lockMessageWakeSlot(ctx, tx, agentID, channelID); err != nil {
+		return err
+	}
+	activeRunID, err := findActiveMessageRunTx(ctx, tx, agentID, channelID)
+	if err != nil {
+		return err
+	}
+	if activeRunID != "" {
+		_, err = tx.Exec(ctx, `
+			UPDATE agent_message_wake_slots SET active_run_id = $3, updated_at = now()
+			 WHERE agent_id = $1 AND channel_id = $2`, agentID, channelID, activeRunID)
+		if err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
+	}
+	var ag agentChannelInfo
+	if err := tx.QueryRow(ctx, `
+		SELECT id::text, name, model_provider, model_name, system_prompt
+		  FROM agents
+		 WHERE id = $1 AND is_active = true`, agentID,
+	).Scan(&ag.ID, &ag.Name, &ag.ModelProvider, &ag.ModelName, &ag.SystemPrompt); err != nil {
+		return err
+	}
+
+	var wake pendingMessageWake
+	for {
+		err = tx.QueryRow(ctx, `
+			SELECT agent_id::text, channel_id::text, COALESCE(thread_id::text, ''), scope_key,
+			       first_message_seq, latest_message_seq, requires_visible_result
+			  FROM agent_pending_message_wakes
+			 WHERE agent_id = $1 AND channel_id = $2
+			 ORDER BY created_at ASC, scope_key ASC
+			 LIMIT 1
+			 FOR UPDATE`, agentID, channelID,
+		).Scan(&wake.AgentID, &wake.ChannelID, &wake.ThreadID, &wake.ScopeKey,
+			&wake.FirstMessageSeq, &wake.LatestMessageSeq, &wake.RequiresVisibleReply)
+		if errors.Is(err, pgx.ErrNoRows) {
+			_, err = tx.Exec(ctx, `
+				UPDATE agent_message_wake_slots SET active_run_id = NULL, updated_at = now()
+				 WHERE agent_id = $1 AND channel_id = $2`, agentID, channelID)
+			if err != nil {
+				return err
+			}
+			return tx.Commit(ctx)
+		}
+		if err != nil {
+			return err
+		}
+
+		err = tx.QueryRow(ctx, `
+			SELECT id::text
+			  FROM messages
+			 WHERE channel_id = $1
+			   AND seq BETWEEN $2 AND $3
+			   AND is_deleted = false
+			   AND thinking_node_id IS NULL
+			   AND (($4 = '' AND thread_id IS NULL) OR thread_id = NULLIF($4, '')::uuid)
+			 ORDER BY seq DESC
+			 LIMIT 1`, channelID, wake.FirstMessageSeq, wake.LatestMessageSeq, wake.ThreadID,
+		).Scan(&wake.TriggerMessageID)
+		if !errors.Is(err, pgx.ErrNoRows) {
+			break
+		}
+		if _, err := tx.Exec(ctx, `
+			DELETE FROM agent_pending_message_wakes
+			 WHERE agent_id = $1 AND channel_id = $2 AND scope_key = $3`, agentID, channelID, wake.ScopeKey); err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+	dmn, err := s.dm.ResolveDaemonForAgent(ctx, agentID, "llm")
+	if err != nil {
+		return err
+	}
+	taskReq, err := s.buildPendingMessageWakeTask(ctx, wake, ag)
+	if err != nil {
+		return err
+	}
+
+	activityText := "等待执行"
+	if dmn.ComputerID != "" && dmn.Status != DaemonStatusOnline {
+		activityText = agentActivityWaitingComputer
+	}
+	runSvc := NewAgentRunService(s.pool)
+	run, err := runSvc.startRunTx(ctx, tx, StartRunInput{
+		AgentID:          agentID,
+		DaemonID:         dmn.ID,
+		TriggerType:      AgentRunTriggerMessage,
+		TriggerMessageID: wake.TriggerMessageID,
+		ChannelID:        channelID,
+		ThreadID:         wake.ThreadID,
+		Status:           AgentRunStatusQueued,
+		ActivityText:     activityText,
+		Source:           ag.ModelProvider,
+		FreshnessSeenSeq: wake.LatestMessageSeq,
+		WakeFirstSeq:     wake.FirstMessageSeq,
+		WakeLatestSeq:    wake.LatestMessageSeq,
+		WakeVisible:      wake.RequiresVisibleReply,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM agent_pending_message_wakes
+		 WHERE agent_id = $1 AND channel_id = $2 AND scope_key = $3`, agentID, channelID, wake.ScopeKey); err != nil {
+		return err
+	}
+	if err := s.persistRemoteMessageRunTx(ctx, tx, dmn, run, taskReq, ag); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE agent_message_wake_slots SET active_run_id = $3, updated_at = now()
+		 WHERE agent_id = $1 AND channel_id = $2`, agentID, channelID, run.ID); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	if dmn.ComputerID != "" {
+		metrics.Global.IncRemoteRunsQueued()
+	}
+	if err := runSvc.hydrateAgentRunTokenUsage(ctx, run); err != nil {
+		slog.Warn("coalesced message Run token usage could not be reloaded", "run_id", run.ID, "error", err)
+	}
+	taskReq.PrestartedRun = true
+	taskReq.RemotePrequeued = dmn.ComputerID != ""
+	go s.runStreamingAgentTask(context.Background(), dmn, taskReq, ag, run)
+	return nil
+}
+
+// persistRemoteMessageRunTx closes the crash window between claiming a wake
+// range and queuing it for a remote Computer. On Server restart the Daemon can
+// accept this payload directly from PostgreSQL even if the dispatch goroutine
+// never started.
+func (s *AgentService) persistRemoteMessageRunTx(ctx context.Context, tx pgx.Tx, dmn *DaemonInfo, run *AgentRun, taskReq daemonTaskRequest, ag agentChannelInfo) error {
+	if dmn.ComputerID == "" {
+		return nil
+	}
+	taskReq.RunID = run.ID
+	taskReq.TaskID = run.ID
+	taskReq.AgentName = ag.Name
+	_ = tx.QueryRow(ctx, `SELECT COALESCE(name, id::text) FROM channels WHERE id = $1`, taskReq.ChannelID).Scan(&taskReq.ChannelName)
+	var customEnv, customArgs json.RawMessage
+	if err := tx.QueryRow(ctx, `SELECT custom_env, custom_args FROM agents WHERE id = $1`, ag.ID).Scan(&customEnv, &customArgs); err == nil {
+		_ = json.Unmarshal(customEnv, &taskReq.CustomEnv)
+		_ = json.Unmarshal(customArgs, &taskReq.CustomArgs)
+	}
+	if taskReq.NodeID == "" && taskReq.ResumeSessionID == "" && !taskReq.ForceFreshSession {
+		_ = tx.QueryRow(ctx, `
+			SELECT sess.external_session_id
+			  FROM agent_runs r
+			  JOIN agent_sessions sess ON sess.id = r.session_id
+			 WHERE r.agent_id = $1 AND r.channel_id = $2 AND r.id <> $3
+			   AND r.thinking_node_id IS NULL AND sess.provider = $4
+			   AND sess.status = 'active' AND COALESCE(sess.external_session_id, '') <> ''
+			 ORDER BY sess.last_active_at DESC, r.updated_at DESC LIMIT 1`,
+			ag.ID, taskReq.ChannelID, run.ID, taskReq.ModelConfig.Provider,
+		).Scan(&taskReq.ResumeSessionID)
+	}
+	payload, err := json.Marshal(taskReq)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE agent_runs
+		   SET computer_id = $2::uuid, daemon_id = $2::text, dispatch_payload = $3,
+		       delivery_expires_at = $4, execution_attempt_id = NULL, accepted_at = NULL,
+		       updated_at = now()
+		 WHERE id = $1 AND finished_at IS NULL`,
+		run.ID, dmn.ComputerID, payload, time.Now().UTC().Add(remoteRunDeliveryTTL),
+	)
+	return err
+}
+
+func (s *AgentService) requeueUndeliveredMessageWake(ctx context.Context, run *AgentRun) error {
+	if run == nil || run.TriggerType != AgentRunTriggerMessage || run.ThinkingNodeID != "" {
+		return nil
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	if err := lockMessageWakeSlot(ctx, tx, run.AgentID, run.ChannelID); err != nil {
+		return err
+	}
+	var first, latest int64
+	var visible bool
+	if err := tx.QueryRow(ctx, `
+		SELECT COALESCE(wake_first_message_seq, 0), COALESCE(wake_latest_message_seq, 0),
+		       wake_requires_visible_result
+		  FROM agent_runs WHERE id = $1 AND finished_at IS NULL AND accepted_at IS NULL`, run.ID,
+	).Scan(&first, &latest, &visible); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return tx.Commit(ctx)
+		}
+		return err
+	}
+	if first == 0 || latest == 0 {
+		return tx.Commit(ctx)
+	}
+	if err := upsertPendingMessageWakeTx(ctx, tx, pendingMessageWake{
+		AgentID: run.AgentID, ChannelID: run.ChannelID, ThreadID: run.ThreadID,
+		ScopeKey: messageWakeScopeKey(run.ThreadID), FirstMessageSeq: first,
+		LatestMessageSeq: latest, RequiresVisibleReply: visible,
+	}); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *AgentService) buildPendingMessageWakeTask(ctx context.Context, wake pendingMessageWake, ag agentChannelInfo) (daemonTaskRequest, error) {
+	var turnMessages, coldStartMessages []agent.Message
+	var err error
+	if wake.ThreadID == "" {
+		turnMessages, err = s.getChannelMessagesInSeqRange(ctx, wake.ChannelID, wake.FirstMessageSeq, wake.LatestMessageSeq)
+	} else {
+		turnMessages, coldStartMessages, err = s.getThreadMessagesInSeqRange(ctx, wake.ChannelID, wake.ThreadID, wake.FirstMessageSeq, wake.LatestMessageSeq)
+	}
+	if err != nil {
+		return daemonTaskRequest{}, err
+	}
+	if len(turnMessages) == 0 {
+		return daemonTaskRequest{}, errors.New("coalesced wake has no remaining messages")
+	}
+	mentionedIDs, err := s.getMentionedAgentIDsInSeqRange(ctx, wake.ChannelID, wake.ThreadID, wake.FirstMessageSeq, wake.LatestMessageSeq)
+	if err != nil {
+		return daemonTaskRequest{}, err
+	}
+	resultContract := agentResultContractNone
+	if wake.RequiresVisibleReply {
+		resultContract = agentResultContractVisibleMessage
+	}
+	return daemonTaskRequest{
+		AgentID:              ag.ID,
+		ChannelID:            wake.ChannelID,
+		ThreadID:             wake.ThreadID,
+		TriggerMessageID:     wake.TriggerMessageID,
+		Messages:             turnMessages,
+		ColdStartMessages:    coldStartMessages,
+		SystemPrompt:         ag.SystemPrompt,
+		ModelConfig:          agent.ModelConfig{Provider: ag.ModelProvider, Model: ag.ModelName},
+		TaskContext:          s.getChannelOpenTasksSummary(ctx, wake.ChannelID),
+		AgentChain:           []string{ag.ID},
+		MentionedNames:       s.resolveMentionedNames(ctx, mentionedIDs),
+		ResultContract:       resultContract,
+		ModelSeenSeq:         wake.LatestMessageSeq,
+		WakeFirstMessageSeq:  wake.FirstMessageSeq,
+		WakeLatestMessageSeq: wake.LatestMessageSeq,
+		WakeMessageCount:     len(turnMessages),
+	}, nil
+}
+
+func (s *AgentService) getChannelMessagesInSeqRange(ctx context.Context, channelID string, firstSeq, latestSeq int64) ([]agent.Message, error) {
+	var channelName, channelType string
+	if err := s.pool.QueryRow(ctx, `SELECT COALESCE(name, id::text), type FROM channels WHERE id = $1`, channelID).Scan(&channelName, &channelType); err != nil {
+		return nil, err
+	}
+	target := "#" + channelName
+	if channelType == "dm" {
+		target = "dm:@" + channelName
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id::text, seq, sender_type, sender_id::text, content, created_at, COALESCE(attachment_ids, '{}')
+		  FROM messages
+		 WHERE channel_id = $1 AND thread_id IS NULL AND thinking_node_id IS NULL
+		   AND is_deleted = false AND seq BETWEEN $2 AND $3
+		 ORDER BY seq ASC`, channelID, firstSeq, latestSeq)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var messages []agent.Message
+	for rows.Next() {
+		var id, senderType, senderID, content string
+		var seq int64
+		var createdAt time.Time
+		var attachmentIDs []string
+		if err := rows.Scan(&id, &seq, &senderType, &senderID, &content, &createdAt, &attachmentIDs); err != nil {
+			return nil, err
+		}
+		role := agent.RoleUser
+		if senderType == "agent" {
+			role = agent.RoleAssistant
+		}
+		shortID := id
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+		messageContent, attachments := s.enrichMessageContentAndAttachments(ctx, content, attachmentIDs)
+		formatted := fmt.Sprintf("New message received:\n\n[target=%s msg=%s time=%s type=%s] @%s: %s",
+			target, shortID, createdAt.UTC().Format(time.RFC3339), senderType,
+			s.resolveSenderName(ctx, senderType, senderID), messageContent)
+		messages = append(messages, agent.Message{Role: role, Content: formatted, SenderID: senderID, Attachments: attachments, Seq: seq})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(messages) > 0 {
+		messages[len(messages)-1].Content += "\n\nThese messages arrived while your previous turn was running. Handle them together in sequence. Complete all your work before stopping.\nReply in the channel or create/reply in a thread as appropriate; use each message's `target` and `msg` fields to choose the exact target."
+	}
+	return messages, nil
+}
+
+func (s *AgentService) getThreadMessagesInSeqRange(ctx context.Context, channelID, threadID string, firstSeq, latestSeq int64) ([]agent.Message, []agent.Message, error) {
+	threadMessages, err := NewThreadService(s.pool).GetThreadContextMessages(ctx, threadID)
+	if err != nil {
+		return nil, nil, err
+	}
+	var channelName, channelType string
+	if err := s.pool.QueryRow(ctx, `SELECT name, type FROM channels WHERE id = $1`, channelID).Scan(&channelName, &channelType); err != nil {
+		return nil, nil, err
+	}
+	target := "#" + channelName
+	if channelType == "dm" {
+		target = "dm:@" + channelName
+	}
+	var turnMessages []agent.Message
+	coldStartMessages := make([]agent.Message, 0, len(threadMessages))
+	for _, message := range threadMessages {
+		role := agent.RoleUser
+		if message.SenderType == "agent" {
+			role = agent.RoleAssistant
+		}
+		shortID := message.ID
+		if len(shortID) > 8 {
+			shortID = shortID[:8]
+		}
+		senderName := message.SenderName
+		if senderName == "" {
+			senderName = message.SenderID
+		}
+		messageContent, attachments := s.enrichMessageContentAndAttachments(ctx, message.Content, message.AttachmentIDs)
+		formatted := agent.Message{
+			Role: role,
+			Content: fmt.Sprintf("[target=%s:%s msg=%s time=%s type=%s] @%s: %s",
+				target, shortID, shortID, message.CreatedAt.UTC().Format(time.RFC3339), message.SenderType, senderName, messageContent),
+			SenderID: message.SenderID, Attachments: attachments, Seq: message.Seq,
+		}
+		coldStartMessages = append(coldStartMessages, formatted)
+		if message.Seq >= firstSeq && message.Seq <= latestSeq {
+			turnMessages = append(turnMessages, formatted)
+		}
+	}
+	if len(turnMessages) > 0 {
+		turnMessages[len(turnMessages)-1].Content += "\n\nThese messages arrived while your previous turn was running. Handle them together in sequence and reply in this thread."
+	}
+	return turnMessages, coldStartMessages, nil
+}
+
+func (s *AgentService) getMentionedAgentIDsInSeqRange(ctx context.Context, channelID, threadID string, firstSeq, latestSeq int64) ([]string, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT mentioned_id::text
+		  FROM messages m
+		 CROSS JOIN LATERAL unnest(COALESCE(m.mentioned_agent_ids, '{}')) AS mentioned_id
+		 WHERE m.channel_id = $1 AND m.seq BETWEEN $2 AND $3
+		   AND m.is_deleted = false AND m.thinking_node_id IS NULL
+		   AND (($4 = '' AND m.thread_id IS NULL) OR m.thread_id = NULLIF($4, '')::uuid)
+		 ORDER BY mentioned_id::text`, channelID, firstSeq, latestSeq, threadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (s *AgentService) drainPendingMessageWakes(ctx context.Context) error {
+	var tableExists bool
+	if err := s.pool.QueryRow(ctx, `SELECT to_regclass('agent_pending_message_wakes') IS NOT NULL`).Scan(&tableExists); err != nil || !tableExists {
+		return err
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT agent_id::text, channel_id::text
+		  FROM agent_pending_message_wakes
+		 ORDER BY agent_id::text, channel_id::text
+		 LIMIT 100`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	type key struct{ agentID, channelID string }
+	var keys []key
+	for rows.Next() {
+		var item key
+		if err := rows.Scan(&item.agentID, &item.channelID); err != nil {
+			return err
+		}
+		keys = append(keys, item)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for _, item := range keys {
+		if err := s.advancePendingMessageWake(ctx, item.agentID, item.channelID); err != nil {
+			slog.Warn("failed to drain pending Agent messages", "agent_id", item.agentID, "channel_id", item.channelID, "error", err)
+		}
+	}
+	return nil
+}

--- a/internal/server/service/agent_message_wake_test.go
+++ b/internal/server/service/agent_message_wake_test.go
@@ -1,0 +1,297 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/solo-ai/solo/pkg/agent"
+)
+
+func TestMessageWakeCoalescesEveryPersistedMessageAndClaimsNextRun(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageIDs := []string{
+		agentRunMessage(t, pool, channelID, ownerID),
+		agentRunMessage(t, pool, channelID, ownerID),
+		agentRunMessage(t, pool, channelID, ownerID),
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_message_wake_slots WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	var seqs [3]int64
+	for i, messageID := range messageIDs {
+		if err := pool.QueryRow(ctx, `SELECT seq FROM messages WHERE id = $1`, messageID).Scan(&seqs[i]); err != nil {
+			t.Fatalf("load message %d seq: %v", i, err)
+		}
+	}
+	active, err := NewAgentRunService(pool).StartRun(ctx, StartRunInput{
+		AgentID: agentID, TriggerType: AgentRunTriggerMessage, TriggerMessageID: messageIDs[0],
+		ChannelID: channelID, Status: AgentRunStatusRunning, ActivityText: "running",
+	})
+	if err != nil {
+		t.Fatalf("start active Run: %v", err)
+	}
+
+	svc := NewAgentService(pool, NewDaemonManager(pool, noopBroadcaster{}), noopBroadcaster{}, nil)
+	dmn := &DaemonInfo{ID: "test-daemon", Status: DaemonStatusOnline}
+	ag := agentChannelInfo{ID: agentID, Name: "Wake Test", ModelProvider: "claude", ModelName: "test"}
+	for i := 1; i < len(messageIDs); i++ {
+		_, queued, err := svc.claimMessageWake(ctx, dmn, daemonTaskRequest{
+			AgentID: agentID, ChannelID: channelID, TriggerMessageID: messageIDs[i],
+			Messages:       []agent.Message{{Role: agent.RoleUser, Content: "message", Seq: seqs[i]}},
+			ModelConfig:    agent.ModelConfig{Provider: "claude", Model: "test"},
+			ResultContract: agentResultContractVisibleMessage,
+		}, ag, seqs[i], seqs[i])
+		if err != nil || !queued {
+			t.Fatalf("claim message %d = queued %v, err %v", i, queued, err)
+		}
+	}
+
+	var first, latest int64
+	var visible bool
+	if err := pool.QueryRow(ctx, `
+		SELECT first_message_seq, latest_message_seq, requires_visible_result
+		  FROM agent_pending_message_wakes
+		 WHERE agent_id = $1 AND channel_id = $2 AND scope_key = 'channel'`, agentID, channelID,
+	).Scan(&first, &latest, &visible); err != nil {
+		t.Fatalf("load pending wake: %v", err)
+	}
+	if first != seqs[1] || latest != seqs[2] || !visible {
+		t.Fatalf("pending range = (%d,%d,%v), want (%d,%d,true)", first, latest, visible, seqs[1], seqs[2])
+	}
+	merged, err := svc.getChannelMessagesInSeqRange(ctx, channelID, first, latest)
+	if err != nil {
+		t.Fatalf("load merged messages: %v", err)
+	}
+	if len(merged) != 2 || merged[0].Seq != seqs[1] || merged[1].Seq != seqs[2] {
+		t.Fatalf("merged seqs = %#v, want [%d %d]", merged, seqs[1], seqs[2])
+	}
+
+	if _, err := NewAgentRunService(pool).FinishRun(ctx, FinishRunInput{
+		RunID: active.ID, Status: AgentRunStatusCompleted, ActivityText: "done",
+	}); err != nil {
+		t.Fatalf("finish active Run: %v", err)
+	}
+	// No daemon is registered in this transaction-focused test. Claim remains
+	// pending and the real watchdog will retry when the Agent's Computer is back.
+	if err := svc.advancePendingMessageWake(ctx, agentID, channelID); err == nil {
+		t.Fatal("advance unexpectedly succeeded without a Daemon")
+	}
+	var pendingCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM agent_pending_message_wakes WHERE agent_id = $1 AND channel_id = $2`, agentID, channelID).Scan(&pendingCount); err != nil {
+		t.Fatalf("count pending after unavailable Daemon: %v", err)
+	}
+	if pendingCount != 1 {
+		t.Fatalf("pending count after unavailable Daemon = %d, want 1", pendingCount)
+	}
+}
+
+func TestPublicChannelSuppressesOnlyUnmentionedOrdinaryWake(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageID := agentRunMessage(t, pool, channelID, ownerID)
+	if _, err := pool.Exec(ctx, `UPDATE channels SET workspace_id = $2 WHERE id = $1`,
+		channelID, "00000000-0000-0000-0000-000000000001"); err != nil {
+		t.Fatalf("move test Channel to public: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO channel_members (channel_id, member_type, member_id)
+		VALUES ($1, 'agent', $2) ON CONFLICT DO NOTHING`, channelID, agentID); err != nil {
+		t.Fatalf("add test Agent to public Channel: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channel_members WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+
+	recorder := newRecordingBroadcaster()
+	svc := NewAgentService(pool, NewDaemonManager(pool, recorder), recorder, nil)
+	svc.TriggerAgentResponse(ctx, channelID, messageID, "user", ownerID, nil, false, nil)
+	var runs int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM agent_runs WHERE agent_id = $1 AND trigger_message_id = $2`, agentID, messageID).Scan(&runs); err != nil {
+		t.Fatalf("count public Runs: %v", err)
+	}
+	if runs != 0 {
+		t.Fatalf("unmentioned public message created %d Runs", runs)
+	}
+
+	svc.TriggerAgentResponse(ctx, channelID, messageID, "user", ownerID, []string{agentID}, true, nil)
+	if !recorder.hasChannelEvent(channelID, "agent.error", agentErrorNoAvailableDaemon) {
+		t.Fatal("explicit public mention was suppressed instead of reaching Daemon resolution")
+	}
+}
+
+func TestMessageWakeScopeKey(t *testing.T) {
+	if messageWakeScopeKey("") != "channel" {
+		t.Fatal("channel scope key changed")
+	}
+	threadID := uuid.NewString()
+	if got := messageWakeScopeKey(threadID); got != "thread:"+threadID {
+		t.Fatalf("thread scope key = %q", got)
+	}
+}
+
+func TestMessageWakePersistsRemoteDispatchBeforeCommit(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageID := agentRunMessage(t, pool, channelID, ownerID)
+	computerID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `INSERT INTO computers (id, name, owner_id, status) VALUES ($1, 'wake-remote', $2, 'online')`, computerID, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM computers WHERE id = $1`, computerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE created_by = $1`, ownerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+	var seq int64
+	if err := pool.QueryRow(ctx, `SELECT seq FROM messages WHERE id = $1`, messageID).Scan(&seq); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewAgentService(pool, NewDaemonManager(pool, noopBroadcaster{}), noopBroadcaster{}, nil)
+	taskReq := daemonTaskRequest{
+		AgentID: agentID, ChannelID: channelID, TriggerMessageID: messageID,
+		Messages:       []agent.Message{{Role: agent.RoleUser, Content: "persist me", Seq: seq}},
+		ModelConfig:    agent.ModelConfig{Provider: "claude", Model: "test"},
+		ResultContract: agentResultContractVisibleMessage,
+	}
+	run, queued, err := svc.claimMessageWake(ctx,
+		&DaemonInfo{ID: computerID, ComputerID: computerID, Status: DaemonStatusOnline},
+		taskReq, agentChannelInfo{ID: agentID, Name: "Wake Test", ModelProvider: "claude", ModelName: "test"}, seq, seq)
+	if err != nil || queued {
+		t.Fatalf("claim remote wake = run %+v, queued %v, err %v", run, queued, err)
+	}
+	var first, latest int64
+	var visible bool
+	var payload json.RawMessage
+	if err := pool.QueryRow(ctx, `
+		SELECT wake_first_message_seq, wake_latest_message_seq, wake_requires_visible_result, dispatch_payload
+		  FROM agent_runs WHERE id = $1`, run.ID,
+	).Scan(&first, &latest, &visible, &payload); err != nil {
+		t.Fatal(err)
+	}
+	var saved daemonTaskRequest
+	if err := json.Unmarshal(payload, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if first != seq || latest != seq || !visible || saved.RunID != run.ID || saved.TaskID != run.ID || len(saved.Messages) != 1 {
+		t.Fatalf("persisted wake = range(%d,%d,%v), payload %+v", first, latest, visible, saved)
+	}
+}
+
+func TestPersistedRemoteWakeUsesRunAsTaskIdentity(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageID := agentRunMessage(t, pool, channelID, ownerID)
+	computerID := uuid.NewString()
+	if _, err := pool.Exec(ctx, `INSERT INTO computers (id, name, owner_id, status) VALUES ($1, 'wake-prequeued', $2, 'online')`, computerID, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM computers WHERE id = $1`, computerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE created_by = $1`, ownerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+	var seq int64
+	if err := pool.QueryRow(ctx, `SELECT seq FROM messages WHERE id = $1`, messageID).Scan(&seq); err != nil {
+		t.Fatal(err)
+	}
+	dm := NewDaemonManager(pool, noopBroadcaster{})
+	svc := NewAgentService(pool, dm, noopBroadcaster{}, nil)
+	taskReq := daemonTaskRequest{
+		AgentID: agentID, ChannelID: channelID, TriggerMessageID: messageID,
+		Messages:       []agent.Message{{Role: agent.RoleUser, Content: "persist me", Seq: seq}},
+		ModelConfig:    agent.ModelConfig{Provider: "claude", Model: "test"},
+		ResultContract: agentResultContractVisibleMessage,
+	}
+	run, queued, err := svc.claimMessageWake(ctx,
+		&DaemonInfo{ID: computerID, ComputerID: computerID, Status: DaemonStatusOnline},
+		taskReq, agentChannelInfo{ID: agentID, Name: "Wake Test", ModelProvider: "claude", ModelName: "test"}, seq, seq)
+	if err != nil || queued {
+		t.Fatalf("claim remote wake = run %+v, queued %v, err %v", run, queued, err)
+	}
+	var payload json.RawMessage
+	if err := pool.QueryRow(ctx, `SELECT dispatch_payload FROM agent_runs WHERE id = $1`, run.ID).Scan(&payload); err != nil {
+		t.Fatal(err)
+	}
+	var saved daemonTaskRequest
+	if err := json.Unmarshal(payload, &saved); err != nil {
+		t.Fatal(err)
+	}
+	if saved.TaskID != run.ID {
+		t.Fatalf("persisted TaskID = %q, want %q", saved.TaskID, run.ID)
+	}
+}
+
+func TestDaemonLostRunRequeuesItsPersistedRange(t *testing.T) {
+	pool := agentRunTestPool(t)
+	ctx := context.Background()
+	ownerID := agentRunUser(t, pool)
+	agentID := agentRunAgent(t, pool, ownerID)
+	channelID := agentRunChannel(t, pool, ownerID)
+	messageID := agentRunMessage(t, pool, channelID, ownerID)
+	var seq int64
+	if err := pool.QueryRow(ctx, `SELECT seq FROM messages WHERE id = $1`, messageID).Scan(&seq); err != nil {
+		t.Fatal(err)
+	}
+	run, err := NewAgentRunService(pool).StartRun(ctx, StartRunInput{
+		AgentID: agentID, TriggerType: AgentRunTriggerMessage, TriggerMessageID: messageID,
+		ChannelID: channelID, Status: AgentRunStatusQueued, WakeFirstSeq: seq,
+		WakeLatestSeq: seq, WakeVisible: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agent_runs WHERE agent_id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM messages WHERE channel_id = $1`, channelID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM channels WHERE created_by = $1`, ownerID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+	svc := NewAgentService(pool, NewDaemonManager(pool, noopBroadcaster{}), noopBroadcaster{}, nil)
+	if err := svc.finishDaemonLostRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	var first, latest int64
+	var visible bool
+	if err := pool.QueryRow(ctx, `
+		SELECT first_message_seq, latest_message_seq, requires_visible_result
+		  FROM agent_pending_message_wakes
+		 WHERE agent_id = $1 AND channel_id = $2 AND scope_key = 'channel'`, agentID, channelID,
+	).Scan(&first, &latest, &visible); err != nil {
+		t.Fatal(err)
+	}
+	if first != seq || latest != seq || !visible {
+		t.Fatalf("requeued range = (%d,%d,%v), want (%d,%d,true)", first, latest, visible, seq, seq)
+	}
+}

--- a/internal/server/service/agent_run.go
+++ b/internal/server/service/agent_run.go
@@ -184,6 +184,9 @@ type StartRunInput struct {
 	Source           string
 	Usage            any
 	FreshnessSeenSeq int64
+	WakeFirstSeq     int64
+	WakeLatestSeq    int64
+	WakeVisible      bool
 }
 
 type AppendRunEventInput struct {
@@ -315,6 +318,28 @@ func stableTranscriptSessionID(transcriptPath string) string {
 }
 
 func (s *AgentRunService) StartRun(ctx context.Context, input StartRunInput) (*AgentRun, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+	run, err := s.startRunTx(ctx, tx, input)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	if err := s.hydrateAgentRunTokenUsage(ctx, run); err != nil {
+		slog.Warn("run created but token usage could not be reloaded", "run_id", run.ID, "error", err)
+	}
+	return run, nil
+}
+
+// startRunTx keeps Run insertion and budget reservation in the caller's
+// transaction. Message wake single-flight uses it so assigning the wake slot
+// and creating the Run cannot be observed separately.
+func (s *AgentRunService) startRunTx(ctx context.Context, tx pgx.Tx, input StartRunInput) (*AgentRun, error) {
 	if input.Status == "" {
 		input.Status = AgentRunStatusQueued
 	}
@@ -322,17 +347,13 @@ func (s *AgentRunService) StartRun(ctx context.Context, input StartRunInput) (*A
 	if err != nil {
 		return nil, err
 	}
-	tx, err := s.pool.Begin(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback(ctx)
 	runID := uuid.NewString()
 	run, err := scanAgentRun(tx.QueryRow(ctx,
 		`INSERT INTO agent_runs (
 		   id, agent_id, daemon_id, session_id, trigger_type, trigger_message_id, channel_id, thread_id, thinking_node_id,
-		   status, activity_text, tool_name, tool_input_summary, source, usage_json, freshness_seen_seq
-		 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		   status, activity_text, tool_name, tool_input_summary, source, usage_json, freshness_seen_seq,
+		   wake_first_message_seq, wake_latest_message_seq, wake_requires_visible_result
+		 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
 		 RETURNING id::text, agent_id::text,
 		       COALESCE((SELECT name FROM agents WHERE id = agent_runs.agent_id), ''),
 		       COALESCE(session_id::text, ''), trigger_type,
@@ -344,18 +365,13 @@ func (s *AgentRunService) StartRun(ctx context.Context, input StartRunInput) (*A
 		nullableUUID(input.TriggerMessageID), nullableUUID(input.ChannelID), nullableUUID(input.ThreadID), nullableUUID(input.ThinkingNodeID),
 		string(input.Status), input.ActivityText, nullableStr(input.ToolName),
 		nullableStr(input.ToolInputSummary), nullableStr(input.Source), usage, nullableInt64(input.FreshnessSeenSeq),
+		nullableInt64(input.WakeFirstSeq), nullableInt64(input.WakeLatestSeq), input.WakeVisible,
 	))
 	if err != nil {
 		return nil, err
 	}
 	if err := NewBudgetService(s.pool).ReserveRunTx(ctx, tx, runID, input.AgentID); err != nil {
 		return nil, err
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return nil, err
-	}
-	if err := s.hydrateAgentRunTokenUsage(ctx, run); err != nil {
-		slog.Warn("run created but token usage could not be reloaded", "run_id", run.ID, "error", err)
 	}
 	return run, nil
 }
@@ -890,7 +906,27 @@ func (s *AgentRunService) ValidateMessageDelivery(ctx context.Context, runID, ag
 		}
 		return false, err
 	}
-	return runChannelID == channelID && runThreadID == threadID && runThinkingNodeID == thinkingNodeID, nil
+	if runChannelID != channelID {
+		return false, nil
+	}
+	if runThinkingNodeID != "" || thinkingNodeID != "" {
+		return runThreadID == threadID && runThinkingNodeID == thinkingNodeID, nil
+	}
+	if runThreadID != "" {
+		return runThreadID == threadID, nil
+	}
+	if threadID == "" {
+		return true, nil
+	}
+
+	var belongsToChannel bool
+	if err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM threads WHERE id = $1 AND channel_id = $2)`,
+		threadID, channelID,
+	).Scan(&belongsToChannel); err != nil {
+		return false, err
+	}
+	return belongsToChannel, nil
 }
 
 func (s *AgentRunService) HasVisibleMessage(ctx context.Context, runID string) (bool, error) {
@@ -903,8 +939,6 @@ func (s *AgentRunService) HasVisibleMessage(ctx context.Context, runID string) (
 			    ON m.sender_type = 'agent'
 			   AND m.sender_id = r.agent_id
 			   AND m.channel_id = r.channel_id
-			   AND COALESCE(m.thread_id::text, '') = COALESCE(r.thread_id::text, '')
-			   AND COALESCE(m.thinking_node_id::text, '') = COALESCE(r.thinking_node_id::text, '')
 			   AND m.metadata->>'agent_run_id' = r.id::text
 			 WHERE r.id = $1
 		)`, runID,

--- a/internal/server/service/agent_run_test.go
+++ b/internal/server/service/agent_run_test.go
@@ -693,15 +693,40 @@ func TestAgentRunVisibleMessageDelivery(t *testing.T) {
 	if _, err := runSvc.ValidateMessageDelivery(ctx, run.ID, uuid.NewString(), channelID, "", ""); err == nil {
 		t.Fatal("ValidateMessageDelivery accepted another agent")
 	}
+	rootMessageID := agentRunMessage(t, pool, channelID, ownerID)
+	threadID, _, err := NewThreadService(pool).GetOrCreateThread(ctx, channelID, rootMessageID)
+	if err != nil {
+		t.Fatalf("GetOrCreateThread: %v", err)
+	}
+	matches, err = runSvc.ValidateMessageDelivery(ctx, run.ID, agentID, channelID, threadID, "")
+	if err != nil || !matches {
+		t.Fatalf("ValidateMessageDelivery child thread = %v, %v", matches, err)
+	}
+	otherChannelID := agentRunChannel(t, pool, ownerID)
+	if otherChannelID == channelID {
+		otherChannelID = uuid.NewString()
+		if _, err := pool.Exec(ctx, `INSERT INTO channels (id, name, created_by) VALUES ($1, $2, $3)`, otherChannelID, "agent-run-other-"+otherChannelID[:8], ownerID); err != nil {
+			t.Fatalf("create other channel: %v", err)
+		}
+	}
+	otherRootMessageID := agentRunMessage(t, pool, otherChannelID, ownerID)
+	otherThreadID, _, err := NewThreadService(pool).GetOrCreateThread(ctx, otherChannelID, otherRootMessageID)
+	if err != nil {
+		t.Fatalf("GetOrCreateThread other channel: %v", err)
+	}
+	matches, err = runSvc.ValidateMessageDelivery(ctx, run.ID, agentID, channelID, otherThreadID, "")
+	if err != nil || matches {
+		t.Fatalf("ValidateMessageDelivery foreign thread = %v, %v", matches, err)
+	}
 
 	visible, err := runSvc.HasVisibleMessage(ctx, run.ID)
 	if err != nil || visible {
 		t.Fatalf("HasVisibleMessage before insert = %v, %v", visible, err)
 	}
 	_, err = pool.Exec(ctx, `
-		INSERT INTO messages (id, channel_id, sender_type, sender_id, content, metadata)
-		VALUES ($1, $2, 'agent', $3, 'delivered', jsonb_build_object('agent_run_id', $4::text, 'delivery', 'visible'))`,
-		uuid.NewString(), channelID, agentID, run.ID,
+		INSERT INTO messages (id, channel_id, thread_id, sender_type, sender_id, content, metadata)
+		VALUES ($1, $2, $3, 'agent', $4, 'delivered', jsonb_build_object('agent_run_id', $5::text, 'delivery', 'visible'))`,
+		uuid.NewString(), channelID, threadID, agentID, run.ID,
 	)
 	if err != nil {
 		t.Fatalf("insert visible message: %v", err)

--- a/internal/server/service/thread.go
+++ b/internal/server/service/thread.go
@@ -56,7 +56,7 @@ func (s *ThreadService) GetThreadContextMessages(ctx context.Context, threadID s
 		 FROM messages m
 		 LEFT JOIN users u ON m.sender_id = u.id
 		 LEFT JOIN agents a ON m.sender_id = a.id
-		 WHERE m.thread_id = $1
+		 WHERE m.thread_id = $1 AND m.is_deleted = false
 		 ORDER BY created_at ASC, id ASC`,
 		threadID,
 	)

--- a/migrations/000049_coalesce_agent_message_wakes.down.sql
+++ b/migrations/000049_coalesce_agent_message_wakes.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE agent_runs
+    DROP CONSTRAINT IF EXISTS chk_agent_run_wake_range,
+    DROP COLUMN IF EXISTS wake_requires_visible_result,
+    DROP COLUMN IF EXISTS wake_latest_message_seq,
+    DROP COLUMN IF EXISTS wake_first_message_seq;
+
+DROP TABLE IF EXISTS agent_pending_message_wakes;
+DROP TABLE IF EXISTS agent_message_wake_slots;

--- a/migrations/000049_coalesce_agent_message_wakes.up.sql
+++ b/migrations/000049_coalesce_agent_message_wakes.up.sql
@@ -1,0 +1,40 @@
+CREATE TABLE agent_message_wake_slots (
+    agent_id     UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    channel_id   UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    active_run_id UUID REFERENCES agent_runs(id) ON DELETE SET NULL,
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (agent_id, channel_id)
+);
+
+CREATE INDEX idx_agent_message_wake_slots_active_run
+    ON agent_message_wake_slots(active_run_id)
+    WHERE active_run_id IS NOT NULL;
+
+CREATE TABLE agent_pending_message_wakes (
+    agent_id             UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+    channel_id           UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    scope_key            TEXT NOT NULL,
+    thread_id            UUID REFERENCES threads(id) ON DELETE CASCADE,
+    first_message_seq    BIGINT NOT NULL CHECK (first_message_seq > 0),
+    latest_message_seq   BIGINT NOT NULL CHECK (latest_message_seq >= first_message_seq),
+    requires_visible_result BOOLEAN NOT NULL DEFAULT false,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (agent_id, channel_id, scope_key),
+    CHECK (
+        (thread_id IS NULL AND scope_key = 'channel') OR
+        (thread_id IS NOT NULL AND scope_key = 'thread:' || thread_id::text)
+    )
+);
+
+CREATE INDEX idx_agent_pending_message_wakes_oldest
+    ON agent_pending_message_wakes(agent_id, channel_id, created_at, scope_key);
+
+ALTER TABLE agent_runs
+    ADD COLUMN wake_first_message_seq BIGINT,
+    ADD COLUMN wake_latest_message_seq BIGINT,
+    ADD COLUMN wake_requires_visible_result BOOLEAN NOT NULL DEFAULT false,
+    ADD CONSTRAINT chk_agent_run_wake_range CHECK (
+        (wake_first_message_seq IS NULL AND wake_latest_message_seq IS NULL) OR
+        (wake_first_message_seq > 0 AND wake_latest_message_seq >= wake_first_message_seq)
+    );


### PR DESCRIPTION
## What changed

- Serialize message-triggered Agent Runs per Agent and Channel with PostgreSQL wake slots.
- Merge busy messages as persisted sequence ranges, preserving every message and consuming them together in order.
- Persist remote dispatch payloads and wake ranges atomically for Server and Daemon restart recovery.
- Suppress unmentioned Agent wakes in the public Workspace while keeping explicit mentions.
- Attribute Channel Run replies sent into a child Thread to the originating Run, preventing false missing-result reminders.
- Add a repeatable real frontend, API, PostgreSQL, Daemon, and Claude E2E plus architecture design.

## Root cause

Every persisted message independently created a Run. Concurrent Runs shared the same Agent and Channel provider Session and could each enter missing-visible-result recovery. Separately, a valid Channel Run reply sent into a Thread failed strict scope attribution, so Solo treated it as no visible result and repeatedly injected the reminder prompt.

## Validation

- go test ./... -count=1
- npx tsc --noEmit
- npm run lint (0 errors; existing warnings only)
- npx next build --webpack
- clean database migration from 000001 through 000049
- real Playwright E2E: three messages persisted; two busy messages merged into one follow-up Run; replies linked to Runs; zero reminders; public unmentioned message created zero Runs; explicit mention completed