### PR TITLE
fix(daemon): isolate computer pairing profiles (RADAR-P0-06)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-first-run test-e2e-agent-delivery test-e2e-agent-target-resolution test-e2e-agent-message-coalescing test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-product-completeness test-e2e-token-accounting test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces
+.PHONY: help dev init start restart rebuild stop clean-pids build migrate db-reset test-release-install test-e2e-first-run test-e2e-agent-delivery test-e2e-agent-target-resolution test-e2e-agent-message-coalescing test-e2e-agent-template-credential test-e2e-automation test-e2e-budget-gate test-e2e-budget-gate-run test-e2e-agent-session-resume test-e2e-agent-idle-resume test-e2e-agent-scope-router test-e2e-send-freshness test-e2e-websocket-recovery test-e2e-m8 test-e2e-m9 test-e2e-remote-product-completeness test-e2e-token-accounting test-e2e-remote-server test-e2e-public-remote test-e2e-workspaces test-e2e-auto-daemon
 .DEFAULT_GOAL := help
 
 ENV_FILE ?= .env
@@ -103,6 +103,9 @@ test-e2e-remote-server: rebuild ## Verify pairing, reverse runtime RPC, durable 
 
 test-e2e-workspaces: rebuild ## Verify Workspace isolation, multi-user collaboration, two local Daemons, Guest access, UI, and DB truth
 	@cd frontend && CI=1 SOLO_E2E_WORKSPACES=1 npx playwright test e2e/workspace-multi-daemon.spec.ts --workers=1
+
+test-e2e-auto-daemon: rebuild ## Verify two page pairing commands use isolated Daemons
+	@cd frontend && CI=1 SOLO_E2E_WORKSPACES=1 npx playwright test e2e/workspace-multi-daemon.spec.ts --grep "page pairing commands" --workers=1
 
 test-e2e-public-remote: ## Verify real SMTP, registration, recovery, DB state, and clean-machine setup UX
 	@bash scripts/test-public-remote-e2e.sh

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -94,6 +94,12 @@ func main() {
 		os.Exit(1)
 	}
 	slog.Info("machine lock acquired", "pid", machineLock.PID)
+	pidPath, err := writeDaemonProcessRecord(strings.TrimSpace(os.Getenv("SOLO_DAEMON_STATE_DIR")), machineLock.PID)
+	if err != nil {
+		_ = machineLock.Release()
+		slog.Error("failed to write daemon process record", "error", err)
+		os.Exit(1)
+	}
 
 	// Create task manager
 	taskMgr = newTaskManager()
