### PR TITLE
fix(agents): read legacy agents without home channels

### DIFF
--- a/internal/server/handler/agent.go
+++ b/internal/server/handler/agent.go
@@ -411,7 +411,7 @@ func (h *AgentHandler) Get(w http.ResponseWriter, r *http.Request) {
 	var customEnvBytes, customArgsBytes []byte
 	err := h.pool.QueryRow(r.Context(),
 		`SELECT id, name, COALESCE(description, ''), owner_id,
-		        home_channel_id, kind, model_provider, model_name,
+		        COALESCE(home_channel_id::text, ''), kind, model_provider, model_name,
 		        system_prompt, is_active, COALESCE(avatar_url, ''),
 		        custom_env, custom_args, COALESCE(runtime_id, ''),
 		        created_at, updated_at

--- a/internal/server/handler/agent_test.go
+++ b/internal/server/handler/agent_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+func TestAgentHandlerGetReturnsLegacyAgentWithoutHomeChannel(t *testing.T) {
+	pool := handlerTestPool(t)
+	ctx := context.Background()
+	ownerID := uuid.NewString()
+	agentID := uuid.NewString()
+	email := fmt.Sprintf("legacy-agent-%s@example.test", ownerID)
+
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO users (id, email, display_name, password_hash) VALUES ($1, $2, 'Legacy Agent Owner', 'test')`,
+		ownerID, email,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM agents WHERE id = $1`, agentID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id = $1`, ownerID)
+	})
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO agents (id, name, owner_id, model_name) VALUES ($1, $2, $3, 'test')`,
+		agentID, "legacy-agent-"+agentID[:8], ownerID,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/agents/"+agentID, nil)
+	req.Header.Set("X-User-ID", ownerID)
+	route := chi.NewRouteContext()
+	route.URLParams.Add("agentID", agentID)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, route))
+	recorder := httptest.NewRecorder()
+
+	(&AgentHandler{pool: pool}).Get(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	var response AgentResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.ID != agentID || response.HomeChannelID != "" {
+		t.Fatalf("response = %+v, want legacy Agent %s with empty home_channel_id", response, agentID)
+	}
+}

--- a/internal/server/handler/attachment_test.go
+++ b/internal/server/handler/attachment_test.go
@@ -25,7 +25,7 @@ func TestAttachmentRejectsBearerTokenInQuery(t *testing.T) {
 }
 
 func TestAgentRunAttachmentTokenIsLimitedToRunChannel(t *testing.T) {
-	pool := attachmentTestPool(t)
+	pool := handlerTestPool(t)
 	ctx := context.Background()
 	ownerID := uuid.NewString()
 	agentID := uuid.NewString()
@@ -87,7 +87,7 @@ func TestAgentRunAttachmentTokenIsLimitedToRunChannel(t *testing.T) {
 }
 
 func TestUserAvatarAttachmentIsVisibleOnlyInsideSharedWorkspace(t *testing.T) {
-	pool := attachmentTestPool(t)
+	pool := handlerTestPool(t)
 	ctx := context.Background()
 	ownerID := uuid.NewString()
 	viewerID := uuid.NewString()
@@ -173,7 +173,7 @@ func TestUserAvatarAttachmentIsVisibleOnlyInsideSharedWorkspace(t *testing.T) {
 	}
 }
 
-func attachmentTestPool(t *testing.T) *pgxpool.Pool {
+func handlerTestPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {


### PR DESCRIPTION
## Summary

- return legacy Agents whose `home_channel_id` is `NULL` instead of failing the detail request
- preserve the existing string API contract by serializing the missing home Channel as an empty string
- cover the regression through the real handler and PostgreSQL path

## Validation

- `go test ./...` against a fresh PostgreSQL database with all current migrations

Fixes #120