### PR TITLE
fix: restore shared avatars and reliable agent targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-agent-message-coalescing test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-product-completeness test-e2e-token-accounting test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-agent-delivery test-e2e-agent-target-resolution test-e2e-agent-message-coalescing test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-product-completeness test-e2e-token-accounting test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -41,6 +41,9 @@ rebuild: stop clean-pids build start ## Rebuild binaries from a clean .pids dir 
 
 test-e2e-agent-delivery: ## Rebuild and verify the real Agent result delivery contract
 	@bash scripts/run-local-e2e.sh agent-delivery env CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts
+
+test-e2e-agent-target-resolution: ## Verify Channel name and UUID sends with a stale provider Session token
+	@WATCHPACK_POLLING=true bash scripts/run-local-e2e.sh agent-target-resolution env CI=1 SOLO_E2E_REAL_AGENT_DELIVERY=1 npx playwright test e2e/agent-result-delivery.spec.ts --grep "sends by Channel name and UUID" --workers=1
 
 test-e2e-agent-message-coalescing: ## Rebuild and verify persisted busy-message coalescing with a real Agent
 	@bash scripts/run-local-e2e.sh agent-message-coalescing env CI=1 npx playwright test e2e/agent-message-coalescing.spec.ts --workers=1

--- a/cmd/daemon/handler.go
+++ b/cmd/daemon/handler.go
@@ -1754,9 +1754,6 @@ func resolveSoloBinary() string {
 	if configured := strings.TrimSpace(os.Getenv("SOLO_CLI_BIN")); configured != "" {
 		candidates = append(candidates, configured)
 	}
-	if path, err := exec.LookPath("solo"); err == nil {
-		candidates = append(candidates, path)
-	}
 	if exe, err := os.Executable(); err == nil {
 		candidates = append(candidates, filepath.Join(filepath.Dir(exe), "solo"))
 	}
@@ -1765,6 +1762,9 @@ func resolveSoloBinary() string {
 			filepath.Join(wd, ".pids", "solo"),
 			filepath.Join(wd, "bin", "solo"),
 		)
+	}
+	if path, err := exec.LookPath("solo"); err == nil {
+		candidates = append(candidates, path)
 	}
 	for _, candidate := range candidates {
 		info, err := os.Stat(candidate)

--- a/cmd/daemon/solo_binary_test.go
+++ b/cmd/daemon/solo_binary_test.go
@@ -34,11 +34,31 @@ func TestResolveSoloBinaryPrefersBuildCompanionOverInstalledPATH(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(installedDir, "solo"), []byte("stale"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Chdir(root)
+	previousDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previousDir); err != nil {
+			t.Errorf("restore working directory: %v", err)
+		}
+	})
 	t.Setenv("PATH", installedDir)
 	t.Setenv("SOLO_CLI_BIN", "")
 
