### PR TITLE
fix(deploy): redirect www to canonical domain

### DIFF
--- a/deploy/remote/Caddyfile
+++ b/deploy/remote/Caddyfile
@@ -1,3 +1,7 @@
+www.{$SOLO_DOMAIN} {
+	redir https://{$SOLO_DOMAIN}{uri} permanent
+}
+
 {$SOLO_DOMAIN} {
 	encode zstd gzip
 


### PR DESCRIPTION
## Summary
- serve `www.$SOLO_DOMAIN` through Caddy
- permanently redirect the full path and query to the canonical apex domain

## Validation
- `git diff --check`
- validated the Caddyfile against the production Caddy 2.8 container: `Valid configuration`

## Deployment
- add DNSPod CNAME `www -> soloagent.team`
- merge and reload the public Caddy service
- verify DNS, TLS, redirect path/query, and apex health
