### PR TITLE
fix(onboarding): preserve workspace invite flow

### DIFF
--- a/frontend/components/onboarding/first-run-wizard.tsx
+++ b/frontend/components/onboarding/first-run-wizard.tsx
@@ -39,6 +39,7 @@ export function FirstRunWizard() {
   const targetRef = useRef<HTMLElement | null>(null);
   const completing = useRef(false);
   const guideSkipKey = user?.id ? `solo:first-run-guide-skipped:${user.id}` : null;
+  const onboardingDeferred = pathname.startsWith('/invite/');
 
   const load = useCallback(async () => {
     if (!isAuthenticated) return;
@@ -80,7 +81,7 @@ export function FirstRunWizard() {
   }, [guideSkipKey, searchParams, status?.required]);
 
   useEffect(() => {
-    if (!status?.required || !guideStateReady || !guideVisible) return;
+    if (onboardingDeferred || !status?.required || !guideStateReady || !guideVisible) return;
     if (status.step === 1) {
       if (pathname !== '/home' && pathname !== '/computers') router.replace('/home?onboarding=1');
       return;
@@ -94,7 +95,7 @@ export function FirstRunWizard() {
     if (status.lucy_channel_id && (pathname !== '/dashboard' || currentChannel !== status.lucy_channel_id || !params.has('onboarding'))) {
       router.replace(`/dashboard?channel=${encodeURIComponent(status.lucy_channel_id)}&onboarding=1`);
     }
-  }, [guideStateReady, guideVisible, pathname, router, status]);
+  }, [guideStateReady, guideVisible, onboardingDeferred, pathname, router, status]);
 
   useEffect(() => {
     const defaultRuntime = status?.runtimes.find((item) => isSupportedAgentRuntime(item.type));
@@ -102,7 +103,7 @@ export function FirstRunWizard() {
   }, [runtime, status?.runtimes]);
 
   useEffect(() => {
-    if (!status?.required || !status.greeting_ready || completing.current) return;
+    if (onboardingDeferred || !status?.required || !status.greeting_ready || completing.current) return;
     completing.current = true;
     void complete().then(({ channel_id }) => {
       setStatus((current) => current ? { ...current, required: false } : current);
@@ -111,7 +112,7 @@ export function FirstRunWizard() {
       completing.current = false;
       setError(err instanceof Error ? err.message : t('firstRunCompleteError'));
     });
-  }, [complete, router, status]);
+  }, [complete, onboardingDeferred, router, status]);
 
   const targetSelector = useMemo(() => {
     if (!status?.required || !guideVisible) return '';
@@ -203,7 +204,7 @@ export function FirstRunWizard() {
     router.replace(`${pathname}${query ? `?${query}` : ''}`, { scroll: false });
   };
 
-  if (authLoading || !isAuthenticated || !status?.required) return null;
+  if (onboardingDeferred || authLoading || !isAuthenticated || !status?.required) return null;
 
   const onTarget = () => targetRef.current?.click();
   const onCoachAction = status.step === 3 ? () => setLucyOpen(true) : onTarget;

--- a/frontend/e2e/workspace-invite-link.spec.ts
+++ b/frontend/e2e/workspace-invite-link.spec.ts
@@ -86,7 +86,9 @@ test.describe('Workspace member invite links', () => {
   test('redirects visitors, then lets a signed-in user join and see the workspace', async ({ page, browser, request }) => {
     const owner = await register(request, 'InviteOwner');
     const member = await register(request, 'InviteMember');
-    const workspaceID = owner.workspace_id!;
+    const workspaceID = (await call<Workspace>(request, owner, 'post', '/api/v1/workspaces', undefined, {
+      name: `Invite ${Date.now().toString(36)}`,
+    })).id;
     let invitePath = '';
 
     try {
@@ -96,6 +98,8 @@ test.describe('Workspace member invite links', () => {
       const visitorContext = await browser.newContext();
       const visitor = await visitorContext.newPage();
       await visitor.goto(invitePath);
+      await expect(visitor.getByRole('heading', { name: /invited to join/i })).toBeVisible();
+      await visitor.getByRole('button', { name: /log in or sign up to join/i }).click();
       await expect(visitor).toHaveURL(/\/auth\/login\?return_to=.*invite/);
       await visitorContext.close();
 


### PR DESCRIPTION
## 用户问题\n新注册用户通过邀请链接登录后会回到邀请页，但全局首次引导立刻把用户带到个人主页，导致无法确认加入工作区。\n\n## 修复\n- 邀请确认页暂缓首次引导的跳转、完成动作和遮罩\n- 加入工作区后恢复原有首次引导\n- 更新真实邀请链路测试，适配不再自动创建工作区的注册流程\n\n## 验证\n- `npx eslint components/onboarding/first-run-wizard.tsx e2e/workspace-invite-link.spec.ts`\n- `SOLO_E2E_WORKSPACES=1 npm run test:e2e -- e2e/workspace-invite-link.spec.ts`（真实前端、API、PostgreSQL，1 passed）\n- PostgreSQL 核对邀请工作区最终为 2 名成员