### PR TITLE
Improve Solo search discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
   <img src="./solo-badge.svg" alt="SOLO" width="360">
 </p>
 
+<h1 align="center">Solo Agent</h1>
+
 <p align="center">
-  <strong>Local-first workspace for humans and AI coding agents.</strong><br>
+  <strong>Open-source, local-first workspace for humans and AI coding agents.</strong><br>
   Coordinate multiple agents through channels, threaded conversations, task boards, and channel-scoped teams.
 </p>
 
 <p align="center">
-  English | <a href="./README.zh-CN.md">简体中文</a>
+  <a href="https://soloagent.team">Solo Agent Website</a> · English | <a href="./README.zh-CN.md">简体中文</a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,13 +2,15 @@
   <img src="./solo-badge.svg" alt="SOLO" width="360">
 </p>
 
+<h1 align="center">Solo Agent</h1>
+
 <p align="center">
-  <strong>本地优先的人类与 AI 编码智能体协作工作区。</strong><br>
+  <strong>开源、本地优先的人类与 AI 编码智能体协作工作区。</strong><br>
   通过频道、讨论串、任务看板和频道团队协调多个智能体。
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | 简体中文
+  <a href="https://soloagent.team">Solo Agent 官网</a> · <a href="./README.md">English</a> | 简体中文
 </p>
 
 <p align="center">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,150 +1,51 @@
-"use client";
+import type { Metadata } from "next";
+import HomeAuthRedirect from "@/components/home-auth-redirect";
+import HomePage from "@/components/home-page";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { useAuth } from "@/lib/auth-context";
-import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/spinner";
-import { Decoration } from "@/components/ui/decoration";
+const title = "Solo Agent — Open-Source Multi-Agent Workspace";
+const description =
+  "Solo Agent (SoloAgent) is an open-source, local-first workspace where humans and AI coding agents collaborate through channels, tasks, teams, and persistent memory.";
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Solo Agent",
+  alternateName: ["Solo", "SoloAgent", "solo-agent"],
+  url: "https://soloagent.team/",
+  sameAs: ["https://github.com/solo-agent/solo"],
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "macOS, Windows, Linux",
+  description,
+};
 
-export default function Home() {
-  const router = useRouter();
-  const { isAuthenticated, isLoading } = useAuth();
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: "https://soloagent.team/",
+  },
+  openGraph: {
+    type: "website",
+    url: "https://soloagent.team/",
+    siteName: "Solo Agent",
+    title,
+    description,
+  },
+  twitter: {
+    card: "summary",
+    title,
+    description,
+  },
+};
 
