### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.1.0 - 2026-08-14
+
+### Features
+
+- Add multi-user Workspaces, role-based membership, Guest access, and multiple independently paired Daemons across connected Computers.
+- Add scheduled Channel automations with explicit completion and review behavior, retry safety, and real end-to-end coverage.
+- Add monthly Token budgets, per-Run settlement, and accurate current-turn Claude Code and Codex usage across persistent Sessions.
+- Add remote avatar and attachment storage, authenticated downloads, Public Workspace ownership, message pinning, member muting, and posting policies.
+- Coalesce wakes for busy Agents while preserving distinct messages, deterministic routing, durable delivery, and send-time freshness checks.
+- Add explainable Task recovery and shared backend capability contracts for local Agent runtimes.
+
+### Fixes
+
+- Preserve managed Daemon pairing across restarts and canonicalize legacy remote Daemon identities without disrupting active Computers.
+- Refresh Agent-scoped credentials before template discovery and keep remote runtime permissions available to active Runs.
+- Clarify pin and mute controls with consistent human/Agent actions, visible state, loading feedback, and success notifications.
+- Refresh production web dependencies and lockfile compatibility.
+
+### Testing
+
+- Add real end-to-end coverage for Workspaces, multi-Daemon execution, automations, Token accounting, remote uploads, governance, wake coalescing, and runtime capability detection.
+
 ## 1.0.0 - 2026-08-09
 
 ### Features


### PR DESCRIPTION
## Summary

- document the v1.1.0 features and fixes released since v1.0.0
- record the real Workspace, automation, remote storage, governance, wake-coalescing, and Token-accounting coverage
- prepare the exact notes used by the annotated tag and GitHub Release

## Verification

- `make SERVER_PORT=18080 DAEMON_PORT=18081 FRONTEND_PORT=13000 test-e2e-token-accounting` — passed with real Claude Code and Codex runtimes
- `make test-release-install` — passed archive, checksum, installer, binaries, and linked version checks