@@ -229,6 +235,9 @@ func main() {
 
 	// Release machine lock
 	if machineLock != nil {
+		if err := removeDaemonProcessRecord(pidPath, machineLock.PID); err != nil {
+			slog.Warn("failed to remove daemon process record", "error", err)
+		}
 		if err := machineLock.Release(); err != nil {
 			slog.Warn("failed to release machine lock", "error", err)
 		} else {
@@ -251,6 +260,36 @@ func resolveInternalToken(configuredToken, jwtSecret string) string {
 		return configuredToken
 	}
 	return jwtSecret
+}
+
+func writeDaemonProcessRecord(stateDir string, pid int) (string, error) {
+	if stateDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		stateDir = filepath.Join(home, ".solo", "daemon")
+	}
+	path := filepath.Join(stateDir, "daemon.pid")
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func removeDaemonProcessRecord(path string, pid int) error {
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	recorded, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || recorded != pid {
+		return nil
+	}
+	return os.Remove(path)
 }
 
 // registerWithServer sends a registration request to the server.

--- a/cmd/daemon/main_test.go
+++ b/cmd/daemon/main_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
 
 func TestResolveInternalToken(t *testing.T) {
 	t.Run("uses dedicated internal token", func(t *testing.T) {
@@ -14,4 +19,30 @@ func TestResolveInternalToken(t *testing.T) {
 			t.Fatalf("resolveInternalToken() = %q, want jwt-secret", got)
 		}
 	})
+}
+
+func TestDaemonProcessRecordOnlyRemovesItsOwnPID(t *testing.T) {
+	dir := t.TempDir()
+	path, err := writeDaemonProcessRecord(dir, os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(strconv.Itoa(os.Getpid()+1)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeDaemonProcessRecord(path, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("another process record was removed: %v", err)
+	}
+	if _, err := writeDaemonProcessRecord(dir, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeDaemonProcessRecord(path, os.Getpid()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "daemon.pid")); !os.IsNotExist(err) {
+		t.Fatalf("own process record still exists: %v", err)
+	}
 }

--- a/cmd/solo/daemon.go
+++ b/cmd/solo/daemon.go
@@ -33,14 +33,14 @@ func handleDaemonCommand(args []string) int {
 		fmt.Fprintln(os.Stderr, "solo: daemon command required: connect, start, stop, restart, status, logs")
 		return exitUsage
 	}
-	profile, commandArgs, err := parseDaemonProfile(args[1:])
+	profile, profileExplicit, commandArgs, err := parseDaemonProfile(args[1:])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "solo: daemon: %v\n", err)
 		return exitUsage
 	}
 	switch args[0] {
 	case "connect":
-		err = daemonConnect(commandArgs, profile)
+		err = daemonConnect(commandArgs, profile, profileExplicit)
 	case "start":
 		err = startManagedDaemonProfile(profile, nil)
 	case "stop":
@@ -63,34 +63,37 @@ func handleDaemonCommand(args []string) int {
 	return exitOK
 }
 
-func parseDaemonProfile(args []string) (string, []string, error) {
+func parseDaemonProfile(args []string) (string, bool, []string, error) {
 	profile := defaultDaemonProfile
+	explicit := false
 	result := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		if args[i] == "--profile" {
 			if i+1 >= len(args) {
-				return "", nil, errors.New("--profile requires a name")
+				return "", false, nil, errors.New("--profile requires a name")
 			}
 			profile = args[i+1]
+			explicit = true
 			i++
 			continue
 		}
 		if strings.HasPrefix(args[i], "--profile=") {
 			profile = strings.TrimPrefix(args[i], "--profile=")
+			explicit = true
 			continue
 		}
 		result = append(result, args[i])
 	}
 	profile = strings.TrimSpace(profile)
 	if profile == "" || len(profile) > 64 {
-		return "", nil, errors.New("invalid Daemon profile name")
+		return "", false, nil, errors.New("invalid Daemon profile name")
 	}
 	for _, r := range profile {
 		if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' || r == '_') {
-			return "", nil, errors.New("Daemon profile may contain only letters, numbers, '-' and '_'")
+			return "", false, nil, errors.New("Daemon profile may contain only letters, numbers, '-' and '_'")
 		}
 	}
-	return profile, result, nil
+	return profile, explicit, result, nil
 }
 
 func daemonStateDir() (string, error) {
@@ -163,20 +166,28 @@ func daemonProfilePID(profile string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
-	raw, err := os.ReadFile(path)
-	if err != nil {
-		return 0, false
+	if raw, readErr := os.ReadFile(path); readErr == nil {
+		if pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw))); parseErr == nil && daemonProcessAlive(pid) {
+			return pid, true
+		}
+		_ = os.Remove(path)
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
-	if err != nil || pid <= 1 {
-		return 0, false
+	var lock struct {
+		PID int `json:"pid"`
+	}
+	if raw, readErr := os.ReadFile(filepath.Join(filepath.Dir(path), "lock.json")); readErr == nil && json.Unmarshal(raw, &lock) == nil && daemonProcessAlive(lock.PID) {
+		_ = os.WriteFile(path, []byte(strconv.Itoa(lock.PID)+"\n"), 0o600)
+		return lock.PID, true
+	}
+	return 0, false
+}
+
+func daemonProcessAlive(pid int) bool {
+	if pid <= 1 {
+		return false
 	}
 	process, err := os.FindProcess(pid)
-	if err != nil || process.Signal(syscall.Signal(0)) != nil {
-		_ = os.Remove(path)
-		return 0, false
-	}
-	return pid, true
+	return err == nil && process.Signal(syscall.Signal(0)) == nil
 }
 
 func startManagedDaemon(extraEnv []string) error {
@@ -281,7 +292,7 @@ func stopManagedDaemonProfile(profile string) error {
 	return errors.New("Daemon did not stop within 10 seconds")
 }
 
-func daemonConnect(args []string, profile string) error {
+func daemonConnect(args []string, profile string, profileExplicit bool) error {
 	fs := flag.NewFlagSet("solo daemon connect", flag.ContinueOnError)
 	server := fs.String("server", "", "Solo Server URL")
 	computerID := fs.String("computer-id", "", "Computer ID")
@@ -293,12 +304,14 @@ func daemonConnect(args []string, profile string) error {
 	if err != nil || parsed.Host == "" || parsed.User != nil || (parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Scheme != "https" && !(parsed.Scheme == "http" && (parsed.Hostname() == "localhost" || parsed.Hostname() == "127.0.0.1"))) {
 		return errors.New("--server must be an https URL (http is allowed only for localhost)")
 	}
-	if _, err := uuid.Parse(strings.TrimSpace(*computerID)); err != nil {
+	computer := strings.TrimSpace(*computerID)
+	if _, err := uuid.Parse(computer); err != nil {
 		return errors.New("--computer-id must be a valid UUID")
 	}
 	if strings.TrimSpace(*token) == "" {
 		return errors.New("--token is required")
 	}
+	profile = daemonConnectProfile(profile, computer, profileExplicit)
 	credentialPath, err := managedProfileCredentialPath(profile)
 	if err != nil {
 		return err
@@ -310,7 +323,7 @@ func daemonConnect(args []string, profile string) error {
 	serverURL := strings.TrimRight(parsed.String(), "/")
 	if err := startManagedDaemonProfile(profile, []string{
 		"DAEMON_SERVER_URL=" + serverURL,
-		"SOLO_COMPUTER_ID=" + strings.TrimSpace(*computerID),
+		"SOLO_COMPUTER_ID=" + computer,
 		"SOLO_ENROLLMENT_TOKEN=" + strings.TrimSpace(*token),
 	}); err != nil {
 		return err
@@ -319,7 +332,7 @@ func daemonConnect(args []string, profile string) error {
 	for time.Now().Before(deadline) {
 		raw, readErr := os.ReadFile(credentialPath)
 		var credential managedDaemonCredential
-		if readErr == nil && !bytes.Equal(raw, oldCredential) && json.Unmarshal(raw, &credential) == nil && credential.ComputerID == strings.TrimSpace(*computerID) && strings.TrimRight(credential.ServerURL, "/") == serverURL && credential.Credential != "" && managedDaemonConnectedProfile(profile) {
+		if readErr == nil && !bytes.Equal(raw, oldCredential) && json.Unmarshal(raw, &credential) == nil && credential.ComputerID == computer && strings.TrimRight(credential.ServerURL, "/") == serverURL && credential.Credential != "" && managedDaemonConnectedProfile(profile) {
 			fmt.Printf("Computer paired with %s. The Daemon will reconnect automatically.\n", serverURL)
 			return nil
 		}
@@ -330,6 +343,20 @@ func daemonConnect(args []string, profile string) error {
 		time.Sleep(250 * time.Millisecond)
 	}
 	return errors.New("pairing timed out after 15 seconds")
+}
+
+func daemonConnectProfile(profile, computerID string, explicit bool) string {
+	if explicit {
+		return profile
+	}
+	path, err := managedProfileCredentialPath(defaultDaemonProfile)
+	if err == nil {
+		var credential managedDaemonCredential
+		if raw, readErr := os.ReadFile(path); readErr == nil && json.Unmarshal(raw, &credential) == nil && credential.ComputerID == computerID {
+			return defaultDaemonProfile
+		}
+	}
+	return computerID
 }
 
 func printDaemonStatus() error {

--- a/cmd/solo/daemon_test.go
+++ b/cmd/solo/daemon_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -127,8 +129,53 @@ func TestDaemonProfilesUseIndependentState(t *testing.T) {
 	if alpha == beta || !strings.HasSuffix(alpha, filepath.Join("daemons", "alpha")) || !strings.HasSuffix(beta, filepath.Join("daemons", "beta")) {
 		t.Fatalf("profiles share state: alpha=%q beta=%q", alpha, beta)
 	}
-	profile, remaining, err := parseDaemonProfile([]string{"--server", "https://solo.example", "--profile", "alpha"})
-	if err != nil || profile != "alpha" || len(remaining) != 2 {
+	profile, explicit, remaining, err := parseDaemonProfile([]string{"--server", "https://solo.example", "--profile", "alpha"})
+	if err != nil || profile != "alpha" || !explicit || len(remaining) != 2 {
 		t.Fatalf("profile parse = %q %#v %v", profile, remaining, err)
+	}
+}
+
+func TestDaemonConnectProfileUsesComputerIDUnlessExplicitOrLegacyDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	computerID := "11111111-1111-4111-8111-111111111111"
+	if got := daemonConnectProfile(defaultDaemonProfile, computerID, false); got != computerID {
+		t.Fatalf("new automatic profile = %q, want computer ID", got)
+	}
+	if got := daemonConnectProfile("work", computerID, true); got != "work" {
+		t.Fatalf("explicit profile = %q, want work", got)
+	}
+	path, err := managedCredentialPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(managedDaemonCredential{ComputerID: computerID})
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := daemonConnectProfile(defaultDaemonProfile, computerID, false); got != defaultDaemonProfile {
+		t.Fatalf("legacy default profile = %q, want default", got)
+	}
+}
+
+func TestDaemonProfilePIDRecoversFromLiveLock(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	lockPath, err := daemonStatePath("lock.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(map[string]int{"pid": os.Getpid()})
+	if err := os.WriteFile(lockPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if pid, running := daemonPID(); !running || pid != os.Getpid() {
+		t.Fatalf("daemonPID() = %d, %v; want current process", pid, running)
+	}
+	pidPath, err := daemonStatePath("daemon.pid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw, err = os.ReadFile(pidPath); err != nil || strings.TrimSpace(string(raw)) != strconv.Itoa(os.Getpid()) {
+		t.Fatalf("repaired pid record = %q, %v", raw, err)
 	}
 }

--- a/docs/design/public-remote-product-architecture.md
+++ b/docs/design/public-remote-product-architecture.md
@@ -104,16 +104,22 @@ Computers page creates Computer and one-time enrollment token
  -> user runs generated install command
  -> installer downloads archive + checksum from GitHub Releases
  -> installs `solo` and `solo-daemon`
- -> `solo daemon connect` starts `solo-daemon` with the one-time token
+ -> the Computer ID is also used as the managed Daemon profile
+ -> `solo daemon connect` starts that profile with the one-time token
  -> Daemon exchanges and persists the machine credential
  -> `solo daemon status` observes the managed background process
 ```
 
-`connect` replaces only this Computer's local pairing and restarts the managed
-Daemon. The Server's existing one-current-connection fence remains the remote
-authority. `start`, `stop`, `restart`, `status`, and `logs` operate on the local
-managed process. Direct `solo-daemon` execution remains supported for containers
-and advanced operators.
+The Computers page and installer derive the profile from the existing Computer
+ID; users do not choose another name. Each Computer therefore owns an independent
+local state directory, process, port, credential, and log. `connect` replaces only
+that Computer's local pairing and restarts only its managed Daemon. This remains
+compatible with the released CLI that already supports explicit profiles, while a
+newer CLI can also infer the same profile when it is omitted. No database or API
+migration is required. The Server's existing one-current-connection fence remains
+the remote authority. `start`, `stop`, `restart`, `status`, and `logs` operate on
+the selected local managed process. Direct `solo-daemon` execution remains
+supported for containers and advanced operators.
 
 ## 4. Data flow and trust boundaries
 

--- a/frontend/e2e/workspace-multi-daemon.spec.ts
+++ b/frontend/e2e/workspace-multi-daemon.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test, type APIRequestContext, type Page } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
-import { homedir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { registerVerified } from './support/auth';
 
 const apiBase = process.env.SOLO_E2E_API_URL ?? 'http://127.0.0.1:8080';
 const repoRoot = join(process.cwd(), '..');
-const soloBinary = join(repoRoot, '.pids', 'solo');
-const daemonBinary = join(repoRoot, '.pids', 'daemon');
+const soloBinary = process.env.SOLO_E2E_SOLO_BINARY ?? join(repoRoot, '.pids', 'solo');
+const daemonBinary = process.env.SOLO_E2E_DAEMON_BINARY ?? join(repoRoot, '.pids', 'daemon');
 const publicWorkspaceID = '00000000-0000-0000-0000-000000000001';
 
 interface AuthResponse {
@@ -163,6 +163,15 @@ function connectDaemon(profile: string, computer: Computer) {
   ]);
 }
 
+function automaticDaemon(home: string, args: string[]): string {
+  return execFileSync(soloBinary, ['daemon', ...args], {
+    cwd: repoRoot,
+    env: { ...process.env, HOME: home, SOLO_DAEMON_BINARY: daemonBinary },
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+}
+
 async function availableRuntime(request: APIRequestContext, auth: AuthResponse, workspaceID: string, computerID: string): Promise<Runtime> {
   const runtimes = await call<Runtime[]>(request, auth, 'get', `/api/v1/agent-backends/detect?computer_id=${computerID}`, workspaceID);
   const runtime = ['codex', 'claude', 'opencode', 'hermes', 'openclaw']
@@ -175,6 +184,50 @@ async function availableRuntime(request: APIRequestContext, auth: AuthResponse, 
 test.describe('Workspace and multi-Daemon product flow', () => {
   test.skip(process.env.SOLO_E2E_WORKSPACES !== '1', 'requires the make-managed frontend, API, PostgreSQL, and real local runtime');
   test.setTimeout(600000);
+
+  test('keeps two page pairing commands isolated by computer ID', async ({ page, request }) => {
+    const auth = await register(request, 'AutomaticDaemon');
+    const suffix = Date.now().toString(36);
+    const home = mkdtempSync(join(tmpdir(), 'solo-auto-daemon-'));
+    const computers = await Promise.all([
+      call<Computer>(request, auth, 'post', '/api/v1/computers', undefined, { name: `Automatic A ${suffix}` }),
+      call<Computer>(request, auth, 'post', '/api/v1/computers', undefined, { name: `Automatic B ${suffix}` }),
+    ]);
+
+    try {
+      for (const computer of computers) {
+        if (!computer.enrollment_token) throw new Error(`Computer ${computer.id} has no enrollment token`);
+        automaticDaemon(home, [
+          'connect', '--server', apiBase, '--computer-id', computer.id,
+          '--token', computer.enrollment_token, '--profile', computer.id,
+        ]);
+      }
+
+      await expect.poll(() => databaseJSON<number>(`
+        SELECT to_json(count(*))::text FROM computers
+         WHERE id IN ('${computers[0].id}','${computers[1].id}') AND status='online'
+      `), { intervals: [250, 500, 1000] }).toBe(2);
+
+      const directories = computers.map((computer) => join(home, '.solo', 'daemons', computer.id));
+      const ports = directories.map((directory) => Number(readFileSync(join(directory, 'port'), 'utf8').trim()));
+      const pids = directories.map((directory) => Number(readFileSync(join(directory, 'daemon.pid'), 'utf8').trim()));
+      expect(ports[0]).not.toBe(ports[1]);
+      expect(pids[0]).not.toBe(pids[1]);
+
+      databaseJSON(`WITH updated AS (UPDATE users SET onboarding_completed_at=now() WHERE id='${auth.user.id}' RETURNING 1) SELECT to_json(EXISTS(SELECT 1 FROM updated))::text`);
+      await authenticatePage(page, auth);
+      await page.goto('/computers');
+      for (const computer of computers) {
+        await expect(page.getByText(computer.name, { exact: true })).toBeVisible();
+      }
+    } finally {
+      for (const computer of computers) {
+        try { automaticDaemon(home, ['stop', '--profile', computer.id]); } catch { /* primary assertion reports failure */ }
+      }
+      rmSync(home, { recursive: true, force: true });
+      deactivateTestUsers(auth);
+    }
+  });
 
   test('switches isolated Workspaces and collaborates through two users and two Daemons', async ({ page, request, browser }) => {
     const userA = await register(request, 'WorkspaceA');

--- a/frontend/lib/computer-pairing.ts
+++ b/frontend/lib/computer-pairing.ts
@@ -6,7 +6,7 @@ export function computerPairingCommands(computerId: string, token: string) {
   const server = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
   const installer = process.env.NEXT_PUBLIC_INSTALL_URL ?? 'https://raw.githubusercontent.com/solo-agent/solo/master/scripts/install.sh';
   return {
-    installed: `solo daemon connect --server ${shellQuote(server)} --computer-id ${shellQuote(computerId)} --token ${shellQuote(token)}`,
+    installed: `solo daemon connect --server ${shellQuote(server)} --computer-id ${shellQuote(computerId)} --token ${shellQuote(token)} --profile ${shellQuote(computerId)}`,
     fresh: `curl -fsSL ${shellQuote(installer)} | bash -s -- connect --server ${shellQuote(server)} --computer-id ${shellQuote(computerId)} --token ${shellQuote(token)}`,
   };
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,5 +95,5 @@ if [ "$CONNECT" -eq 1 ]; then
   [ -n "$SERVER" ] || fail "connect requires --server"
   [ -n "$COMPUTER_ID" ] || fail "connect requires --computer-id"
   [ -n "$TOKEN" ] || fail "connect requires --token"
-  exec "$BIN_DIR/solo" daemon connect --server "$SERVER" --computer-id "$COMPUTER_ID" --token "$TOKEN"
+  exec "$BIN_DIR/solo" daemon connect --server "$SERVER" --computer-id "$COMPUTER_ID" --token "$TOKEN" --profile "$COMPUTER_ID"
 fi


### PR DESCRIPTION
## 用户变化
- 同一台电脑连续复制两条“添加电脑”命令，可同时连接成两台独立电脑，不再互相顶掉。
- 用户不需要理解或填写 profile；复制命令时会自动带上当前电脑的唯一标识。
- 离线重连和进程状态识别更可靠。

## 改动范围
- 前后端：连接命令自动隔离；CLI 兼容未显式指定 profile 的场景；Daemon 补充自身进程记录。
- 页面：无新增入口、字段或按钮，只改变复制出来的连接命令。
- 无数据库迁移，无接口破坏性变更。

## 验证
- go test ./cmd/solo ./cmd/daemon
- npm run lint（0 errors；49 个仓库既有 warnings）
- bash -n scripts/install.sh
- make test-e2e-auto-daemon（当前源码构建）
- 使用本机已安装 v1.1.0 CLI 与 Daemon 跑同一真实 E2E：两台电脑同时在线、PID/端口/状态目录互相独立，并核对 PostgreSQL 持久化状态

## 已知边界
- 历史遗留的离线电脑记录不会自动删除，可通过现有重连入口继续使用。