-  useEffect(() => {
-    if (!isLoading && isAuthenticated) {
-      router.push("/dashboard");
-    }
-  }, [isAuthenticated, isLoading, router]);
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-brutal-cream">
-        <Spinner size="md" />
-      </div>
-    );
-  }
-
+export default function Page() {
   return (
-    <div className="relative min-h-screen flex flex-col items-center justify-center bg-brutal-cream px-4 overflow-hidden">
-      {/* v3.2 (Phase 2): grid texture behind the hero gives the page
-          a faint engineering-paper feel. Low contrast (6% black lines)
-          so the foreground still wins. */}
-      <div className="absolute inset-0 bg-grid pointer-events-none" aria-hidden />
-
-      <div className="relative w-full max-w-md text-center">
-        {/* v3.3: scattered sticker ornaments around the hero. */}
-        <Decoration
-          shape="star"
-          color="accent"
-          size="sm"
-          animation="spin"
-          rotation={-12}
-          className="absolute -top-4 -left-6"
-        />
-        <Decoration
-          shape="zap"
-          color="warning"
-          size="sm"
-          animation="bounce"
-          rotation={14}
-          className="absolute -top-2 -right-8"
-        />
-        <Decoration
-          shape="sparkle"
-          color="info"
-          size="sm"
-          animation="pulse"
-          rotation={6}
-          className="absolute top-1/2 -left-12"
-        />
-
-        {/* Logo */}
-        <div className="inline-flex h-16 w-16 items-center justify-center bg-brutal-primary border-brutal-4 shadow-brutal mb-6">
-          <span className="font-heading font-black text-3xl text-white">S</span>
-        </div>
-
-        {/* Value prop — v3.2 (Phase 2): the wordmark is now hollow
-            (text-stroke) and slightly rotated to read like a sticker
-            slapped on the page. Brutalist "display" treatment reserved
-            for this hero position only. */}
-        <h1
-          className="font-heading font-black text-6xl text-black mb-3"
-          style={{
-            transform: 'rotate(-2deg)',
-            WebkitTextStroke: '2px #000',
-            color: 'transparent',
-          }}
-        >
-          Solo
-        </h1>
-        <p className="font-sans text-lg text-muted-foreground mb-8 max-w-sm mx-auto">
-          A workspace where you and AI agents collaborate as a real team.
-        </p>
-
-        {/* Feature highlights — v3.1: use border-brutal-4 + shadow-brutal-2xl
-            with slight sticker rotation to feel hand-placed. Most product
-            surfaces still use the smaller 2px/3px tokens; this is a hero
-            treatment reserved for marketing-level emphasis. */}
-        <div className="grid grid-cols-3 gap-5 mb-10 text-left">
-          <div
-            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
-            style={{ transform: 'rotate(-0.6deg)' }}
-          >
-            <div className="font-heading font-black text-sm mb-1">Agents</div>
-            <p className="font-sans text-xs text-muted-foreground">
-              Persistent AI teammates with memory, roles, and skills.
-            </p>
-          </div>
-          <div
-            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
-            style={{ transform: 'rotate(0.4deg)' }}
-          >
-            <div className="font-heading font-black text-sm mb-1">Channels</div>
-            <p className="font-sans text-xs text-muted-foreground">
-              Organize work in channels — chat, coordinate, ship.
-            </p>
-          </div>
-          <div
-            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
-            style={{ transform: 'rotate(-0.3deg)' }}
-          >
-            <div className="font-heading font-black text-sm mb-1">Tasks</div>
-            <p className="font-sans text-xs text-muted-foreground">
-              Track work from message to completion with clear ownership.
-            </p>
-          </div>
-        </div>
-
-        {/* CTA — v3.3: yellow button now casts a yellow hard shadow
-            (inline style beats .btn-brutal's black shadow in cascade).
-            The CTA's relative + mb-10 wrapping gives the 7px shadow
-            physical room and pushes the helper text clear of the shadow
-            box, so "Sign In" no longer collides with the shadow. */}
-        <div className="space-y-3">
-          <div className="relative mb-10">
-            <Link href="/auth/register">
-              <Button
-                variant="default"
-                className="w-full text-base py-3 animate-pulse-brutal"
-                style={{ boxShadow: '7px 7px 0 0 var(--color-brutal-primary)' }}
-              >
-                Get Started
-              </Button>
-            </Link>
-          </div>
-          <p className="font-sans text-sm text-muted-foreground">
-            Already have an account?{" "}
-            <Link
-              href="/auth/login"
-              className="font-heading font-bold text-black hover:text-brutal-primary transition-colors"
-            >
-              Sign In
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <HomeAuthRedirect />
+      <HomePage />
+    </>
   );
 }

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/api/",
+        "/auth/",
+        "/computers",
+        "/dashboard",
+        "/guest/",
+        "/observability",
+        "/settings",
+        "/templates",
+      ],
+    },
+    sitemap: "https://soloagent.team/sitemap.xml",
+    host: "https://soloagent.team",
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: "https://soloagent.team/",
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+  ];
+}

--- a/frontend/components/home-auth-redirect.tsx
+++ b/frontend/components/home-auth-redirect.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+import { Spinner } from "@/components/ui/spinner";
+
+export default function HomeAuthRedirect() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      router.push("/dashboard");
+    }
+  }, [isAuthenticated, isLoading, router]);
+
+  if (!isLoading && !isAuthenticated) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-brutal-cream">
+      <Spinner size="md" />
+    </div>
+  );
+}