-	if got := resolveSoloBinary(); got != companion {
+	got := resolveSoloBinary()
+	gotInfo, err := os.Stat(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	companionInfo, err := os.Stat(companion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(gotInfo, companionInfo) {
 		t.Fatalf("resolveSoloBinary() = %q, want build companion %q", got, companion)
 	}
 }

--- a/cmd/daemon/solo_binary_test.go
+++ b/cmd/daemon/solo_binary_test.go
@@ -17,3 +17,28 @@ func TestResolveSoloBinaryUsesConfiguredExecutable(t *testing.T) {
 		t.Fatalf("resolveSoloBinary() = %q, want %q", got, path)
 	}
 }
+
+func TestResolveSoloBinaryPrefersBuildCompanionOverInstalledPATH(t *testing.T) {
+	root := t.TempDir()
+	companion := filepath.Join(root, ".pids", "solo")
+	if err := os.MkdirAll(filepath.Dir(companion), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(companion, []byte("current"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	installedDir := filepath.Join(root, "installed")
+	if err := os.MkdirAll(installedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installedDir, "solo"), []byte("stale"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+	t.Setenv("PATH", installedDir)
+	t.Setenv("SOLO_CLI_BIN", "")
+
+	if got := resolveSoloBinary(); got != companion {
+		t.Fatalf("resolveSoloBinary() = %q, want build companion %q", got, companion)
+	}
+}

--- a/cmd/solo/README.md
+++ b/cmd/solo/README.md
@@ -85,10 +85,20 @@ solo task reopen -n <number> -c <channel_id>
 ### message send -- send a message to a channel
 
 ```bash
-solo message send -c <content> -C <channel_id> [-t <thread_id>]
+solo message send -c <content> --target <target>
 ```
 
-Note the case convention: `-c` for content, `-C` for channel ID, `-t` for thread ID.
+`--target` is the canonical destination flag and accepts either a Channel name
+or UUID, with an optional message short ID for a Thread:
+
+```bash
+solo message send -c "hello" --target '#general'
+solo message send -c "hello" --target '00000000-0000-0000-0000-000000000002'
+solo message send -c "reply" --target '#general:a1b2c3d4'
+```
+
+Lowercase `-c` always means content; it never means Channel. The obsolete
+`-C`/`-t` form is not supported.
 
 ### channel members -- list members of a channel
 
@@ -144,7 +154,7 @@ solo task update -n 3 -c my-channel -s done
 **Post a threaded reply:**
 
 ```bash
-solo message send -c "I'll take this one" -C my-channel -t th-abc123
+solo message send -c "I'll take this one" --target '#my-channel:abc123'
 ```
 
 **Script-friendly task listing:**

--- a/cmd/solo/main.go
+++ b/cmd/solo/main.go
@@ -1070,11 +1070,7 @@ func handleServerInfo(args []string, baseURL, token string) {
 	fs.StringVar(&output, "output", "", "Output format: json")
 	fs.Parse(args)
 
-	statusCode, body, err := proxyOrDirect("server_info", "", "", token)
-	if err != nil && allowDirectFallback() {
-		url := fmt.Sprintf("%s/api/v1/server/info", baseURL)
-		statusCode, body, err = doHTTP(http.MethodGet, url, token, nil)
-	}
+	statusCode, body, err := requestServerInfo(baseURL, token)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "solo: error: request failed: %v\n", err)
 		doExit(exitUsage)
@@ -1312,10 +1308,12 @@ func resolveTarget(baseURL, token, target string) (channelID, threadMsgID string
 }
 
 func resolveChannelName(baseURL, token, name string) (string, error) {
-	url := fmt.Sprintf("%s/api/v1/server/info", baseURL)
-	_, body, err := doHTTP(http.MethodGet, url, token, nil)
+	statusCode, body, err := requestServerInfo(baseURL, token)
 	if err != nil {
 		return "", err
+	}
+	if statusCode >= 400 {
+		return "", fmt.Errorf("server info failed (HTTP %d): %s", statusCode, extractErrorMessage(body))
 	}
 	var resp struct {
 		Channels []struct {
@@ -1334,6 +1332,14 @@ func resolveChannelName(baseURL, token, name string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("channel %q not found", name)
+}
+
+func requestServerInfo(baseURL, token string) (int, []byte, error) {
+	statusCode, body, err := proxyOrDirect("server_info", "", "", token)
+	if allowDirectFallback() && (err != nil || statusCode >= 400) {
+		return doHTTP(http.MethodGet, fmt.Sprintf("%s/api/v1/server/info", baseURL), token, nil)
+	}
+	return statusCode, body, err
 }
 
 // resolveChannelParam strips the # prefix (if present) and resolves a channel
@@ -1493,8 +1499,8 @@ func printMessageSendResult(body []byte, channelID, threadID string) {
 		fmt.Printf("Message sent to thread. Message ID: %s (to reply in this thread, use target \"%s:%s\")\n",
 			resp.ID, channelID, threadID)
 	} else {
-		fmt.Printf("Message sent to channel. Message ID: %s (to reply in this message's thread, use --target 'channel:%s')\n",
-			resp.ID, shortID)
+		fmt.Printf("Message sent to channel. Message ID: %s (to reply in this message's thread, use --target '%s:%s')\n",
+			resp.ID, channelID, shortID)
 	}
 }
 

--- a/cmd/solo/main_test.go
+++ b/cmd/solo/main_test.go
@@ -708,6 +708,107 @@ func TestHandleMessageSend(t *testing.T) {
 	}
 }
 
+func TestHandleMessageSendResolvesChannelNameThroughDaemonProxy(t *testing.T) {
+	var actions []string
+	var sentChannelID string
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/daemon/proxy" {
+			t.Fatalf("unexpected daemon path %s", r.URL.Path)
+		}
+		var request struct {
+			Action    string `json:"action"`
+			ChannelID string `json:"channel_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		actions = append(actions, request.Action)
+		w.Header().Set("Content-Type", "application/json")
+		switch request.Action {
+		case "server_info":
+			fmt.Fprint(w, `{"channels":[{"id":"550e8400-e29b-41d4-a716-446655440001","name":"general"}]}`)
+		case "message_send":
+			sentChannelID = request.ChannelID
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":"msg-by-name","channel_id":"550e8400-e29b-41d4-a716-446655440001"}`)
+		default:
+			t.Fatalf("unexpected proxy action %q", request.Action)
+		}
+	}))
+	defer daemon.Close()
+	t.Setenv("SOLO_DAEMON_URL", daemon.URL)
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+
+	code, stdout, stderr := captureAndRun(t, func() {
+		handleMessageSend([]string{"-c", "hello", "--target", "#general"}, "http://expired-token-must-not-be-used.invalid", "expired-token")
+	})
+
+	if code != exitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if got, want := strings.Join(actions, ","), "server_info,message_send"; got != want {
+		t.Fatalf("proxy actions = %q, want %q", got, want)
+	}
+	if sentChannelID != "550e8400-e29b-41d4-a716-446655440001" {
+		t.Fatalf("message channel = %q", sentChannelID)
+	}
+	if !strings.Contains(stdout, "550e8400-e29b-41d4-a716-446655440001:msg-by-n") {
+		t.Fatalf("send output did not contain a reusable UUID target: %q", stdout)
+	}
+}
+
+func TestHandleMessageSendUUIDSkipsChannelNameLookup(t *testing.T) {
+	var actions []string
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request struct {
+			Action    string `json:"action"`
+			ChannelID string `json:"channel_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		actions = append(actions, request.Action)
+		if request.ChannelID != "550e8400-e29b-41d4-a716-446655440001" {
+			t.Fatalf("message channel = %q", request.ChannelID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"msg-by-id","channel_id":"550e8400-e29b-41d4-a716-446655440001"}`)
+	}))
+	defer daemon.Close()
+	t.Setenv("SOLO_DAEMON_URL", daemon.URL)
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+
+	code, _, stderr := captureAndRun(t, func() {
+		handleMessageSend([]string{"-c", "hello", "--target", "550e8400-e29b-41d4-a716-446655440001"}, "http://expired-token-must-not-be-used.invalid", "expired-token")
+	})
+	if code != exitOK {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if got, want := strings.Join(actions, ","), "message_send"; got != want {
+		t.Fatalf("proxy actions = %q, want %q", got, want)
+	}
+}
+
+func TestResolveChannelNamePreservesServerInfoError(t *testing.T) {
+	daemon := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":"unauthorized","message":"Agent Run credential is no longer active"}`)
+	}))
+	defer daemon.Close()
+	t.Setenv("SOLO_DAEMON_URL", daemon.URL)
+	t.Setenv("SOLO_AGENT_ID", "agent-1")
+
+	_, err := resolveChannelName("http://unused.invalid", "expired-token", "general")
+	if err == nil || !strings.Contains(err.Error(), "Agent Run credential is no longer active") {
+		t.Fatalf("resolve error = %v", err)
+	}
+	if strings.Contains(err.Error(), `channel "general" not found`) {
+		t.Fatalf("authentication failure was mislabeled as a missing Channel: %v", err)
+	}
+}
+
 func TestPrintMessageSendResultHeld(t *testing.T) {
 	_, stdout, _ := captureAndRun(t, func() {
 		printMessageSendResult([]byte(`{

--- a/docs/plans/remote-product-completeness.md
+++ b/docs/plans/remote-product-completeness.md
@@ -66,6 +66,62 @@ not deleted or moved. Local non-production deployments keep their current
 default paths but receive the same writable-directory validation when a path is
 explicitly configured.
 
+### Shared user-avatar access
+
+A custom user avatar remains an `attachments` row and Server-owned file. The
+uploading user owns its lifecycle, and `users.avatar_url` identifies which JPEG,
+PNG, or WebP attachment is currently published as that user's profile image.
+The existing upload and profile APIs, frontend blob loading, database fields,
+and file paths do not change.
+
+Authenticated attachment reads add one narrow authorization path: a human user
+may read an attachment when it is the current avatar of another active user and
+both users belong to at least one common Workspace. This matches every frontend
+surface that returns another user's profile while keeping unrelated uploads and
+avatars from isolated Workspaces private. Agent Run credentials do not gain
+this permission. Replacing or clearing an avatar immediately removes the extra
+read path because authorization is evaluated from the current `users.avatar_url`
+value on every request.
+
+No migration or URL rewrite is needed for existing profiles. Legacy avatar URLs
+using either the original attachment or thumbnail route remain valid. Missing
+files still return not found, invalid credentials still return unauthorized,
+and the frontend keeps its deterministic preset/initials fallback. Verification
+must cover two real users in one Workspace, the same attachment from an
+unrelated Workspace, the browser-visible image, and persisted profile state.
+
+### Agent CLI channel-target resolution
+
+The `solo` CLI accepts either a Workspace-scoped Channel name or its UUID for
+message targets, with an optional message short ID for Threads. UUID targets
+remain lookup-free. Name targets are resolved against `server info` in the
+currently executing Agent Run's Workspace before the message is sent.
+
+The local Daemon owns the fresh Run credential, so Agent-side name resolution
+must use the same Daemon proxy as the subsequent send. It must not call the
+remote Server with the long-lived provider Session's originally injected token:
+that token can expire while Claude or Codex remains alive. Direct authenticated
+Server lookup remains the compatibility path for a standalone human CLI that
+has no Agent/Daemon scope. Non-success lookup responses are surfaced as their
+real authentication or Server error and are never rewritten as a misleading
+`channel not found` result.
+
+No database, Server API, frontend state, or migration changes are required.
+The generated Agent prompt continues to prefer the exact `target=` header while
+explicitly documenting that both `#channel-name` and Channel UUID forms are
+valid. `--target` is the canonical message destination flag; the historical
+lowercase `-c` continues to mean message content only, and the obsolete
+`-C`/`-t` form is not revived. CLI success output must print a syntactically
+valid UUID-based Thread target rather than the unsupported placeholder
+`channel:<short-id>`. Existing name, UUID, and Thread inputs remain compatible;
+ambiguous or absent names still fail without guessing. Verification covers an
+active Daemon proxy with an intentionally stale direct token, both name and UUID
+sends, the generated prompt, and the actual persisted message destination.
+The Daemon also copies the CLI shipped beside its own executable (or the current
+development build) into the Agent Workspace before falling back to any `solo`
+found on the machine PATH, so an older globally installed CLI cannot silently
+override the Server/Daemon version under test or in a packaged installation.
+
 ## 3. Workspace governance, pinning, and muting
 
 ### Roles

--- a/frontend/e2e/agent-result-delivery.spec.ts
+++ b/frontend/e2e/agent-result-delivery.spec.ts
@@ -6,7 +6,10 @@ import { acquireLocalComputer, type LocalComputerLease } from './support/local-c
 import { registerVerified } from './support/auth';
 
 const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
-const credentials = { email: 'agent-result-delivery-human-e2e@solo.local', password: 'SoloE2E-2026!' };
+const credentials = {
+  email: `agent-result-delivery-${Date.now()}-${process.pid}@solo.local`,
+  password: 'SoloE2E-2026!',
+};
 const daemonLogPath = join(process.cwd(), '..', 'daemon.log');
 
 interface AuthResponse {
@@ -489,6 +492,88 @@ test.describe('real Agent result delivery contract', () => {
       const persistedMessage = page.locator(`[data-message-id="${state.message_id}"]`);
       await expect(persistedMessage).toBeVisible();
       await expect(page.locator(`[data-message-id="${second.message_id}"]`)).toContainText('SECOND_OK');
+    } finally {
+      if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
+      if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);
+    }
+  });
+
+  test('sends by Channel name and UUID through a current Run when the provider Session token is stale', async ({ page, request }) => {
+    const auth = await authenticate(request);
+    const suffix = Date.now().toString(36);
+    let channel: Entity | null = null;
+    let agent: Entity | null = null;
+
+    try {
+      channel = await api<Entity>(request, auth.access_token, 'post', '/api/v1/channels', {
+        name: `target-resolution-${suffix}`,
+        description: 'Real Agent Channel name and UUID target resolution E2E',
+      });
+      agent = await api<Entity>(request, auth.access_token, 'post', `/api/v1/channels/${channel.id}/agents`, {
+        name: `Target Resolution E2E ${suffix}`,
+        computer_id: localComputer.id,
+        model_provider: 'claude',
+        model_name: 'sonnet',
+        system_prompt: [
+          'When introducing yourself, use solo message send to send exactly TARGET_RESOLUTION_READY.',
+          `When a user message contains NAME_TARGET, run exactly: SOLO_AUTH_TOKEN=expired-provider-session-token solo message send -c NAME_TARGET_OK --target '#${channel.name}'`,
+          'For NAME_TARGET, do not inspect server info, use a Channel UUID, or retry with another target.',
+          `When a user message contains UUID_TARGET, run exactly: SOLO_AUTH_TOKEN=expired-provider-session-token solo message send -c UUID_TARGET_OK --target '${channel.id}'`,
+          'Do not merely print either reply. Send no other visible text.',
+        ].join(' '),
+      });
+
+      await expect.poll(() => {
+        const state = deliveryState(agent!.id);
+        return `${state.status}/${state.message_id ? 'visible' : 'missing'}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe('completed/visible');
+      const introduction = deliveryState(agent.id);
+
+      const nameTrigger = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: `@${agent.name} NAME_TARGET` },
+      );
+      await expect.poll(() => {
+        const state = channelSessionState(nameTrigger.id);
+        return `${state.status}/${state.external_session_id}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${introduction.external_session_id}/NAME_TARGET_OK`,
+      );
+      const byName = channelSessionState(nameTrigger.id);
+
+      const uuidTrigger = await api<{ id: string }>(
+        request,
+        auth.access_token,
+        'post',
+        `/api/v1/channels/${channel.id}/messages`,
+        { content: `@${agent.name} UUID_TARGET` },
+      );
+      await expect.poll(() => {
+        const state = channelSessionState(uuidTrigger.id);
+        return `${state.status}/${state.external_session_id}/${state.message_content}`;
+      }, { timeout: 180000, intervals: [500, 1000, 2000] }).toBe(
+        `completed/${byName.external_session_id}/UUID_TARGET_OK`,
+      );
+      const byUUID = channelSessionState(uuidTrigger.id);
+
+      const persisted = databaseJSON<{ name_messages: number; uuid_messages: number; wrong_channels: number }>(`
+        SELECT json_build_object(
+          'name_messages', COUNT(*) FILTER (WHERE content = 'NAME_TARGET_OK' AND channel_id = '${channel!.id}'),
+          'uuid_messages', COUNT(*) FILTER (WHERE content = 'UUID_TARGET_OK' AND channel_id = '${channel!.id}'),
+          'wrong_channels', COUNT(*) FILTER (WHERE content IN ('NAME_TARGET_OK', 'UUID_TARGET_OK') AND channel_id <> '${channel!.id}')
+        )::text
+          FROM messages
+         WHERE sender_id = '${agent.id}'
+      `);
+      expect(persisted).toEqual({ name_messages: 1, uuid_messages: 1, wrong_channels: 0 });
+
+      await authenticatePage(page, auth);
+      await page.goto(`/dashboard?channel=${channel.id}`);
+      await expect(page.locator(`[data-message-id="${byName.message_id}"]`)).toContainText('NAME_TARGET_OK');
+      await expect(page.locator(`[data-message-id="${byUUID.message_id}"]`)).toContainText('UUID_TARGET_OK');
     } finally {
       if (agent) await api(request, auth.access_token, 'delete', `/api/v1/agents/${agent.id}`).catch(() => undefined);
       if (channel) await api(request, auth.access_token, 'delete', `/api/v1/channels/${channel.id}`).catch(() => undefined);

--- a/frontend/e2e/remote-product-completeness.spec.ts
+++ b/frontend/e2e/remote-product-completeness.spec.ts
@@ -13,7 +13,7 @@ interface AuthResponse {
 interface Workspace { id: string; name: string; role: 'owner' | 'admin' | 'member' }
 interface Channel { id: string; name: string }
 interface Message { id: string; content: string; thread_id?: string }
-interface Attachment { id: string; filename: string; url: string }
+interface Attachment { id: string; filename: string; url: string; thumbnail_url?: string }
 interface ChannelMember { member_id: string; workspace_role?: 'owner' | 'admin' | 'member' }
 
 async function register(request: APIRequestContext, name: string): Promise<AuthResponse> {
@@ -209,7 +209,19 @@ test.describe('remote product completeness', () => {
       });
       expect(avatarUpload.ok()).toBe(true);
       const avatar = await avatarUpload.json() as Attachment;
-      await call(request, member, 'patch', '/api/v1/users/me', workspace.id, { avatar_url: avatar.url });
+      const avatarURL = avatar.thumbnail_url || avatar.url;
+      await call(request, member, 'patch', '/api/v1/users/me', workspace.id, { avatar_url: avatarURL });
+
+      const avatarDownload = await request.get(`${apiBase}${avatarURL}`, { headers: headers(owner, workspace.id) });
+      expect(avatarDownload.ok()).toBe(true);
+      expect(avatarDownload.headers()['content-type']).toContain('image/png');
+      const avatarMessage = await call<Message>(request, member, 'post', `/api/v1/channels/${channel.id}/messages`, workspace.id, {
+        content: `AVATAR_VISIBLE_${suffix}`,
+      });
+      await page.reload();
+      const sharedAvatar = page.locator(`[data-message-id="${avatarMessage.id}"]`).getByLabel(member.user.display_name).locator('img');
+      await expect(sharedAvatar).toBeVisible();
+      await expect.poll(() => sharedAvatar.evaluate((image) => image.complete && image.naturalWidth > 0)).toBe(true);
 
       const persisted = databaseJSON<{ pin_count: number; mute_count: number; attachment_count: number; avatar_url: string; policy: string }>(`
         SELECT json_build_object(
@@ -220,7 +232,7 @@ test.describe('remote product completeness', () => {
           'policy',(SELECT posting_policy FROM channels WHERE id='${channel.id}')
         )::text
       `);
-      expect(persisted).toEqual({ pin_count: 0, mute_count: 0, attachment_count: 2, avatar_url: avatar.url, policy: 'everyone' });
+      expect(persisted).toEqual({ pin_count: 0, mute_count: 0, attachment_count: 2, avatar_url: avatarURL, policy: 'everyone' });
 
       await call(request, admin, 'put', `/api/v1/channels/${channel.id}/moderation/mutes/${member.user.id}`, workspace.id, { reason: 'remove cleanup' });
       await call(request, admin, 'delete', `/api/v1/workspaces/${workspace.id}/members/${member.user.id}`, workspace.id);

--- a/internal/server/handler/attachment.go
+++ b/internal/server/handler/attachment.go
@@ -311,6 +311,21 @@ func (h *AttachmentHandler) authorize(r *http.Request) bool {
 		            AND dm.member_id = $2
 		          WHERE $1::uuid = ANY(m.attachment_ids)
 		         )
+		         OR EXISTS (
+		           SELECT 1
+		             FROM users avatar_owner
+		             JOIN workspace_members owner_membership
+		               ON owner_membership.user_id = avatar_owner.id
+		             JOIN workspace_members viewer_membership
+		               ON viewer_membership.workspace_id = owner_membership.workspace_id
+		              AND viewer_membership.user_id = $2
+		            WHERE avatar_owner.id = a.user_id
+		              AND avatar_owner.is_active = true
+		              AND avatar_owner.avatar_url IN (
+		                '/api/v1/attachments/' || a.id::text,
+		                '/api/v1/attachments/' || a.id::text || '/thumbnail'
+		              )
+		         )
 		       ))
 		     )
 		)`, chi.URLParam(r, "attachmentID"), claims.Subject, claims.ActorType, nullableClaim(claims.RunID), nullableClaim(claims.ComputerID)).Scan(&allowed)

--- a/internal/server/handler/attachment_test.go
+++ b/internal/server/handler/attachment_test.go
@@ -86,6 +86,93 @@ func TestAgentRunAttachmentTokenIsLimitedToRunChannel(t *testing.T) {
 	}
 }
 
+func TestUserAvatarAttachmentIsVisibleOnlyInsideSharedWorkspace(t *testing.T) {
+	pool := attachmentTestPool(t)
+	ctx := context.Background()
+	ownerID := uuid.NewString()
+	viewerID := uuid.NewString()
+	outsiderID := uuid.NewString()
+	sharedWorkspaceID := uuid.NewString()
+	isolatedWorkspaceID := uuid.NewString()
+	attachmentID := uuid.NewString()
+	ownerEmail := fmt.Sprintf("avatar-owner-%s@example.test", ownerID)
+	viewerEmail := fmt.Sprintf("avatar-viewer-%s@example.test", viewerID)
+	outsiderEmail := fmt.Sprintf("avatar-outsider-%s@example.test", outsiderID)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id, email, display_name, password_hash) VALUES
+			($1, $2, 'Avatar Owner', 'test'),
+			($3, $4, 'Avatar Viewer', 'test'),
+			($5, $6, 'Avatar Outsider', 'test')`,
+		ownerID, ownerEmail, viewerID, viewerEmail, outsiderID, outsiderEmail); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM attachments WHERE id = $1`, attachmentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM workspaces WHERE id IN ($1, $2)`, sharedWorkspaceID, isolatedWorkspaceID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id IN ($1, $2, $3)`, ownerID, viewerID, outsiderID)
+	})
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO workspaces (id, name, visibility, created_by) VALUES
+			($1, $2, 'private', $3),
+			($4, $5, 'private', $6)`,
+		sharedWorkspaceID, "shared-avatar-"+ownerID, ownerID,
+		isolatedWorkspaceID, "isolated-avatar-"+outsiderID, outsiderID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO workspace_members (workspace_id, user_id, role) VALUES
+			($1, $2, 'owner'),
+			($1, $3, 'member'),
+			($4, $5, 'owner')`,
+		sharedWorkspaceID, ownerID, viewerID, isolatedWorkspaceID, outsiderID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO attachments (id, user_id, filename, mime_type, size, storage_path)
+		VALUES ($1, $2, 'avatar.png', 'image/png', 1, 'avatar.png')`, attachmentID, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE users SET avatar_url = $1 WHERE id = $2`,
+		"/api/v1/attachments/"+attachmentID+"/thumbnail", ownerID); err != nil {
+		t.Fatal(err)
+	}
+
+	authorized := func(userID, email, name string) bool {
+		t.Helper()
+		token, err := auth.GenerateAccessToken(userID, email, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/attachments/"+attachmentID+"/thumbnail", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		route := chi.NewRouteContext()
+		route.URLParams.Add("attachmentID", attachmentID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, route))
+		return (&AttachmentHandler{pool: pool}).authorize(req)
+	}
+
+	if !authorized(viewerID, viewerEmail, "Avatar Viewer") {
+		t.Fatal("shared Workspace member could not read the current user avatar")
+	}
+	if authorized(outsiderID, outsiderEmail, "Avatar Outsider") {
+		t.Fatal("user outside the avatar owner's Workspaces could read the avatar")
+	}
+	if _, err := pool.Exec(ctx, `UPDATE users SET avatar_url = $1 WHERE id = $2`,
+		"/api/v1/attachments/"+attachmentID, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if !authorized(viewerID, viewerEmail, "Avatar Viewer") {
+		t.Fatal("shared Workspace member could not read a current non-thumbnail avatar")
+	}
+	if _, err := pool.Exec(ctx, `UPDATE users SET avatar_url = NULL WHERE id = $1`, ownerID); err != nil {
+		t.Fatal(err)
+	}
+	if authorized(viewerID, viewerEmail, "Avatar Viewer") {
+		t.Fatal("shared Workspace member could still read an attachment after it stopped being the current avatar")
+	}
+}
+
 func attachmentTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("DATABASE_URL")

--- a/pkg/agent/prompt.go
+++ b/pkg/agent/prompt.go
@@ -99,7 +99,7 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 	b.WriteString("```\n\n")
 	b.WriteString("Parse this line structurally: the `@name:` immediately after `]` is the **sender label**, never a recipient or @mention. Only `@name` tokens inside the content after that sender label are @mentions. For example, `] @lili: hello` means lili sent `hello`; it does not address or @mention lili.\n\n")
 	b.WriteString("Header fields:\n")
-	b.WriteString("- `target=` — where the message came from. Reuse as the `--target` parameter when replying.\n")
+	b.WriteString("- `target=` — where the message came from. Reuse its exact value as the `--target` parameter when replying; do not translate a Channel name into an ID or probe alternate forms.\n")
 	b.WriteString("- `msg=` — message short ID (first 8 chars of UUID). Use as thread suffix to start/reply in a thread.\n")
 	b.WriteString("- `time=` — timestamp.\n")
 	b.WriteString("- `type=` — sender kind. Values are `human`, `agent`, or `system`.\n\n")
@@ -107,7 +107,7 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 
 	// Sending messages
 	b.WriteString("### Sending messages\n\n")
-	b.WriteString("- **Reply to a channel**: `solo message send --target '#channel-name' <<'EOF'` followed by the message body and `EOF`\n")
+	b.WriteString("- **Reply to a channel**: `solo message send --target '#channel-name' <<'EOF'` followed by the message body and `EOF`. A Channel UUID is also accepted in place of `#channel-name`.\n")
 	b.WriteString("- **Reply to a DM**: `solo message send --target 'dm:@peer-name' <<'EOF'` followed by the message body and `EOF`\n")
 	b.WriteString("- **Reply in a thread**: `solo message send --target '#channel-name:shortid' <<'EOF'` followed by the message body and `EOF`\n")
 	b.WriteString("- **Start a NEW DM**: `solo message send --target 'dm:@person-name' <<'EOF'` followed by the message body and `EOF`\n")
@@ -117,6 +117,7 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 	b.WriteString("Long message with \"quotes\", $vars, `backticks`, and code blocks.\n")
 	b.WriteString("EOF\n")
 	b.WriteString("```\n")
+	b.WriteString("\n`--target` is the canonical destination flag. It accepts both Channel names (`#general`) and Channel UUIDs, plus the same forms with a `:shortid` Thread suffix. The CLI resolves names inside the current Workspace; do not retry with guessed flag combinations.\n")
 	b.WriteString("\n**IMPORTANT**: To reply to any message, always reuse the exact `target=` field from the received message header as the `--target` parameter. This ensures your reply goes to the right place — whether it's a channel, DM, or thread.\n\n")
 
 	// Threads
@@ -146,7 +147,7 @@ func BuildSystemPrompt(agent AgentConfig, channel ChannelContext, memoryContent 
 
 	// Reading history
 	b.WriteString("### Reading history\n\n")
-	b.WriteString("`solo message read --channel \"#channel-name\"` or `solo message read --channel \"#channel:shortid\"`\n")
+	b.WriteString("`solo message read --target \"#channel-name\"` or `solo message read --target \"#channel:shortid\"`\n")
 	b.WriteString("Supports `--before` / `--after` for pagination.\n\n")
 
 	// Historical references
@@ -386,7 +387,7 @@ func writeCLICommands(b *strings.Builder, channel ChannelContext) {
 	// Only commands that exist in solo CLI are listed.
 
 	fmt.Fprintf(b, "1. **%s** — Non-blocking check for new messages. Use freely during work — at natural breakpoints or after notifications.\n", bt("solo message check [-c <channel_id>]"))
-	fmt.Fprintf(b, "2. **%s** — Send a message to a channel, DM, or thread. Always use `--target` from the received message header.\n", bt("solo message send -c <content> --target <target>"))
+	fmt.Fprintf(b, "2. **%s** — Send a message to a channel, DM, or thread. `--target` accepts a Channel name or UUID; always reuse the exact target from a received message header.\n", bt("solo message send -c <content> --target <target>"))
 	fmt.Fprintf(b, "3. **%s** — Read past messages from a channel, DM, or thread. Supports `--before` / `--after` pagination.\n", bt("solo message read --target <target> [--before <id>] [--limit <n>]"))
 	fmt.Fprintf(b, "4. **%s** — List channels in this server, which ones you have joined, plus all agents and humans.\n", bt("solo server info"))
 	fmt.Fprintf(b, "5. **%s** — List the members (agents and humans) of a specific channel.\n", bt("solo channel members -c <channel_id>"))

--- a/pkg/agent/prompt_test.go
+++ b/pkg/agent/prompt_test.go
@@ -237,6 +237,9 @@ func TestBuildSystemPrompt_MessageFormat(t *testing.T) {
 	assertHas(t, p, "type=")
 	assertHas(t, p, "is the **sender label**, never a recipient or @mention")
 	assertHas(t, p, "] @lili: hello")
+	assertHas(t, p, "Reuse its exact value as the `--target` parameter")
+	assertHas(t, p, "both Channel names (`#general`) and Channel UUIDs")
+	assertNotHas(t, p, "solo message read --channel")
 }
 
 func TestBuildSystemPrompt_MessageNotifications(t *testing.T) {


### PR DESCRIPTION
## What changed

- Allow authenticated users to load the current custom avatar of another active user when both belong to the same Workspace, without exposing unrelated uploads or cross-Workspace avatars.
- Resolve Agent message targets by Channel name through the Daemon's current Run credential while keeping UUID targets lookup-free.
- Prefer the `solo` CLI shipped beside the running Daemon (or the current development build) over an older globally installed CLI.
- Keep `--target` as the single destination flag for Channel names, UUIDs, and Thread suffixes; do not revive the obsolete `-C`/`-t` form.
- Correct the generated Agent prompt, CLI documentation, and successful-send Thread continuation target.
- Add real browser/API/PostgreSQL coverage for shared avatars and real Claude coverage for stale-token Channel-name/UUID delivery.

## Why

Two remote-product paths were inconsistent:

1. Avatar URLs were returned to collaborators, but attachment authorization only allowed the uploader to download the underlying file, so other users saw a fallback avatar.
2. Channel-name lookup called the remote Server with a provider Session token that could expire while the Agent remained alive. In development, the Daemon could also copy a stale globally installed CLI instead of the newly built companion binary. Agents consequently entered a misleading "name not found → inspect channels → retry with UUID" loop.

The changes keep authorization Workspace-scoped and make target lookup use the same fresh Run credential and CLI version as the subsequent send.

## Validation

- `go test ./... -count=1`
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- Real two-user frontend/API/PostgreSQL E2E for shared-avatar visibility and Workspace isolation
- `make SERVER_PORT=18080 DAEMON_PORT=18081 FRONTEND_PORT=13000 test-e2e-agent-target-resolution`
  - real Claude persistent Session
  - intentionally stale provider Session token
  - Channel-name and UUID sends both succeeded once
  - browser-visible messages and persisted destination verified