--- a/frontend/components/home-page.tsx
+++ b/frontend/components/home-page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Decoration } from "@/components/ui/decoration";
+
+export default function HomePage() {
+  return (
+    <div className="relative min-h-screen flex flex-col items-center justify-center bg-brutal-cream px-4 overflow-hidden">
+      {/* v3.2 (Phase 2): grid texture behind the hero gives the page
+          a faint engineering-paper feel. Low contrast (6% black lines)
+          so the foreground still wins. */}
+      <div className="absolute inset-0 bg-grid pointer-events-none" aria-hidden />
+
+      <div className="relative w-full max-w-md text-center">
+        {/* v3.3: scattered sticker ornaments around the hero. */}
+        <Decoration
+          shape="star"
+          color="accent"
+          size="sm"
+          animation="spin"
+          rotation={-12}
+          className="absolute -top-4 -left-6"
+        />
+        <Decoration
+          shape="zap"
+          color="warning"
+          size="sm"
+          animation="bounce"
+          rotation={14}
+          className="absolute -top-2 -right-8"
+        />
+        <Decoration
+          shape="sparkle"
+          color="info"
+          size="sm"
+          animation="pulse"
+          rotation={6}
+          className="absolute top-1/2 -left-12"
+        />
+
+        {/* Logo */}
+        <div className="inline-flex h-16 w-16 items-center justify-center bg-brutal-primary border-brutal-4 shadow-brutal mb-6">
+          <span className="font-heading font-black text-3xl text-white">S</span>
+        </div>
+
+        {/* Value prop — v3.2 (Phase 2): the wordmark is now hollow
+            (text-stroke) and slightly rotated to read like a sticker
+            slapped on the page. Brutalist "display" treatment reserved
+            for this hero position only. */}
+        <h1
+          className="font-heading font-black text-6xl text-black mb-3"
+          style={{
+            transform: 'rotate(-2deg)',
+            WebkitTextStroke: '2px #000',
+            color: 'transparent',
+          }}
+        >
+          Solo
+        </h1>
+        <p className="font-sans text-lg text-muted-foreground mb-8 max-w-sm mx-auto">
+          <strong className="text-foreground">Solo Agent</strong> is an open-source workspace where you and AI coding agents collaborate as a real team.
+        </p>
+
+        {/* Feature highlights — v3.1: use border-brutal-4 + shadow-brutal-2xl
+            with slight sticker rotation to feel hand-placed. Most product
+            surfaces still use the smaller 2px/3px tokens; this is a hero
+            treatment reserved for marketing-level emphasis. */}
+        <div className="grid grid-cols-3 gap-5 mb-10 text-left">
+          <div
+            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
+            style={{ transform: 'rotate(-0.6deg)' }}
+          >
+            <div className="font-heading font-black text-sm mb-1">Agents</div>
+            <p className="font-sans text-xs text-muted-foreground">
+              Persistent AI teammates with memory, roles, and skills.
+            </p>
+          </div>
+          <div
+            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
+            style={{ transform: 'rotate(0.4deg)' }}
+          >
+            <div className="font-heading font-black text-sm mb-1">Channels</div>
+            <p className="font-sans text-xs text-muted-foreground">
+              Organize work in channels — chat, coordinate, ship.
+            </p>
+          </div>
+          <div
+            className="border-brutal-4 p-3.5 bg-white shadow-brutal-2xl"
+            style={{ transform: 'rotate(-0.3deg)' }}
+          >
+            <div className="font-heading font-black text-sm mb-1">Tasks</div>
+            <p className="font-sans text-xs text-muted-foreground">
+              Track work from message to completion with clear ownership.
+            </p>
+          </div>
+        </div>
+
+        {/* CTA — v3.3: yellow button now casts a yellow hard shadow
+            (inline style beats .btn-brutal's black shadow in cascade).
+            The CTA's relative + mb-10 wrapping gives the 7px shadow
+            physical room and pushes the helper text clear of the shadow
+            box, so "Sign In" no longer collides with the shadow. */}
+        <div className="space-y-3">
+          <div className="relative mb-10">
+            <Link href="/auth/register">
+              <Button
+                variant="default"
+                className="w-full text-base py-3 animate-pulse-brutal"
+                style={{ boxShadow: '7px 7px 0 0 var(--color-brutal-primary)' }}
+              >
+                Get Started
+              </Button>
+            </Link>
+          </div>
+          <p className="font-sans text-sm text-muted-foreground">
+            Already have an account?{" "}
+            <Link
+              href="/auth/login"
+              className="font-heading font-bold text-black hover:text-brutal-primary transition-colors"
+            >
+              Sign In
+            </Link>
+          </p>
+          <p className="font-sans text-sm text-muted-foreground">
+            <a
+              href="https://github.com/solo-agent/solo"
+              target="_blank"
+              rel="noreferrer"
+              className="font-heading font-bold text-black hover:text-brutal-primary transition-colors"
+            >
+              Solo Agent on GitHub
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -47,8 +47,8 @@ const en = {
   days: '{n} day',
 
   // ── Layout / Nav / App Shell ──
-  appTitle: 'Solo — Channel-based Multi-Agent Collaboration Platform',
-  appDescription: 'A collaboration space for humans and AI, organized like a team chat',
+  appTitle: 'Solo Agent — Open-Source Multi-Agent Workspace',
+  appDescription: 'An open-source, local-first workspace where humans and AI coding agents collaborate through channels, tasks, teams, and persistent memory.',
   navChannels: 'Channels',
   navTasks: 'Task Board',
   navTeams: 'Teams',


### PR DESCRIPTION
## What changed

- Make **Solo Agent** the consistent product name in the English and Chinese READMEs.
- Add crawlable homepage metadata, canonical URL, Open Graph/Twitter tags, and SoftwareApplication JSON-LD.
- Keep the existing authenticated redirect while rendering indexable homepage content on the server.
- Add `robots.txt` and `sitemap.xml` metadata routes.
- Include the `Solo Agent`, `SoloAgent`, `solo-agent`, and `Solo` name variants where appropriate.

## Why

Search engines and GitHub had weak exact-name signals for the repository and website, so lower-star repositories could rank above the official Solo Agent project.

## Impact

This strengthens entity/name consistency and crawlability for Google queries such as `solo-agent`, `soloagent`, and `solo`, without changing the signed-in product flow.

## Validation

- `npm run build`
- Targeted ESLint for the changed frontend files
- `git diff --check`
- Verified generated homepage HTML includes the canonical URL, structured data, visible Solo Agent text, and GitHub link
